### PR TITLE
docs(logmind): refresh skill to cover v0.2.3 → v0.2.5

### DIFF
--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -34,6 +34,16 @@ context months later is not.
 
 ## How to log
 
+### CLI (preferred)
+
+```bash
+logmind log "Use PostgreSQL for primary database" \
+  -r "Need ACID compliance and complex joins" \
+  -a "MongoDB" -a "SQLite" \
+  -i "Connection pooling required" \
+  -i "Schema migrations needed"
+```
+
 ### Python
 
 ```python
@@ -45,39 +55,80 @@ log("Use PostgreSQL for primary database",
     implications=["Connection pooling required", "Schema migrations needed"])
 ```
 
-### CLI
+## What `logmind log` does automatically
 
-```bash
-logmind log "Use PostgreSQL for primary database" \
-  -r "Need ACID compliance and complex joins" \
-  -a "MongoDB" -a "SQLite" \
-  -i "Connection pooling required" \
-  -i "Schema migrations needed"
-```
+A single `logmind log` invocation handles all of this — you do NOT need to
+follow up with manual `git add`, `git commit`, or `logmind timeline --write`:
 
-## Branch-aware logging
+1. Appends the decision entry to the active log file (default branch →
+   `docs/decisions.md`; feature branch → `docs/decisions-branches/<branch>.md`).
+2. Archives the oldest decision if `decisions.md` exceeds `max_recent` (rotation).
+3. Regenerates `docs/file-structure.md` (default branch only — on feature
+   branches the tree snapshot diverges and would conflict).
+4. **Regenerates `docs/timeline.md` on every branch (v0.2.3+)** — the derived
+   index that `check-derived-docs` CI verifies. Auto-staged into the same
+   commit, so no extra `logmind timeline --write` step is needed.
+5. Stages the touched files (see `--stage` below).
+6. Creates the commit with message `logmind: <decision>`.
+7. Pushes to remote (`auto_push: true` in config).
 
-When you are on a feature branch (anything other than the project's default
-branch), the entry is written to
-`docs/decisions-branches/<sanitized-branch>.md` rather than
-`docs/decisions.md`. On PR merge, a GitHub Action appends a one-line
-summary linking the PR + the per-branch file to `docs/decisions.md`. You do
-not need to manage this routing — `logmind log` does it automatically.
+## `--stage scoped` (default) vs `--stage all`
+
+- **`--stage scoped` (default — use this 95% of the time):** stages ONLY
+  the decision file, `file-structure.md`, archive (if rotated), and
+  `timeline.md` (if regenerated). Unrelated working-tree changes stay
+  unstaged — log the decision first, then commit the code separately.
+- **`--stage all`:** stages everything in the working tree alongside the
+  decision. Use ONLY when the code change and the decision genuinely belong
+  in the same atomic commit (rare — usually you want them as two commits in
+  the same PR so the decision is reviewable on its own).
+
+Both modes regenerate and stage `timeline.md`. If you ever find yourself
+running `logmind timeline --write docs/timeline.md` after a `logmind log`,
+something's wrong (most likely an older logmind version — check `logmind
+--version` and `logmind doctor`).
+
+## Branch-aware routing (automatic)
+
+On a feature branch the entry lands in
+`docs/decisions-branches/<sanitized-branch>.md`. On PR merge a workflow
+appends a one-line summary linking the PR + the per-branch file to
+`docs/decisions.md`. You do not manage this — `logmind log` does.
 
 ## Reading prior context
 
-Before starting non-trivial work, read:
+Before starting non-trivial work, read in order:
 
-- `docs/decisions.md` — 20 most recent decisions on the default branch
-- `docs/decisions-branches/<your-branch>.md` (if present) — decisions made
-  earlier on the same feature branch
-- `docs/file-structure.md` — current project tree
+1. **`docs/timeline.md`** — auto-generated chronological overview across
+   every branch; start here.
+2. **`docs/decisions.md`** — direct-on-main decisions in detail (20 most
+   recent).
+3. **`docs/decisions-branches/<your-branch>.md`** if present — decisions
+   made earlier on the same feature branch.
+4. **`docs/file-structure.md`** — current project tree.
 
 ```bash
 logmind show               # recent decisions on the current branch
 logmind show --all         # include archive
 logmind search "postgres"  # full-text across both files
 ```
+
+## Verifying install health
+
+`logmind doctor` (v0.2.4+) reports installed-vs-latest versions for logmind
+(and clud-bug if present), flags stale workflow templates against bundled
+markers, and exits non-zero on drift so it's CI-pluggable.
+
+```bash
+logmind doctor             # one-shot status table
+logmind doctor --json      # for scripts
+logmind doctor --offline   # skip PyPI / npm probes
+logmind doctor --exit-zero # always exit 0 (informational CI runs)
+```
+
+Run after `logmind init` to confirm a clean install, or any time
+templates / pins might have drifted. Stale-pin drift is auto-healed by
+`logmind init` itself in v0.2.5+, even when no template body changed.
 
 ## Setup (one-time, per project)
 
@@ -86,15 +137,20 @@ If the project doesn't yet have logmind:
 ```bash
 pip install logmind
 logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block
+logmind doctor             # confirm clean install
 ```
 
 ## Don'ts
 
 - **Don't use `git add` + `git commit` directly** for changes that carry a
-  decision. `logmind log` writes the decision file, stages every change in
-  the working tree, and creates the commit in one step. Manual `git commit`
-  bypasses the logging entirely or splits it across two commits — both lose
-  the value of reasoning attached to the code.
+  decision. `logmind log` writes the decision file, stages the touched
+  files, and creates the commit in one step. Manual `git commit` either
+  bypasses the logging entirely or splits it across two commits — both
+  lose the value of having the reasoning attached to the code change.
+- **Don't run `logmind timeline --write docs/timeline.md` after a `logmind
+  log`** — it's already regenerated and staged. The standalone command is
+  an escape hatch for unusual situations (a corrupted timeline, a tree
+  someone touched outside logmind), not part of the normal flow.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
## Summary
The logmind skill body was last updated before three releases worth of new features. This refresh:

- **Adds a "What \`logmind log\` does automatically" section** so agents understand the full set of side effects: appends decision, archives rotation, regenerates file-structure.md, **regenerates timeline.md (v0.2.3+)**, stages everything, commits, pushes.
- **Adds a "scoped vs all" section** explaining \`--stage scoped\` (default, recommended) vs \`--stage all\` (rare; bundles unrelated changes into the decision commit). Resolves a real confusion that bit another agent recently.
- **Adds \`logmind doctor\`** (v0.2.4+) with all four flags documented.
- **Notes v0.2.5+ stale-pin auto-heal** on \`logmind init\` even when no template body changed.
- **Adds an explicit "Don't" rule** against running \`logmind timeline --write\` after \`logmind log\` — auto-regen already did it.

## Why
A real bug report from an agent: ran \`logmind log "..." --stage all\`, then ran \`logmind timeline --write docs/timeline.md\` after, found a dirty file that wasn't in the previous commit. The agent's memory pointed at \`--stage all\` (which IS fine — auto-regen still fires) but the skill never mentioned that the timeline regen happens inside \`logmind log\`. So the post-log timeline rewrite either:
- Found something genuinely stale (rare — usually means old logmind version)
- Or produced no diff (in which case the manual command was wasted)

The skill now tells agents explicitly: don't run the manual timeline rewrite after a log; it's already done. If you find drift, check \`logmind --version\` and \`logmind doctor\`.

## Validation
- ✓ Frontmatter still has \`name: logmind\` and a multi-line description (validate-skills.yml checks).
- ✓ Body still starts with \`# logmind\` h1.
- ✓ \`name:\` matches directory \`logmind/\`.
- ✓ 110 → 167 lines; 83 insertions, 27 deletions.

## Test plan
- [ ] validate-skills.yml CI passes (no frontmatter or h1 regressions)
- [ ] After merge, downstream caches (\`npx skills add\`) pick up the new content on next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)