### PR TITLE
feat: review_mode field on all skills + mechanical notify-clud-bug.yml PR-opener

### DIFF
--- a/.github/workflows/notify-clud-bug.yml
+++ b/.github/workflows/notify-clud-bug.yml
@@ -1,114 +1,202 @@
-name: notify clud-bug on skill change
+name: sync skill to clud-bug
 
-# When a baseline skill that clud-bug pins via SHA in lib/skills.js
-# changes on main, open an issue on thrillmade/clud-bug so the
-# maintainer knows to bump BASELINE_SKILLS_REF + release a new
-# clud-bug version. Closes the manual-sync chore between this
-# canonical SKILL.md and clud-bug's bundled offline-fallback copy.
+# Open a PR on thrillmade/clud-bug refreshing one bundled baseline SKILL.md
+# from the current state of this repo, plus the BASELINE_SKILLS_REF pin in
+# lib/skills.js, plus a patch version bump and CHANGELOG entry. Replaces the
+# v0.x workflow that opened an issue with "you should update X" instructions
+# the maintainer then applied by hand — the PR shape applies them directly.
 #
-# Only fires when one of the FOUR skills clud-bug pins changes:
-#   - critical-issues-only
-#   - evidence-based-review
-#   - respect-existing-conventions
-#   - clud-bug-collaboration
+# Trigger: workflow_dispatch only during the smoke-test phase. Once the
+# produced PRs look right, a follow-up one-line edit adds an `on: push`
+# trigger that fires automatically on changes to the matching SKILL.md files
+# on main. Conservatively starting manual to minimise blast radius if the
+# transform misfires.
 #
-# Other skills (logmind, future) aren't pinned by clud-bug so they
-# don't need this notification.
+# Auth: CLUD_BUG_NOTIFY_PAT — fine-grained PAT scoped to thrillmade/clud-bug
+# with Contents: write + Pull requests: write. (Pre-v0.6 of this workflow
+# the same secret only needed Issues: write; rotate the token's scope when
+# enabling this workflow, otherwise the push or `gh pr create` step fails
+# with a 403.)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "skills/critical-issues-only/SKILL.md"
-      - "skills/evidence-based-review/SKILL.md"
-      - "skills/respect-existing-conventions/SKILL.md"
-      - "skills/clud-bug-collaboration/SKILL.md"
+  workflow_dispatch:
+    inputs:
+      skill_name:
+        description: 'Baseline skill slug to sync into clud-bug'
+        required: true
+        type: choice
+        options:
+          - critical-issues-only
+          - evidence-based-review
+          - respect-existing-conventions
+          - clud-bug-collaboration
 
 permissions:
-  # GITHUB_TOKEN can create issues on this repo, but it CAN'T create
-  # issues on a different repo (thrillmade/clud-bug). The workflow
-  # uses a CLUD_BUG_NOTIFY_PAT secret instead — fine-grained PAT
-  # scoped to thrillmade/clud-bug with Issues: write.
   contents: read
 
 jobs:
-  open-issue:
+  sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Identify changed baseline skills
-        id: changes
-        env:
-          BEFORE: ${{ github.event.before }}
-          AFTER: ${{ github.event.after }}
+      - name: Checkout agent-skills
+        uses: actions/checkout@v6
+
+      - name: Verify source SKILL.md exists
+        run: test -f "skills/${{ inputs.skill_name }}/SKILL.md"
+
+      - name: Compute source SHA and short SHA
+        id: src
         run: |
           set -euo pipefail
-          # The 4 skills clud-bug pins. Keep in sync with the `paths:`
-          # filter above.
-          tracked=(critical-issues-only evidence-based-review respect-existing-conventions clud-bug-collaboration)
-          changed=()
-          # git fetch the before SHA so we can diff
-          git fetch --no-tags --depth=1 origin "$BEFORE" 2>/dev/null || true
-          if git cat-file -e "$BEFORE" 2>/dev/null; then
-            diff_files=$(git diff --name-only "$BEFORE...$AFTER" -- 'skills/**/SKILL.md')
-          else
-            # First push to main or shallow clone fallback — assume all 4 changed
-            diff_files=$(printf "skills/%s/SKILL.md\n" "${tracked[@]}")
-          fi
-          for skill in "${tracked[@]}"; do
-            if echo "$diff_files" | grep -qx "skills/${skill}/SKILL.md"; then
-              changed+=("$skill")
-            fi
-          done
-          if [ ${#changed[@]} -eq 0 ]; then
-            echo "No baseline skill changed in this push; skipping."
-            exit 0
-          fi
-          # Newline-separated for the issue body
-          printf '%s\n' "${changed[@]}" > /tmp/changed-skills.txt
-          echo "changed_count=${#changed[@]}" >> "$GITHUB_OUTPUT"
-          echo "head_sha=${AFTER}" >> "$GITHUB_OUTPUT"
+          SHA="$(git rev-parse HEAD)"
+          SHORT="${SHA:0:7}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "short=${SHORT}" >> "$GITHUB_OUTPUT"
+          echo "branch=skills-refresh/${{ inputs.skill_name }}-${SHORT}" >> "$GITHUB_OUTPUT"
 
-      - name: Open issue on thrillmade/clud-bug
-        if: steps.changes.outputs.changed_count != ''
+      - name: Checkout thrillmade/clud-bug
+        uses: actions/checkout@v6
+        with:
+          repository: thrillmade/clud-bug
+          path: clud-bug
+          token: ${{ secrets.CLUD_BUG_NOTIFY_PAT }}
+
+      - name: Verify CLUD_BUG_NOTIFY_PAT has push + PR scope
         env:
           GH_TOKEN: ${{ secrets.CLUD_BUG_NOTIFY_PAT }}
-          HEAD_SHA: ${{ steps.changes.outputs.head_sha }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::CLUD_BUG_NOTIFY_PAT secret missing. Install a fine-grained PAT scoped to thrillmade/clud-bug with Contents: write + Pull requests: write."
+            exit 1
+          fi
+          # Surfaces the scope mismatch loudly before we try to mutate the repo.
+          gh api repos/thrillmade/clud-bug --jq '.full_name' > /dev/null
+
+      - name: Short-circuit if PR already open for this branch
+        id: existing
+        working-directory: clud-bug
+        env:
+          GH_TOKEN: ${{ secrets.CLUD_BUG_NOTIFY_PAT }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::CLUD_BUG_NOTIFY_PAT secret missing — install a fine-grained PAT scoped to thrillmade/clud-bug with Issues: write to enable this notifier."
-            exit 0
+          NUM="$(gh pr list --head '${{ steps.src.outputs.branch }}' --state open --json number --jq '.[0].number // ""')"
+          if [ -n "$NUM" ]; then
+            echo "::notice::Existing PR #${NUM} already open for ${{ steps.src.outputs.branch }} — leaving as-is. Close it manually if you want to regenerate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
-          changed_md=$(awk '{print "- `" $0 "`"}' /tmp/changed-skills.txt)
-          body=$(cat <<EOF
-          One or more clud-bug baseline skills changed on agent-skills' \`main\`.
-          Bump \`BASELINE_SKILLS_REF\` in \`lib/skills.js\` to:
 
-              ${HEAD_SHA}
+      - name: Compare source vs bundled (skip if identical)
+        id: diff
+        if: steps.existing.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          SRC="skills/${{ inputs.skill_name }}/SKILL.md"
+          DST="clud-bug/templates/skills/baseline/${{ inputs.skill_name }}.md"
+          if [ ! -f "$DST" ]; then
+            echo "::error::Bundled copy ${DST} not found in clud-bug — the skill_name input may not be a tracked baseline."
+            exit 1
+          fi
+          if diff -q "$SRC" "$DST" >/dev/null 2>&1; then
+            # Bundled is byte-identical to source. The pin may still be stale,
+            # but the content sync would be a no-op — and the version bump
+            # would be churn. Skip; a future change to the source re-triggers.
+            echo "::notice::Source and bundled copies of ${{ inputs.skill_name }} are byte-identical — nothing to sync."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
 
-          Then sync the bundled offline-fallback copies under
-          \`templates/skills/baseline/\` from the new agent-skills HEAD,
-          test, and release a new clud-bug patch.
+      - name: Apply sync (copy + pin + version + changelog)
+        if: steps.existing.outputs.skip != 'true' && steps.diff.outputs.skip != 'true'
+        working-directory: clud-bug
+        env:
+          SHA: ${{ steps.src.outputs.sha }}
+          SHORT: ${{ steps.src.outputs.short }}
+          SKILL: ${{ inputs.skill_name }}
+        run: |
+          set -euo pipefail
+          # 1. Copy source SKILL.md into bundled location.
+          cp "../skills/${SKILL}/SKILL.md" "templates/skills/baseline/${SKILL}.md"
 
-          ## Changed skills
-          ${changed_md}
+          # 2. Bump BASELINE_SKILLS_REF in lib/skills.js. The constant is
+          #    declared as a single line:
+          #      const BASELINE_SKILLS_REF = '<40-hex-sha>';
+          #    Verify after sed that the new SHA actually landed — if the
+          #    declaration shape ever changes the regex would silently no-op.
+          sed -i.bak -E "s|^(const BASELINE_SKILLS_REF = ')[a-f0-9]{40}(';.*)$|\1${SHA}\2|" lib/skills.js
+          rm lib/skills.js.bak
+          if ! grep -q "BASELINE_SKILLS_REF = '${SHA}'" lib/skills.js; then
+            echo "::error::BASELINE_SKILLS_REF sed did not produce the expected line — check the constant declaration shape in lib/skills.js."
+            exit 1
+          fi
 
-          ## Why
-          clud-bug fetches each baseline SKILL.md from agent-skills at
-          install/update time using the SHA pin. Until the SHA bumps,
-          installed clud-bugs continue to fetch the OLDER version — the
-          bundled offline fallback is the only safety net against drift.
+          # 3. Bump patch version in package.json. Use node to avoid pulling
+          #    in jq just for this single field — clud-bug already requires
+          #    node to run.
+          NEW_VERSION="$(node -e "const p=require('./package.json'); const [maj,min,pat]=p.version.split('.').map(Number); console.log(\`\${maj}.\${min}.\${pat+1}\`)")"
+          node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json')); p.version='${NEW_VERSION}'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');"
+          echo "new_version=${NEW_VERSION}" >> "$GITHUB_ENV"
 
-          ## Source change
-          https://github.com/thrillmade/agent-skills/commit/${HEAD_SHA}
+          # 4. Prepend a CHANGELOG entry under [Unreleased]. The file format
+          #    is Keep-a-Changelog; the [Unreleased] header sits at the top.
+          DATE="$(date -u +%Y-%m-%d)"
+          ENTRY_FILE="$(mktemp)"
+          cat > "$ENTRY_FILE" <<EOF
 
-          ## Auto-generated
-          Opened by \`agent-skills/.github/workflows/notify-clud-bug.yml\`.
+          ## [${NEW_VERSION}] — ${DATE}
+
+          ### Changed
+
+          - **Bundled \`${SKILL}\` SKILL.md refreshed** from \`thrillmade/agent-skills@${SHORT}\`. \`BASELINE_SKILLS_REF\` in \`lib/skills.js\` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by \`agent-skills/.github/workflows/notify-clud-bug.yml\`.
+
           EOF
-          )
-          gh issue create \
+          # awk inserts the entry on the line after the [Unreleased] header.
+          awk -v ef="$ENTRY_FILE" '
+            /^## \[Unreleased\]/ {
+              print
+              while ((getline line < ef) > 0) print line
+              close(ef)
+              next
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
+          rm "$ENTRY_FILE"
+
+      - name: Commit + push + open PR
+        if: steps.existing.outputs.skip != 'true' && steps.diff.outputs.skip != 'true'
+        working-directory: clud-bug
+        env:
+          GH_TOKEN: ${{ secrets.CLUD_BUG_NOTIFY_PAT }}
+          SHA: ${{ steps.src.outputs.sha }}
+          SHORT: ${{ steps.src.outputs.short }}
+          BRANCH: ${{ steps.src.outputs.branch }}
+          SKILL: ${{ inputs.skill_name }}
+        run: |
+          set -euo pipefail
+          git config user.name "agent-skills-sync[bot]"
+          git config user.email "agent-skills-sync@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add -A
+          git commit -m "chore(skills): refresh bundled ${SKILL} from agent-skills@${SHORT}"
+          git push -u origin "${BRANCH}"
+
+          PR_BODY="Automated bundled-copy sync from \`thrillmade/agent-skills\`.
+
+          **Source SKILL.md:** https://github.com/thrillmade/agent-skills/blob/${SHA}/skills/${SKILL}/SKILL.md
+          **Source commit:** https://github.com/thrillmade/agent-skills/commit/${SHA}
+
+          ## Changes applied
+
+          - \`templates/skills/baseline/${SKILL}.md\` ← byte-for-byte copy of the source above.
+          - \`lib/skills.js\` — \`BASELINE_SKILLS_REF\` bumped to \`${SHA}\` so the install-time fetch from \`thrillmade/agent-skills\` and the bundled offline-fallback both resolve to identical content.
+          - \`package.json\` — patch version bump to \`${new_version}\`.
+          - \`CHANGELOG.md\` — entry under [Unreleased] documenting the refresh.
+
+          ## How this was generated
+
+          \`agent-skills/.github/workflows/notify-clud-bug.yml\` (\`workflow_dispatch\`) — invoked manually during the smoke-test phase. A future change to that workflow will add an \`on: push\` auto-trigger once the produced PRs are confirmed sane."
+
+          gh pr create \
             --repo thrillmade/clud-bug \
-            --title "agent-skills: baseline skills changed — bump BASELINE_SKILLS_REF" \
-            --label "deps,from-agent-skills" \
-            --body "$body" \
-            || echo "::warning::failed to open issue on clud-bug (likely a missing label — re-run after creating the labels, or remove --label)"
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore(skills): refresh bundled ${SKILL} from agent-skills@${SHORT}" \
+            --body "${PR_BODY}"

--- a/.github/workflows/notify-clud-bug.yml
+++ b/.github/workflows/notify-clud-bug.yml
@@ -160,6 +160,17 @@ jobs:
           ' CHANGELOG.md > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
           rm "$ENTRY_FILE"
 
+          # Verify the entry actually landed. Mirrors the sed-then-grep check
+          # above so the awk can't silently no-op if clud-bug's [Unreleased]
+          # header shape ever drifts (e.g. "## [Unreleased] - 2026-XX-YY").
+          # Without this, the version + pin bump would still ship but the
+          # CHANGELOG entry would be missing, and the failure would only
+          # surface on maintainer review.
+          if ! grep -qF "[${NEW_VERSION}]" CHANGELOG.md; then
+            echo "::error::CHANGELOG entry for ${NEW_VERSION} not inserted — check the [Unreleased] header shape in clud-bug's CHANGELOG.md."
+            exit 1
+          fi
+
       - name: Commit + push + open PR
         if: steps.existing.outputs.skip != 'true' && steps.diff.outputs.skip != 'true'
         working-directory: clud-bug

--- a/docs/decisions-branches/feat__skill-review-mode.md
+++ b/docs/decisions-branches/feat__skill-review-mode.md
@@ -1,0 +1,12 @@
+## 2026-05-27 00:49 - Add review_mode: shared to all baseline-type skill frontmatters
+
+**Reasoning:** clud-bug bundled copies inject review_mode: shared into the 3 baseline reviewer skills' frontmatters (clud-bug-collaboration, critical-issues-only, evidence-based-review, respect-existing-conventions). Bundled copies diverge from agent-skills source on that single line, making notify-clud-bug.yml (the future PR 2b mechanical sync) harder than necessary — a pure 'cp source to bundled' would clobber clud-bug's enrichment. Adding the field at source eliminates the divergence and makes the sync a verbatim copy. Same field added for logmind so the catalog is consistent across all skills (logmind ships as a baseline elsewhere in some installs too).
+
+**Alternatives considered:** Strip review_mode from bundled copies on clud-bug side instead — rejected: the field is real routing config that clud-bug consumes; stripping breaks the routing semantics., Skip logmind (different lifecycle) — rejected: consistency across the catalog is cheap and the field is the right default everywhere except the 4 already-dedicated skills., Mark test-discipline as shared too — rejected: existing file has it as dedicated, and per 'respect-existing-conventions' (this very skill in the same PR), match the convention. Test review benefits from focused attention as much as brand voice / PII / API contract.
+
+**Implications:**
+- Five frontmatters touched: logmind, critical-issues-only, evidence-based-review, respect-existing-conventions, clud-bug-collaboration. Four already-dedicated skills (api-contract-enforcement, brand-voice-review, pii-and-compliance, test-discipline) unchanged. validate-skills.yml passes additional fields through; no validator change needed.
+- Unblocks PR 2b — notify-clud-bug.yml can be a 'cp source → bundled + bump SHA + bump version + open PR' shell script with no transform layer or LLM in the middle.
+- Future skills authored in this catalog should declare review_mode explicitly; the existing inconsistency (where 4 had it and 5 didn't) was an accident of authoring order, not intent.
+
+---

--- a/docs/decisions-branches/feat__skill-review-mode.md
+++ b/docs/decisions-branches/feat__skill-review-mode.md
@@ -10,3 +10,15 @@
 - Future skills authored in this catalog should declare review_mode explicitly; the existing inconsistency (where 4 had it and 5 didn't) was an accident of authoring order, not intent.
 
 ---
+## 2026-05-27 06:10 - Rewrite notify-clud-bug.yml as mechanical PR-opener (workflow_dispatch only)
+
+**Reasoning:** Original v0.x workflow opened an issue on thrillmade/clud-bug saying 'baseline skill X changed, bump BASELINE_SKILLS_REF + sync bundled copy + release'. The maintainer then applied those steps by hand. The new version applies them directly: copies source SKILL.md to bundled, bumps the SHA pin, bumps patch version, prepends CHANGELOG entry, opens PR. PR shape eliminates a manual round-trip; the PR can be reviewed, merged, and released in one pass instead of issue→branch→push→PR→merge→release. PR 2a already eliminated the source/bundled frontmatter divergence (review_mode field) so the copy is verbatim — no transform layer or LLM in the loop.
+
+**Alternatives considered:** Open a PR auto on push to baseline SKILL.md — rejected (initially): workflow_dispatch only during smoke-test phase, so the produced PRs can be manually inspected for shape correctness before granting auto-trigger authority. Add 'on: push' as a one-line follow-up after the first 2-3 manual runs look right., Sync ALL changed baselines in a single PR — rejected: skill-by-skill PRs keep clud-bug-review's per-PR context tight, isolate any sed/awk misfires to one skill, and give the maintainer skill-level control over which to land first., Call Anthropic API to draft the bundled copy from a diff — rejected (the original plan's default): hallucination surface for a fundamentally mechanical task. PR 2a (review_mode source/bundled alignment) made this unnecessary.
+
+**Implications:**
+- Idempotency via branch name (skills-refresh/<skill>-<short-sha>) — re-running for the same source SHA finds an open PR and exits silently. Different SHA → different branch → new PR. Stale PRs from prior runs stay open for manual cleanup; acceptable since the maintainer was going to look at them anyway.
+- CLUD_BUG_NOTIFY_PAT now needs Contents + Pull requests: write on thrillmade/clud-bug (previously only Issues: write). Token must be rotated before the first dispatch — the workflow exits non-zero with a clear error if the scope is missing, so failure mode is loud.
+- Side-effects asserted by step 'Apply sync': sed regex match on the BASELINE_SKILLS_REF line is verified by grep after; if the constant's declaration shape ever changes the workflow fails with a specific error rather than silently no-opping. node used for package.json edits (no jq dep).
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Rewrite notify-clud-bug.yml as mechanical PR-opener (workflow_dispatch only) *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
 - **2026-05-27** — Add review_mode: shared to all baseline-type skill frontmatters *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
 - **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
 - **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — Add review_mode: shared to all baseline-type skill frontmatters *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
 - **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
 - **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
 - **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/skills/clud-bug-collaboration/SKILL.md
+++ b/skills/clud-bug-collaboration/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: clud-bug-collaboration
 description: How Claude Code agents working in a clud-bug-installed repo should interact with the bot's review threads, strict-mode gate, and skill set. Use this skill whenever you're about to push a commit, address a clud-bug PR review comment, edit anything under .claude/skills/, modify .github/workflows/clud-bug-*.yml, or wonder why a PR check is red. Also use when planning work in a repo that has a `clud-bug-review` workflow installed — even if the user didn't mention clud-bug by name.
+review_mode: shared
 ---
 
 # Working in a clud-bug-installed repo

--- a/skills/critical-issues-only/SKILL.md
+++ b/skills/critical-issues-only/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: critical-issues-only
 description: PR review discipline - flag only correctness, security, and performance issues. Skip nits.
+review_mode: shared
 ---
 
 # Critical issues only

--- a/skills/evidence-based-review/SKILL.md
+++ b/skills/evidence-based-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: evidence-based-review
 description: Every PR review claim must quote the specific code being criticized. No hand-waving.
+review_mode: shared
 ---
 
 # Evidence-based review

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -10,6 +10,7 @@ description: |
   significant module. Logging is part of the work, not after it. Also use
   to read prior decisions before starting any task in such a project so
   you don't re-litigate something already decided.
+review_mode: shared
 ---
 
 # logmind: log decisions as you work

--- a/skills/respect-existing-conventions/SKILL.md
+++ b/skills/respect-existing-conventions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: respect-existing-conventions
 description: Don't suggest changes that fight the codebase's established patterns. Match what's already there.
+review_mode: shared
 ---
 
 # Respect existing conventions


### PR DESCRIPTION
## Summary

Combined PR delivering two tightly-coupled changes that together replace the manual cross-repo sync between this repo and `thrillmade/clud-bug`:

**Part 1 — `review_mode` field on all baseline-type frontmatters** (5 files, 1 line each)
Adds explicit `review_mode: shared` to the 5 frontmatters that didn't already declare it. The other 4 (`api-contract-enforcement`, `brand-voice-review`, `pii-and-compliance`, `test-discipline`) already had `review_mode: dedicated` per the v0.5.9+ clud-bug routing contract. After this PR every SKILL.md declares its routing mode explicitly.

This eliminates the source/bundled divergence that previously blocked a verbatim sync:
```bash
diff clud-bug/templates/skills/baseline/critical-issues-only.md agent-skills/skills/critical-issues-only/SKILL.md
# 4d3
# < review_mode: shared
```

**Part 2 — `notify-clud-bug.yml` rewrite (issue-opener → PR-opener)**
The v0.x workflow opened an issue on `thrillmade/clud-bug` saying "baseline skill X changed, bump `BASELINE_SKILLS_REF` + sync bundled copy + release a new version". The maintainer then applied those steps by hand.

This rewrite applies them directly. For one selected skill:
- `cp skills/<name>/SKILL.md` → `clud-bug/templates/skills/baseline/<name>.md` (now byte-identical thanks to Part 1)
- `sed BASELINE_SKILLS_REF` in `clud-bug/lib/skills.js` to the current agent-skills commit SHA
- `node` bumps `clud-bug/package.json` patch version
- `awk` prepends a CHANGELOG entry under `[Unreleased]`
- Pushes a branch named `skills-refresh/<skill>-<short-sha>` and opens a PR on clud-bug

## Why these ship together

Part 2 only works as a verbatim copy if Part 1 lands first. Verifying after Part 1 lands but before Part 2's first dispatch is the natural smoke-test: the source and bundled copies should `diff` to empty for each of the 4 baselines after `git pull` on both repos.

## Operational notes

- **Trigger:** `workflow_dispatch` only during the smoke-test phase. One-line follow-up adds `on: push` after the first 2-3 manual runs look right.
- **Auth:** `CLUD_BUG_NOTIFY_PAT` scope must expand from `Issues: write` to `Contents: write` + `Pull requests: write` on `thrillmade/clud-bug` before the first dispatch. The workflow exits non-zero with a specific error if scope is missing, so failure mode is loud.
- **Idempotency:** branch name encodes source SHA. Re-dispatch for the same SHA finds an open PR and exits silently. Different SHA → different branch → new PR.
- **No LLM:** rejected the original plan's "Claude drafts the bundled copy" option. Part 1 made it unnecessary — mechanical sync is now possible and removes hallucination surface.

## Verification

- `validate-skills.yml` accepts additional frontmatter fields; no validator change needed.
- Local YAML parse confirms every touched frontmatter parses cleanly, including `logmind`'s multiline `description: |` block.
- Workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/notify-clud-bug.yml').read())"`).
- AGENTS.md `v4-slim → v5-slim` bump in commit 1 is `logmind log` refresh-mode output (same auto-refresh as PRs #20 and #21).

## Test plan

- [ ] CI passes (validate-skills, check-decisions, check-derived-docs, check-links, clud-bug-review).
- [ ] After merge, rotate `CLUD_BUG_NOTIFY_PAT` scope to add `Contents + Pull requests: write` on `thrillmade/clud-bug`.
- [ ] Dispatch the workflow once per baseline skill (4 runs) as a smoke-test. Confirm each opens a single PR on `thrillmade/clud-bug` with the expected 4-file diff. Close the PRs without merging (the bundled copies don't actually need updating yet — verifying shape only).
- [ ] Once smoke-tested, ship a one-line follow-up adding `on: push` with the original baseline path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
