### PR TITLE
Add clud-bug baseline skills

### DIFF
--- a/skills/clud-bug-collaboration/SKILL.md
+++ b/skills/clud-bug-collaboration/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: clud-bug-collaboration
+description: How Claude Code agents working in a clud-bug-installed repo should interact with the bot's review threads, strict-mode gate, and skill set. Use this skill whenever you're about to push a commit, address a clud-bug PR review comment, edit anything under .claude/skills/, modify .github/workflows/clud-bug-*.yml, or wonder why a PR check is red. Also use when planning work in a repo that has a `clud-bug-review` workflow installed — even if the user didn't mention clud-bug by name.
+---
+
+# Working in a clud-bug-installed repo
+
+Clud Bug reviews every PR via `anthropics/claude-code-action`. As another
+Claude Code agent working alongside it, here's what to know — these aren't
+arbitrary rules, they're the consequences of how the gate is wired.
+
+## When you push fixes to a clud-bug-reviewed PR
+
+The bot reviews on `pull_request: synchronize` (every push). When you push
+a commit that addresses an issue Clud Bug flagged in a prior review, the bot
+will re-review the PR within ~2 minutes and **resolve its own prior
+unresolved inline review threads** where the flagged issue is verifiably
+fixed in the current diff. You don't have to resolve threads manually.
+
+If a thread it left isn't auto-resolved after your fix:
+- The bot judged the issue still open (read its latest comment for why).
+- Or the resolution call hit a transient API issue (re-push to retry).
+
+Don't manually resolve clud-bug threads on its behalf. The check
+(`required_conversation_resolution` branch protection) will block merge if
+unresolved threads remain — and the right fix is usually "fix the actual
+issue and re-push," not "mark the conversation resolved."
+
+## When you read the PR's `clud-bug-review` check status
+
+- **Green** = Clud Bug ran and either found no critical issues OR strict
+  mode is off (advisory).
+- **Red** = either the action errored OR strict mode is on AND Clud Bug
+  flagged a critical issue. Read the latest `## 🐛 Clud Bug review` comment
+  on the PR — the body indicates "critical findings" or "clean."
+- **Skipped/green-with-comment** = bot- or fork-authored PR (Dependabot,
+  Renovate, fork contributor). GitHub deliberately doesn't pass repo
+  secrets to those workflows. The bot posts a one-line "Clud Bug skipped"
+  comment and exits 0. Review the diff manually.
+
+## Strict mode
+
+Read `.claude/skills/.clud-bug.json` to check this repo's setting.
+`strictMode: true` means the workflow check fails on critical findings.
+The setting is read from the **base ref**, so a PR cannot disable strict
+mode on itself by editing the manifest. Changes take effect for PRs opened
+after the change merges to the base branch.
+
+To disable strict mode for a repo, edit the manifest on the base branch:
+
+```json
+{ "strictMode": false, ... }
+```
+
+## When you modify a clud-bug skill
+
+Skills live in `.claude/skills/<slug>/SKILL.md`. Three groups:
+
+- **Baseline** (`critical-issues-only`, `evidence-based-review`,
+  `respect-existing-conventions`) — managed by clud-bug; if you edit them
+  in-place they'll be overwritten on the next `clud-bug update`. To
+  customize behavior for this repo, write a NEW skill rather than mutating
+  a baseline.
+- **From skills.sh** — installed via `clud-bug add <source/name>`. Tracked
+  in `.claude/skills/.clud-bug.json`. Use `clud-bug refresh` to sync.
+- **Custom** (anything not in the manifest) — yours, never touched by any
+  clud-bug command. Drop a new `.md` here and it auto-loads on the next PR.
+
+When you write a custom skill, follow the SKILL.md frontmatter format
+(`name`, `description`) and write specific, evidence-anchored guidance.
+Generic advice gets ignored; rules with examples and quoted-line evidence
+move the bot's behavior.
+
+## When you edit `.github/workflows/clud-bug-*.yml`
+
+`anthropics/claude-code-action` **refuses to run on PRs that modify its
+own workflow file** (App token exchange fails with 401, "Workflow
+validation failed"). This is a security guard against PRs that try to
+neuter the reviewer or exfiltrate secrets.
+
+Consequence: if you bundle a workflow tweak with other work, the
+`clud-bug-review` check on that PR will fail and not actually review your
+other changes either.
+
+The fix: split workflow edits into their own PR. The CLI helps:
+
+```bash
+# After editing .github/workflows/clud-bug-*.yml locally:
+clud-bug edit-workflow
+```
+
+It refuses to run if your working tree has non-workflow changes, so the
+isolation guarantee is enforced. Branches from `origin/main`, not HEAD —
+unrelated commits on a feature branch can't leak in.
+
+## When the secret is missing
+
+`ANTHROPIC_API_KEY` must be set in the repo's Actions secrets. Without it,
+the workflow's guard step fails loudly with an `::error::` annotation
+explaining how to set it. (For bot/fork PRs where the secret legitimately
+isn't passed, the guard posts a one-line advisory comment and exits 0
+instead of failing red.)
+
+## Updating clud-bug itself
+
+`clud-bug-self-update.yml` runs weekly (Mondays 12:00 UTC) and opens a PR
+when a newer clud-bug version is published to npm. Pin to a specific
+version by adding `pinVersion: "x.y.z"` to `.claude/skills/.clud-bug.json`.
+
+To trigger an update on demand:
+
+```bash
+clud-bug update
+```
+
+Re-renders workflow templates and refreshes baseline skills from the
+currently-installed clud-bug version. Custom and skills.sh-installed
+skills are left untouched.
+
+## Where to find more
+
+- Site: https://cludbug.dev
+- Repo: https://github.com/thrillmot/clud-bug
+- Skill catalog: https://github.com/thrillmot/agent-skills

--- a/skills/critical-issues-only/SKILL.md
+++ b/skills/critical-issues-only/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: critical-issues-only
+description: PR review discipline - flag only correctness, security, and performance issues. Skip nits.
+---
+
+# Critical issues only
+
+When reviewing a pull request, only surface issues that fall into one of these buckets:
+
+1. **Correctness bugs** — the code does the wrong thing, mishandles a case, or breaks an existing contract.
+2. **Security vulnerabilities** — injection, auth bypass, secret exposure, unsafe deserialization, SSRF, etc.
+3. **Performance problems** — algorithmic blowups, N+1 queries, memory leaks, blocking calls in hot paths.
+4. **Missing or broken test coverage** for new code paths that meaningfully change behavior.
+
+## Do not surface
+
+- Style preferences, formatting, naming preferences.
+- Architectural rewrites unless the existing approach is actively broken.
+- "You could also..." suggestions that aren't bugs.
+- Nitpicks the author can fix in 30 seconds and don't change behavior.
+
+## How to phrase findings
+
+- One concrete issue per comment. No bundling unrelated nits.
+- Quote the specific line or block being criticized.
+- Say what's wrong, then what to do about it. Skip the throat-clearing.
+
+If the diff has no issues in the four buckets above, post a single short comment confirming that — don't invent problems.

--- a/skills/evidence-based-review/SKILL.md
+++ b/skills/evidence-based-review/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: evidence-based-review
+description: Every PR review claim must quote the specific code being criticized. No hand-waving.
+---
+
+# Evidence-based review
+
+Every claim in your review must be backed by evidence the PR author can verify in seconds.
+
+## Required for every finding
+
+- **Quote the exact line or block** you're talking about (use a fenced code block or `gh pr` inline-comment anchor).
+- **Cite the file and line range** so the author can navigate directly there.
+- **State the failure mode concretely**: what input produces what wrong output, or what attacker action exploits what gap.
+
+## Banned phrasings
+
+These are red flags that you're hand-waving instead of reviewing:
+
+- "This might cause issues" → say *which* issue, with the input that triggers it.
+- "Consider refactoring this" → either it has a bug, or it doesn't. Not your call to redesign their code.
+- "This doesn't follow best practices" → cite *which* practice and why it matters here.
+- "You should add tests" → name the specific code path that isn't covered.
+
+## Verifying your own claims
+
+Before posting a comment, ask: if the author asked "show me", could I point at the exact line and exact failure case? If not, delete the comment.
+
+A short, specific review of three real issues beats a long, vague review of fifteen maybes.

--- a/skills/respect-existing-conventions/SKILL.md
+++ b/skills/respect-existing-conventions/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: respect-existing-conventions
+description: Don't suggest changes that fight the codebase's established patterns. Match what's already there.
+---
+
+# Respect existing conventions
+
+A code review is not a redesign. The PR author is working within a codebase that has its own conventions, abstractions, and trade-offs that long predate this PR.
+
+## Before suggesting any change, check
+
+- **Is this pattern already used elsewhere in the repo?** If yes, the author is following convention. Don't push them off it.
+- **Did the team explicitly choose this approach?** Look at neighboring files, git log on related code, or comments. If the surrounding code already does it this way, that's a signal.
+- **Would adopting your suggestion require changing 50 other files?** If yes, your suggestion belongs in a separate refactor PR or RFC, not this review.
+
+## Things that often *look* like problems but usually aren't
+
+- Manual loops where a `.map()` would also work — both are fine.
+- Repeated three-line patterns that "could be a helper" — three is below the threshold to justify abstraction.
+- Type annotations the language can infer — explicitness is a valid choice.
+- Defensive null checks at module boundaries — context-dependent.
+
+## When convention itself is the bug
+
+If the existing pattern *is* the source of the bug, say so explicitly: "the convention used here propagates [specific bug]; this PR should break from it because [reason]." Don't quietly suggest a different approach without naming the trade-off.
+
+The bar for "you should do it differently than the rest of the codebase" is high. Clear it before suggesting.


### PR DESCRIPTION
## Summary

Four review-discipline skills sourced from [clud-bug](https://cludbug.dev) v0.5.1's bundled baseline kit:

- **critical-issues-only** — flag bugs, security, perf only. Skip nits.
- **evidence-based-review** — every claim must quote the line being criticized.
- **respect-existing-conventions** — don't suggest fights with the codebase's patterns.
- **clud-bug-collaboration** — guidance for Claude Code agents working in clud-bug-installed repos (thread auto-resolution after fixes, reading the \`clud-bug-review\` gate, why \`claude-code-action\` rejects PRs that modify its own workflow, base-ref strict-mode semantics).

## Why now

\`clud-bug/lib/skills.js\` already pins a SHA from this repo and tries fetching \`https://raw.githubusercontent.com/thrillmot/agent-skills/<SHA>/skills/<name>/SKILL.md\` for each baseline at install time. But until this PR, only \`skills/logmind/SKILL.md\` lived here, so every clud-bug install silently fell back to the bundled copies in the npm package. Designed behavior, but the canonical-home story wasn't real.

After this merges:
1. clud-bug v0.5.2 (next release) bumps \`BASELINE_SKILLS_REF\` in \`lib/skills.js\` to the merge SHA of this PR.
2. Fresh installs will see \`baseline kit: 4 specimens (from thrillmot/agent-skills)\` instead of \`(bundled fallback)\`.
3. Future skill edits happen here; clud-bug bumps the SHA when ready to ship.

## Layout

Each skill follows the skills.sh \`skills/<name>/SKILL.md\` collection convention so the existing collection structure (alongside \`skills/logmind/\`) works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)