### PR TITLE
README: document two consumer patterns for SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ npx skills add https://github.com/thrillmot/agent-skills
 
 Browse on skills.sh: <https://www.skills.sh/thrillmot/agent-skills>
 
+## Consumer patterns — using these skills from your tool
+
+There are two distinct ways a tool can consume a SKILL.md:
+
+**1. Install-pointer (e.g. [logmind](https://logmind.dev)).** The tool ships an `AGENTS.md` that points at the install URL. The *agent runtime* (Claude Code, Cursor, Codex…) installs the skill via `npx skills add`. The tool itself never reads `SKILL.md` — the skill is consumed by the agent, not by the tool. Lightest integration, no runtime fetch.
+
+**2. Fetch + cache + bundled fallback (e.g. [clud-bug](https://github.com/thrillmot/clud-bug)).** The tool itself loads the SKILL.md text into a prompt at runtime — e.g. a bot reviewer needs the skill contents as context for the LLM call. The recommended shape:
+
+```text
+1. Try fetching from https://raw.githubusercontent.com/thrillmot/agent-skills/main/skills/<name>/SKILL.md
+2. On any failure (network, 404, timeout, non-200) fall back to the bundled copy
+   shipped inside the tool's npm/PyPI/etc. package
+3. Cache successful fetches to ~/.cache/<tool>/skills/<sha-of-source>.md
+4. A scheduled CI job in your tool's repo pulls the bundled copies from
+   agent-skills periodically so the offline fallback doesn't drift
+```
+
+The bundled copies are the source of truth for the offline path; this repo is the source of truth for the canonical content. Both stay in sync via the scheduled refresh.
+
+Whichever pattern applies, prefer the **collection layout** (`skills/<name>/SKILL.md`) over flat top-level files — that's what skills.sh requires to render the rich page (install count, related skills, security audits).
+
 ## Adding a new skill to this collection
 
 1. Create `skills/<name>/SKILL.md` with frontmatter (`name`, `description`).


### PR DESCRIPTION
## Summary
- Surface the two distinct shapes a tool can take when consuming a SKILL.md
- **Install-pointer** (logmind): AGENTS.md points at the install URL; the agent runtime installs the skill
- **Fetch + cache + bundled fallback** (clud-bug): the tool itself loads SKILL.md text into a prompt at runtime; recipe documented inline
- Callout that the collection layout (`skills/<name>/SKILL.md`) is required for skills.sh's rich page render

## Why
Came out of a comparison between how logmind and the upcoming clud-bug v0.5 release will use the same `thrillmot/agent-skills` repo. Different consumer shapes — both correct for their use case. Documenting it here so future tool authors can pick the right pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)