### PR TITLE
logmind v0.5.4 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.4.md
+++ b/.skill-update-todo/v0.5.4.md
@@ -1,0 +1,50 @@
+# logmind v0.5.4 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.4/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.4
+
+## Claude's reasoning
+
+The changelog introduces a new default behavior for `docs/timeline.md` (brief format with elision) and a new `--full` flag for `logmind timeline`. This is user-visible: the on-disk timeline format changes by default, and agents reading `docs/timeline.md` will see the new compact format. The `--full` flag is new CLI behavior that agents should know about.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.4] - 2026-05-28
+
+### Added — `docs/timeline.md` ships brief format on disk (Phase 0.B.4)
+
+The on-disk timeline now defaults to a token-frugal brief layout: per
+month, render the newest + oldest decisions with an elision line
+between them, plus the month-total count in the header. Months with
+≤2 decisions render every entry (nothing to compress).
+
+Example (brief, default):
+
+```
+## 2026-05 (23 decisions)
+
+- **2026-05-28** — newest title *(main)* — [docs/decisions.md](docs/decisions.md)
+- *... 21 more decisions ...*
+- **2026-05-01** — oldest title *(feat/foo)* — [link](link)
+```
+
+Pass `--full` for the legacy per-decision listing:
+
+```bash
+logmind timeline --full                              # full to stdout
+logmind timeline --write docs/timeline.md --full     # full on disk
+```
+
+### Impact
+
+Every consuming repo's `docs/timeline.md` shrinks on next regen. For
+a repo with 5 months × 20 avg decisions, `docs/timeline.md` drops
+from ~100 lines to ~25 lines (~75% reduction). Source files
+(`decisions.md`, `decisions-branches/*.md`, `decisions-archive.md`)
+remain user-owned and untouched.
+
+### Tests
+
+- `tests/test_timeline.py`: brief default produces month header with
+  count; ≥3-entry months show first+elision+last; ≤2-entry months show
+  every entry; `--full` recovers legacy format; brief strictly shorter
+  than full on representative fixtures; rendering still deterministic.

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -116,7 +116,12 @@ appends a one-line summary linking the PR + the per-branch file to
 Before starting non-trivial work, read in order:
 
 1. **`docs/timeline.md`** — auto-generated chronological overview across
-   every branch; start here.
+   every branch; start here. Since v0.5.4 this file uses a **brief
+   format by default**: each month header shows the total decision count,
+   and only the newest + oldest entry per month are listed with an
+   elision line between them (months with ≤2 decisions show every
+   entry). This is intentional — the file is much smaller than before.
+   To see every decision in full, run `logmind timeline --full`.
 2. **`docs/decisions.md`** — direct-on-main decisions in detail (20 most
    recent).
 3. **`docs/decisions-branches/<your-branch>.md`** if present — decisions
@@ -127,7 +132,32 @@ Before starting non-trivial work, read in order:
 logmind show               # recent decisions on the current branch
 logmind show --all         # include archive
 logmind search "postgres"  # full-text across both files
+logmind timeline --full    # full per-decision listing to stdout (v0.5.4+)
+logmind timeline --write docs/timeline.md --full  # write full format on disk (v0.5.4+)
 ```
+
+## `docs/timeline.md` brief format (v0.5.4+, default)
+
+The on-disk timeline now defaults to a token-frugal brief layout. Example:
+
+```
+## 2026-05 (23 decisions)
+
+- **2026-05-28** — newest title *(main)* — [docs/decisions.md](docs/decisions.md)
+- *... 21 more decisions ...*
+- **2026-05-01** — oldest title *(feat/foo)* — [link](link)
+```
+
+Months with ≤2 decisions render every entry (nothing to compress). For
+the legacy per-decision listing pass `--full`:
+
+```bash
+logmind timeline --full                              # full to stdout
+logmind timeline --write docs/timeline.md --full     # full on disk
+```
+
+Source files (`decisions.md`, `decisions-branches/*.md`,
+`decisions-archive.md`) are user-owned and untouched by this change.
 
 ## Verifying install health
 
@@ -217,6 +247,9 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.3.0**: `logmind init` registers a git merge driver for
   `timeline.md` / `file-structure.md` so parallel-PR merges no longer
   conflict on the derived files. Doctor gains three rows tracking it.
+- **v0.5.4**: `docs/timeline.md` defaults to a brief format (newest +
+  oldest per month with elision). Pass `--full` for the legacy
+  per-decision listing.
 
 ## Setup (one-time, per project)
 
@@ -245,6 +278,10 @@ logmind doctor             # confirm clean install
   log`** — it's already regenerated and staged. The standalone command is
   an escape hatch for unusual situations (a corrupted timeline, a tree
   someone touched outside logmind), not part of the normal flow.
+- **Don't be surprised that `docs/timeline.md` only shows two entries
+  per month by default (v0.5.4+).** The brief format is intentional and
+  token-frugal. Use `logmind timeline --full` if you need the complete
+  listing.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.4 shipped.

**CHANGELOG**: [`v0.5.4` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.4/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.4

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The changelog introduces a new default behavior for `docs/timeline.md` (brief format with elision) and a new `--full` flag for `logmind timeline`. This is user-visible: the on-disk timeline format changes by default, and agents reading `docs/timeline.md` will see the new compact format. The `--full` flag is new CLI behavior that agents should know about.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.