### PR TITLE
logmind v0.4.0 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.4.0.md
+++ b/.skill-update-todo/v0.4.0.md
@@ -1,0 +1,27 @@
+# logmind v0.4.0 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.4.0/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.4.0
+
+## Claude's reasoning
+
+The v0.4.0 changes are entirely internal CI/workflow infrastructure: the `notify-agent-skills.yml` workflow now opens a PR instead of an issue, a new helper script calls the Anthropic API to propose SKILL.md edits, and tests cover that script. None of these changes affect how an AI agent uses logmind CLI commands, the logging workflow, git behavior, or any other agent-facing behavior documented in SKILL.md.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.4.0] - 2026-05-27
+
+### Changed — `notify-agent-skills.yml` opens a PR (not an issue) with a Claude-generated proposed SKILL.md update
+- **The reshape.** Every logmind tag push has been opening an *issue* on `thrillmade/agent-skills` titled `logmind vX.Y.Z shipped — review skills/logmind/SKILL.md`. The maintainer then has to read the CHANGELOG, decide what's skill-relevant, write the edit, and PR it themselves. The notification is issue-shaped; the actual work is PR-shaped. v0.4.0 inverts this: the workflow now opens a **PR** on agent-skills with a **Claude-generated proposed SKILL.md edit** based on the release's CHANGELOG section. Reviewer-checklist body, no auto-merge, full reasoning attached.
+- **Mechanism.** New helper script `.github/scripts/propose_skill_update.py` calls the Anthropic API (`claude-sonnet-4-6`) once per release with: the CHANGELOG section sliced via `logmind.core.changelog.extract_sections_between`, plus the current `skills/logmind/SKILL.md` fetched from agent-skills' main. Claude emits either (a) `<reasoning>` + `<skill_md>` XML blocks containing the proposed edit, or (b) a `NO_SKILL_UPDATE_NEEDED` sentinel for releases with no user-facing changes worth surfacing to AI agents. Either way, a stub `.skill-update-todo/vX.Y.Z.md` is always written with full context (CHANGELOG section, Claude's reasoning, release URL).
+- **Auth (already in place).** Same `AGENT_SKILLS_NOTIFY_PAT` from v0.3.x (just expanded scope to Contents + PRs: write, configured earlier in the migration session). `ANTHROPIC_API_KEY` is the existing org-level secret. No setup step required on existing installs.
+- **Failure-mode degradation.** If the Anthropic API call fails or the PAT is missing, a fallback job opens the v0.3.x-shaped issue so the release still gets acknowledged. Shipping discipline preserved — a release shouldn't break because the new flow flakes.
+- **Tests.** `tests/test_propose_skill_update.py` mocks the Anthropic client and exercises: full-proposal parsing, sentinel parsing, sentinel precedence over stray blocks, malformed-response degradation, missing-key/missing-package guards, end-to-end main() with both proposal and sentinel paths.
+
+### Future enhancements considered (not in v0.4.0)
+After 1-3 release dogfoods we'll know whether to:
+- **Prompt-tune** if Claude's proposed edits are consistently off (e.g. N-shot examples drawn from past SKILL.md commit diffs).
+- **Auto-merge gate** on a confidence-score threshold (request a JSON confidence in the structured output, auto-merge when >0.9). Today's design intentionally keeps auto-merge OFF — content is discretionary.
+- **Extend to symmetric flows** if another downstream-sync surface emerges (clud-bug → some-future-consumer, etc.). The two-file shape (changelog slice + current target → propose) generalizes cleanly.
+
+### Migration from v0.3.4
+None required on existing installs. The reshape is server-side (the workflow file inside logmind itself). After this release tags, the next agent-skills notify will arrive as a PR rather than an issue — open it, scan Claude's reasoning, merge or close.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.4.0 shipped.

**CHANGELOG**: [`v0.4.0` on logmind](https://github.com/thrillmade/logmind/blob/v0.4.0/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.4.0

## Shape of this PR

TODO context only (Claude judged release skill-irrelevant)

## Claude's reasoning

The v0.4.0 changes are entirely internal CI/workflow infrastructure: the `notify-agent-skills.yml` workflow now opens a PR instead of an issue, a new helper script calls the Anthropic API to propose SKILL.md edits, and tests cover that script. None of these changes affect how an AI agent uses logmind CLI commands, the logging workflow, git behavior, or any other agent-facing behavior documented in SKILL.md.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.