### PR TITLE
chore: add .github/dependabot.yml (github-actions weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/docs/decisions-branches/chore__dependabot.md
+++ b/docs/decisions-branches/chore__dependabot.md
@@ -1,0 +1,11 @@
+## 2026-05-27 00:43 - Add .github/dependabot.yml for github-actions ecosystem only
+
+**Reasoning:** Workflow files reference pinned action versions (actions/checkout@v6, etc). Without dependabot, these drift silently and CI breaks when a major action retires its runtime — same trap logmind/clud-bug both hit pre-dependabot. github-actions-only scope: this repo has no code dependencies (markdown skills + a small Python validator with no third-party deps), so no npm/pip ecosystem needed.
+
+**Alternatives considered:** Add npm + pip ecosystems too — rejected: nothing in repo to update. Would generate empty Dependabot output., Wait for the planned thrillmade/reporulez/templates/dependabot/github-actions-only.yml template — rejected: doesn't exist yet, and the config is 5 lines. If reporulez ships a different shape later, we can reconcile in a one-line diff.
+
+**Implications:**
+- Weekly cadence picked to align with logmind/clud-bug dogfood schedules and avoid daily PR noise on a low-churn repo.
+- Future: if we add a Node tool (e.g., for a SKILL.md preview/render), add an npm entry then.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
 - **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
 - **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)


### PR DESCRIPTION
## Summary

Adds a minimal Dependabot config to keep workflow action pins (`actions/checkout@v6`, etc.) from drifting silently. `github-actions` ecosystem only — this repo has no code dependencies (markdown skills + a stdlib-only Python validator).

## Notes

- **Weekly cadence** to match the logmind/clud-bug dogfood schedules and avoid daily PR noise on a low-churn repo.
- **No npm/pip entry** by design — nothing here to update.
- The AGENTS.md `v4-slim → v5-slim` bump in this PR is `logmind log` refresh-mode output (same as PR #20). When PR #20 lands first, this diff will collapse to just the new dependabot file.

## Test plan

- [ ] All CI checks pass.
- [ ] clud-bug-review surfaces no critical findings.
- [ ] After merge, watch the next weekly cycle (next Monday) for a sane first scan of `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)