### PR TITLE
logmind v0.5.2 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.2.md
+++ b/.skill-update-todo/v0.5.2.md
@@ -1,0 +1,25 @@
+# logmind v0.5.2 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.2/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.2
+
+## Claude's reasoning
+
+The changelog adds three new flags to `logmind show`: `--brief`, `--limit N` / `-n N`, and `--json`. These are user-visible CLI additions that agents would use for context recall and structured output, and they should be documented in the "Reading prior context" section of SKILL.md alongside the existing `logmind show` examples.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.2] - 2026-05-28
+
+### Added — `logmind show --brief` / `--limit` / `--json` (Phase B.2)
+
+Agent-friendly views on the `show` command. Pure additive — existing
+`logmind show` and `logmind show --all` behavior unchanged.
+
+- `--brief`: one-line summary per decision (`YYYY-MM-DD HH:MM — title [source]`). Cheap recall for agents that need context but don't need full prose. Uses `iter_decisions` from `logmind.core.parser` (already exists).
+- `--limit N` / `-n N`: cap to N most-recent entries (newest-first). Matches the `logmind aggregate --limit` convention. Combinable with `--brief` and `--json`.
+- `--json`: stable structured output for downstream tools. Array of `{date: ISO8601, title: str, source: "main" | "archive"}`. Bypasses the `--quiet` patch so JSON is always emitted to stdout (it's primary output, not progress).
+- All three combine: `logmind show --brief --limit 5` for quick last-5 recall, `logmind show --json --limit 10 --all` for parsed access across main + archive.
+
+### Tests
+
+- `tests/test_cli.py` (+3): brief shape (newest-first), `--limit 2` caps correctly, `--json` produces a valid parseable array.

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -126,8 +126,27 @@ Before starting non-trivial work, read in order:
 ```bash
 logmind show               # recent decisions on the current branch
 logmind show --all         # include archive
+
+# Agent-friendly views (v0.5.2+)
+logmind show --brief               # one-line summary per decision: YYYY-MM-DD HH:MM — title [source]
+logmind show --limit 5             # cap to 5 most-recent entries (newest-first)
+logmind show --brief --limit 5     # quick last-5 recall (cheap context, no full prose)
+logmind show --json                # stable structured output: [{date, title, source}, ...]
+logmind show --json --limit 10 --all  # parsed access across main + archive
+
 logmind search "postgres"  # full-text across both files
 ```
+
+### `logmind show` flags at a glance (v0.5.2+)
+
+| Flag | Short | Effect |
+|------|-------|--------|
+| `--brief` | | One-line summary per decision (`YYYY-MM-DD HH:MM — title [source]`). Cheap recall; no full prose. |
+| `--limit N` | `-n N` | Cap output to N most-recent entries (newest-first). Combinable with `--brief` and `--json`. Matches `logmind aggregate --limit` convention. |
+| `--json` | | Emit a stable JSON array `[{date: ISO8601, title, source: "main"\|"archive"}, ...]` to stdout. Always emitted even under `--quiet`. |
+
+All three flags combine freely. Existing `logmind show` and `logmind show --all`
+behavior is unchanged.
 
 ## Verifying install health
 
@@ -217,6 +236,8 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.3.0**: `logmind init` registers a git merge driver for
   `timeline.md` / `file-structure.md` so parallel-PR merges no longer
   conflict on the derived files. Doctor gains three rows tracking it.
+- **v0.5.2**: `logmind show` gains `--brief`, `--limit N` / `-n N`, and
+  `--json` for agent-friendly context recall and structured output.
 
 ## Setup (one-time, per project)
 


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.2 shipped.

**CHANGELOG**: [`v0.5.2` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.2/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.2

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The changelog adds three new flags to `logmind show`: `--brief`, `--limit N` / `-n N`, and `--json`. These are user-visible CLI additions that agents would use for context recall and structured output, and they should be documented in the "Reading prior context" section of SKILL.md alongside the existing `logmind show` examples.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.