### PR TITLE
README: list the four clud-bug skills in the table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ These skills run inside any agent that loads skills.sh — Claude Code, Cursor, 
 | Skill | Purpose |
 |---|---|
 | [`logmind`](skills/logmind/SKILL.md) | Teach agents when and how to log architectural decisions in projects using [logmind](https://logmind.dev). Activates whenever an agent works in a project with `.logmind/config.yml` or an `AGENTS.md`/`CLAUDE.md` mentioning logmind. |
+| [`critical-issues-only`](skills/critical-issues-only/SKILL.md) | PR review discipline — flag only correctness, security, and performance issues. Skip style nits and naming preferences. Ships as a baseline with [clud-bug](https://github.com/thrillmot/clud-bug). |
+| [`evidence-based-review`](skills/evidence-based-review/SKILL.md) | Every PR review claim must quote the specific code being criticized. No hand-waving, no vague "might cause issues." Cite or delete. Ships as a baseline with clud-bug. |
+| [`respect-existing-conventions`](skills/respect-existing-conventions/SKILL.md) | A code review is not a redesign. Don't suggest changes that fight the codebase's established patterns. Match what's already there. Ships as a baseline with clud-bug. |
+| [`clud-bug-collaboration`](skills/clud-bug-collaboration/SKILL.md) | How Claude Code agents working in a clud-bug-installed repo coexist with the bot's review threads, strict-mode gate, and skill set. Activates in any repo with a `clud-bug-review` workflow installed — even if the user didn't mention clud-bug by name. |
 
 ## Install
 


### PR DESCRIPTION
## Summary

The four clud-bug skills landed in #4 — files at \`skills/<name>/SKILL.md\` are live (HTTP 200) and clud-bug v0.5.2+ SHA-pins this repo at \`a4455977\` to fetch them via the bundled-fallback pattern. But the README's "Skills in this collection" table only listed \`logmind\` — so the four were effectively undiscoverable via README (raw file URL only).

Adds one row each:
- \`critical-issues-only\`
- \`evidence-based-review\`
- \`respect-existing-conventions\`
- \`clud-bug-collaboration\`

Descriptions adapted from each SKILL.md's frontmatter \`description\` field. All four cells flag the skills as **clud-bug baselines** in the cell text so readers understand the relationship.

After this lands, \`https://www.skills.sh/thrillmot/agent-skills\` will render the full set in the rich collection page.