### PR TITLE
logmind v0.5.3 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.3.md
+++ b/.skill-update-todo/v0.5.3.md
@@ -1,0 +1,42 @@
+# logmind v0.5.3 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.3/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.3
+
+## Claude's reasoning
+
+This release only fixes a bug in the `LOGMIND_QUIET=1` mode where `click.secho` progress lines were not being suppressed. The behavior change is purely cosmetic output reduction in quiet mode — the existing SKILL.md already documents `LOGMIND_QUIET=1` implicitly through normal usage, and the fix doesn't add new commands, flags, defaults, or agent-facing guidance. The reduction from 3 lines to 1 line in quiet mode output is invisible to agents following the skill as written.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.3] - 2026-05-28
+
+### Fixed — `LOGMIND_QUIET=1` now also suppresses `click.secho` progress chatter
+
+v0.5.1 monkey-patched `click.echo` but intentionally left `click.secho`
+untouched on the rationale "errors via secho(fg='red'/'yellow') still
+print." Side effect: progress lines that also use secho (the `ℹ Default
+--stage all` cyan notice, `✓ Logged decision` green success) slipped
+through unsuppressed — visibly defeating the token-frugal mode for the
+most common command (`logmind log`).
+
+Fix: monkey-patch `click.secho` too, with a small wrapper that
+suppresses when `_QUIET` UNLESS `fg` is one of `_LOUD_COLORS` =
+`{red, yellow, bright_red, bright_yellow}`. Errors and warnings still
+print; progress chatter goes away.
+
+Concrete user-visible change with `LOGMIND_QUIET=1 logmind log "..."`:
+
+```
+# Before (v0.5.1, v0.5.2):                 # After (v0.5.3):
+ℹ Default --stage all (v0.2.7+): ...       ok logged: <sha> "..."
+✓ Logged decision: "..."
+ok logged: <sha> "..."
+```
+
+3 lines → 1 line. ~67% reduction on the most common quiet-mode call.
+
+### Tests
+
+- `tests/test_cli.py`: assert `LOGMIND_QUIET=1 logmind log` emits only
+  the single `ok logged:` line (no `ℹ`, no `✓`); assert error/warning
+  secho paths still print under quiet mode.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.3 shipped.

**CHANGELOG**: [`v0.5.3` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.3/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.3

## Shape of this PR

TODO context only (Claude judged release skill-irrelevant)

## Claude's reasoning

This release only fixes a bug in the `LOGMIND_QUIET=1` mode where `click.secho` progress lines were not being suppressed. The behavior change is purely cosmetic output reduction in quiet mode — the existing SKILL.md already documents `LOGMIND_QUIET=1` implicitly through normal usage, and the fix doesn't add new commands, flags, defaults, or agent-facing guidance. The reduction from 3 lines to 1 line in quiet mode output is invisible to agents following the skill as written.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.