### PR TITLE
docs(logmind): cover v0.3.0 merge driver + file-structure --write (closes #17)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v4-slim -->
+<!-- logmind-block-version: v5-slim -->
 ## Decision logging — `logmind log` is the commit primitive
 
 This project uses [logmind](https://logmind.dev) for decision logging. **`logmind log` replaces `git add`, `git commit`, and `git push`** for any change that carries a decision. Do not run those git commands directly when logging a decision — `logmind log` does all three in one step.
@@ -33,10 +33,10 @@ That's it. No follow-up `git add`, no follow-up `git commit`, no follow-up `git 
 
 ### The full skill
 
-The complete procedure (when something counts as a decision, branch routing, doctor, refresh patterns) lives in the **`logmind` agent skill** at https://github.com/thrillmot/agent-skills/tree/main/skills/logmind. Most agent runtimes auto-load it. If yours doesn't:
+The complete procedure (when something counts as a decision, branch routing, doctor, refresh patterns) lives in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind. Most agent runtimes auto-load it. If yours doesn't:
 
 ```bash
-npx skills add https://github.com/thrillmot/agent-skills --skill logmind
+npx skills add https://github.com/thrillmade/agent-skills --skill logmind
 ```
 
 ### Required reading before non-trivial work

--- a/docs/decisions-branches/docs__logmind-v0.3.0.md
+++ b/docs/decisions-branches/docs__logmind-v0.3.0.md
@@ -1,0 +1,11 @@
+## 2026-05-27 00:27 - Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md
+
+**Reasoning:** Notifier issue #17 was open since v0.3.0 (2026-05-26). v0.3.0 added a real install-time surface (.gitattributes block, per-clone git config, post-merge hook, file-structure --write CLI, 3 new doctor rows) that agents reading doctor output or rebasing parallel-PR branches will encounter — not internal-only, so a no-op close would leave the skill drifted.
+
+**Alternatives considered:** Close #17 as no-op (rejected: v0.3.0 is user-visible, not refactor), Split into 3 separate PRs per concept (rejected: one cohesive 'parallel-PR merges' section reads as one idea)
+
+**Implications:**
+- Skill grows ~35 lines; structure now has a v0.3.0 section sitting between Verifying-install-health and Upgrading sections
+- Next refresh likely on v0.4.0 (notify-clud-bug pattern, per separate plan)
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,5 +15,6 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
 - **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -149,6 +149,39 @@ body changed. **If `doctor` reports an `AGENTS.md` stale row, your repo's
 embedded logmind instructions are older than what the installed logmind
 would write — re-run `logmind init` to refresh in place.**
 
+## Parallel-PR merges: timeline + file-structure merge driver (v0.3.0+)
+
+Two PRs that both run `logmind log` no longer textually conflict on
+`docs/timeline.md` or `docs/file-structure.md` on rebase. v0.3.0's
+`logmind init` installs three pieces that handle this together:
+
+- **`.gitattributes` block** (idempotent, marker-bracketed) — registers
+  `merge=logmind-timeline` and `merge=logmind-file-structure` for the
+  two derived files.
+- **Per-clone `git config`** — defines the merge drivers themselves
+  (`merge.logmind-timeline.driver = 'logmind timeline --write %A'`,
+  similar for file-structure). Lives in `.git/config`, not committed
+  (git refuses to auto-run a merge driver that isn't explicitly
+  configured locally — security guard against untrusted repos). Fresh
+  clones need `logmind init` once to pick this up.
+- **`.git/hooks/post-merge`** — re-regenerates both derived files from
+  the full post-merge working tree. Belt + suspenders: the driver runs
+  per-file mid-merge before the other branch's `docs/decisions-branches/`
+  files are checked out, so its output can miss decisions; the hook
+  sweeps any incomplete regen at end-of-merge.
+
+`logmind doctor` reports three new rows for these (v0.3.0+):
+`.gitattributes (merge driver)`, `git config (merge driver)`, and
+`post-merge hook`. Missing rows are not drift — they're "not yet
+installed for this logmind version" — the next `logmind init` resolves
+them silently.
+
+The merge driver invokes `logmind file-structure --write <path>`
+(v0.3.0+), the mirror of `logmind timeline --write`. Like the timeline
+command, you should not run it by hand in the normal flow — it exists
+for the merge driver and as an escape hatch (corrupted file, externally
+modified tree).
+
 ## Upgrading: `logmind init` prints the changelog
 
 When you run `pip install --upgrade logmind && logmind init` in an
@@ -180,6 +213,9 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.2.9**: `logmind log` prints a visible `--stage` notice on every
   invocation so the actual behavior is unmissable in output.
 - **v0.2.9**: `logmind doctor` flags stale `AGENTS.md` block-version.
+- **v0.3.0**: `logmind init` registers a git merge driver for
+  `timeline.md` / `file-structure.md` so parallel-PR merges no longer
+  conflict on the derived files. Doctor gains three rows tracking it.
 
 ## Setup (one-time, per project)
 
@@ -187,7 +223,7 @@ If the project doesn't yet have logmind:
 
 ```bash
 pip install logmind
-logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block
+logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block, merge drivers + post-merge hook (v0.3.0+)
 logmind doctor             # confirm clean install
 ```
 


### PR DESCRIPTION
## Summary

Addresses notifier issue #17 (logmind v0.3.0 release) by documenting the
real v0.3.0 surface in \`skills/logmind/SKILL.md\`:

- New **\`Parallel-PR merges: timeline + file-structure merge driver (v0.3.0+)\`** section covering the \`.gitattributes\` block, per-clone \`git config\`, post-merge hook, the three new \`logmind doctor\` rows, and the new \`logmind file-structure --write\` CLI.
- v0.3.0 bullet added to the "Common deltas you'll see if you're upgrading across a stretch" list.
- \`logmind init\` setup-section comment extended to mention merge drivers + post-merge hook.

The skill is now coherent with logmind \`HEAD\` through v0.3.1 (v0.3.1 was org-rename only — no SKILL.md content change needed; covered separately by the AGENTS.md block refresh that \`logmind log\` swept into this commit automatically).

## Side effect — AGENTS.md block refreshed

\`logmind log\` runs refresh-mode on every invocation. This commit also
includes \`AGENTS.md\` block-version bump \`v4-slim → v5-slim\` and the
embedded \`thrillmot → thrillmade\` skill-install URL fix — both of
which were queued for a separate post-migration PR (PR 4 in the plan).
They're folded in here because the refresh ran automatically and the
result was correct.

## Closes

- Closes #17 (v0.3.0)
- Closes #19 (v0.3.1 — no content change required; org rename covered by the AGENTS.md block refresh in this commit)

Issues #14 and #15 already closed by PR #16.

## Test plan

- [ ] \`validate-skills.yml\` passes on PR.
- [ ] clud-bug-review surfaces no critical findings.
- [ ] Visual diff on the new section reads naturally between "Verifying install health" and "Upgrading" sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)