### PR TITLE
logmind v0.5.0 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.0.md
+++ b/.skill-update-todo/v0.5.0.md
@@ -1,0 +1,35 @@
+# logmind v0.5.0 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.0/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.0
+
+## Claude's reasoning
+
+The v0.5.0 release introduces a user-visible default change (`max_depth=2` for `docs/file-structure.md` generation) and a new CLI flag (`--max-depth N`) on `logmind file-structure` and `logmind tree`. Agents reading the skill should know that `file-structure.md` is now truncated at depth 2 by default, and that `--max-depth 0` retrieves the full tree, since this affects how they interpret the file and what commands to use.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.0] - 2026-05-27
+
+### Changed — `docs/file-structure.md` ships at max-depth 2 by default
+
+Phase B.1 of the org-wide token-cost compression roadmap. The biggest
+single token sink in the org (logmind's own `docs/file-structure.md` at
+103 KB) drops to ~10 KB on next regen across every consuming repo.
+
+- `generate_file_structure(repo_root, max_depth=2)` is now the default. The depth-truncation code already existed in `_generate_fallback_tree`; v0.5.0 activates it via the public API.
+- `generate_tree(...)` accepts a new `max_depth: int | None = None` keyword. The system `tree(1)` path passes `-L max_depth+1`; the Python fallback recurses with the existing `_current_depth` check.
+- `write_file_structure(target, max_depth=...)` threads the cap through. `update_file_structure()` (called by `logmind init` + the post-merge auto-regen) picks up the default automatically.
+- New CLI flag on `logmind file-structure` and `logmind tree`: `--max-depth N` (default 2). `--max-depth 0` requests the full tree.
+- `file-structure.md` template footer notes the truncation and directs readers to `--max-depth 0` / `logmind tree --max-depth 0` for the full view.
+
+### Why this compounds
+
+Every clud-bug review on a PR that touches the tree ingests the
+file-structure.md diff. Every agent session that `cat`s the file pays
+the byte cost. Dropping from 103 KB → 10 KB in logmind alone, and
+similar reductions in 6 other consuming repos, compounds on every
+future read.
+
+### Tests
+
+- `tests/test_tree_gen.py` (+4 new): default depth=2 truncates deep trees; `max_depth=None` is unbounded; depth-2 default is strictly shorter than unbounded on a deep tree; `write_file_structure` honors the default.

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -66,7 +66,8 @@ command, and you do NOT need to run `logmind timeline --write` separately:
    `docs/decisions.md`; feature branch → `docs/decisions-branches/<branch>.md`).
 2. Archives the oldest decision if `decisions.md` exceeds `max_recent` (rotation).
 3. Regenerates `docs/file-structure.md` (default branch only — on feature
-   branches the tree snapshot diverges and would conflict).
+   branches the tree snapshot diverges and would conflict). **Since v0.5.0
+   the tree is capped at depth 2 by default** (see below).
 4. **Regenerates `docs/timeline.md` on every branch (v0.2.3+)** — the derived
    index that `check-derived-docs` CI verifies.
 5. **`git add` every change in the working tree (default since v0.2.7)** —
@@ -121,13 +122,46 @@ Before starting non-trivial work, read in order:
    recent).
 3. **`docs/decisions-branches/<your-branch>.md`** if present — decisions
    made earlier on the same feature branch.
-4. **`docs/file-structure.md`** — current project tree.
+4. **`docs/file-structure.md`** — current project tree. **Since v0.5.0
+   this file is generated at max depth 2 by default.** The footer notes
+   the truncation. If you need the full tree, run:
+   ```bash
+   logmind tree --max-depth 0
+   # or
+   logmind file-structure --max-depth 0
+   ```
 
 ```bash
 logmind show               # recent decisions on the current branch
 logmind show --all         # include archive
 logmind search "postgres"  # full-text across both files
 ```
+
+## `docs/file-structure.md` depth cap (v0.5.0+)
+
+`docs/file-structure.md` is now generated at **max depth 2** by default,
+reducing typical file sizes from ~100 KB to ~10 KB. This applies to:
+
+- `logmind log` auto-regen on the default branch.
+- `logmind init` and the post-merge hook auto-regen.
+- `logmind file-structure` and `logmind tree` CLI commands.
+
+To get the full unbounded tree explicitly:
+
+```bash
+logmind tree --max-depth 0
+logmind file-structure --max-depth 0
+```
+
+To generate at a custom depth:
+
+```bash
+logmind tree --max-depth 4
+```
+
+**Don't treat `docs/file-structure.md` as a complete directory listing
+for deep paths** — it stops at depth 2. Use `logmind tree --max-depth 0`
+or `find` / `ls` when you need to inspect deeply nested files.
 
 ## Verifying install health
 
@@ -217,6 +251,8 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.3.0**: `logmind init` registers a git merge driver for
   `timeline.md` / `file-structure.md` so parallel-PR merges no longer
   conflict on the derived files. Doctor gains three rows tracking it.
+- **v0.5.0**: `docs/file-structure.md` is generated at max depth 2 by
+  default. Use `--max-depth 0` for the full tree.
 
 ## Setup (one-time, per project)
 
@@ -245,6 +281,9 @@ logmind doctor             # confirm clean install
   log`** — it's already regenerated and staged. The standalone command is
   an escape hatch for unusual situations (a corrupted timeline, a tree
   someone touched outside logmind), not part of the normal flow.
+- **Don't rely on `docs/file-structure.md` for deep directory listings.**
+  Since v0.5.0 it is truncated at depth 2. Run `logmind tree --max-depth 0`
+  or use `find` when you need to see files nested deeper than two levels.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.0 shipped.

**CHANGELOG**: [`v0.5.0` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.0/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.0

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The v0.5.0 release introduces a user-visible default change (`max_depth=2` for `docs/file-structure.md` generation) and a new CLI flag (`--max-depth N`) on `logmind file-structure` and `logmind tree`. Agents reading the skill should know that `file-structure.md` is now truncated at depth 2 by default, and that `--max-depth 0` retrieves the full tree, since this affects how they interpret the file and what commands to use.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.