### PR TITLE
logmind v0.5.1 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.1.md
+++ b/.skill-update-todo/v0.5.1.md
@@ -1,0 +1,48 @@
+# logmind v0.5.1 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.1/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.1
+
+## Claude's reasoning
+
+The v0.5.1 release adds a user-visible `--quiet`/`-q` flag and `LOGMIND_QUIET=1` environment variable that agents can use to get token-frugal output from `logmind log`, `init`, `show`, `tree --write`, `file-structure --write`, and `timeline --write`. This is directly relevant to AI coding agents using logmind, as it changes how commands can be invoked and what output they produce. The `ok <key-value>` summary lines are always emitted (even without `--quiet`), which is also agent-facing behavior worth noting.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.1] - 2026-05-27
+
+### Added — `--quiet/-q` flag + `LOGMIND_QUIET=1` env var (Phase B.3)
+
+Mirrors clud-bug v0.6.7's RTK-style `ok <key-value>` pattern. Agent
+invocations of `logmind log` / `init` / `show` / `tree --write` /
+`file-structure --write` / `timeline --write` can now opt into a
+token-frugal mode that suppresses progress chatter and emits exactly
+one final `ok <key-value>` summary line.
+
+| Command | Quiet output (always emitted, even without --quiet) |
+|---|---|
+| `logmind log "..."` | `ok logged: <sha> "<decision[:60]>"` |
+| `logmind init` | `ok initialized: docs/ .logmind/ workflows @vX.Y.Z` |
+| `logmind show` | `ok show: docs/decisions.md (N bytes[ + archive])` |
+| `logmind tree` | `ok docs/file-structure.md (N bytes, depth=N/default)` |
+| `logmind file-structure` | `ok <path-or-stdout> (N bytes, depth=N/unbounded)` |
+| `logmind timeline` | `ok timeline: <path-or-stdout> (N bytes)` |
+
+### Activation
+
+Either pass `--quiet` / `-q` to the `logmind` group, or export
+`LOGMIND_QUIET=1` in the environment.
+
+### Behavior
+
+- `_ok(...)` ALWAYS emits, even without quiet (positive confirmation
+  for agents that parse stdout).
+- `click.echo` is monkey-patched at module load so all 185 existing
+  call sites become quiet-aware without per-call edits.
+- `click.secho(fg="red"/"yellow")` (warnings + errors) is UNTOUCHED —
+  quiet doesn't silence real problems.
+
+### Tests
+
+- `tests/test_cli.py` (+3 new): `--help` advertises the flag,
+  `show --quiet` on a fresh repo emits a single `ok` line,
+  `LOGMIND_QUIET=1` env var doesn't break `--help`.

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -104,6 +104,38 @@ Unrelated working-tree changes stay unstaged. Use when:
 Rare for automated agents — they should be working on one task at a
 time and want the single-commit shape.
 
+## Token-frugal quiet mode (v0.5.1+)
+
+Pass `--quiet` / `-q` to the `logmind` group, or set `LOGMIND_QUIET=1`,
+to suppress progress chatter and receive exactly one `ok <key-value>`
+summary line per command. Use this in automated / agent contexts to
+reduce token consumption:
+
+```bash
+logmind --quiet log "Use Redis for session cache" -r "Low-latency reads"
+# → ok logged: a1b2c3d "Use Redis for session cache"
+
+LOGMIND_QUIET=1 logmind init
+# → ok initialized: docs/ .logmind/ workflows @v0.5.1
+
+logmind -q show
+# → ok show: docs/decisions.md (4231 bytes)
+```
+
+The `ok` confirmation line is **always emitted** on stdout even without
+`--quiet` — agents that parse stdout can rely on it unconditionally.
+Errors and warnings (`fg="red"` / `fg="yellow"`) are never suppressed by
+quiet mode.
+
+| Command | `ok` summary line |
+|---|---|
+| `logmind log "..."` | `ok logged: <sha> "<decision[:60]>"` |
+| `logmind init` | `ok initialized: docs/ .logmind/ workflows @vX.Y.Z` |
+| `logmind show` | `ok show: docs/decisions.md (N bytes[ + archive])` |
+| `logmind tree` | `ok docs/file-structure.md (N bytes, depth=N/default)` |
+| `logmind file-structure` | `ok <path-or-stdout> (N bytes, depth=N/unbounded)` |
+| `logmind timeline` | `ok timeline: <path-or-stdout> (N bytes)` |
+
 ## Branch-aware routing (automatic)
 
 On a feature branch the entry lands in
@@ -217,6 +249,9 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.3.0**: `logmind init` registers a git merge driver for
   `timeline.md` / `file-structure.md` so parallel-PR merges no longer
   conflict on the derived files. Doctor gains three rows tracking it.
+- **v0.5.1**: `--quiet`/`-q` flag and `LOGMIND_QUIET=1` env var added;
+  all commands emit a parseable `ok <key-value>` line on stdout (always,
+  even without quiet).
 
 ## Setup (one-time, per project)
 


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.1 shipped.

**CHANGELOG**: [`v0.5.1` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.1/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.1

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The v0.5.1 release adds a user-visible `--quiet`/`-q` flag and `LOGMIND_QUIET=1` environment variable that agents can use to get token-frugal output from `logmind log`, `init`, `show`, `tree --write`, `file-structure --write`, and `timeline --write`. This is directly relevant to AI coding agents using logmind, as it changes how commands can be invoked and what output they produce. The `ok <key-value>` summary lines are always emitted (even without `--quiet`), which is also agent-facing behavior worth noting.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.