### PR TITLE
feat(logmind skill): cover v0.5.0–v0.5.4 features (consolidates auto-PRs #39-#43)

### DIFF
--- a/docs/decisions-branches/feat__logmind-v0.5-skill-update.md
+++ b/docs/decisions-branches/feat__logmind-v0.5-skill-update.md
@@ -1,0 +1,5 @@
+## 2026-05-28 11:30 - logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief)
+
+**Reasoning:** Consolidated update of skills/logmind/SKILL.md to cover all Phase B logmind releases instead of merging 5 separate auto-PRs (#39-#43) that would conflict on SKILL.md edits. Added: (1) Reading-prior-context section notes timeline brief default (v0.5.4) + file-structure depth-2 default (v0.5.0). (2) Expanded show command examples with --brief, --limit, --json (v0.5.2). (3) New 'Agent-invocation mode: LOGMIND_QUIET=1' section covering --quiet flag, env var, ok summary, JSON stdout cleanliness contract, secho fix (v0.5.3). Will close auto-PRs #39-#43 with pointer to this consolidated PR.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
 - **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
 - **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)
 - **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -116,18 +116,55 @@ appends a one-line summary linking the PR + the per-branch file to
 Before starting non-trivial work, read in order:
 
 1. **`docs/timeline.md`** — auto-generated chronological overview across
-   every branch; start here.
+   every branch; start here. **Since v0.5.4 the on-disk format is
+   brief** (per month: header with decision count + first + last entry
+   + elision line). Use `logmind timeline --full` for the legacy
+   per-decision listing.
 2. **`docs/decisions.md`** — direct-on-main decisions in detail (20 most
    recent).
 3. **`docs/decisions-branches/<your-branch>.md`** if present — decisions
    made earlier on the same feature branch.
-4. **`docs/file-structure.md`** — current project tree.
+4. **`docs/file-structure.md`** — current project tree. **Since v0.5.0
+   the on-disk tree is capped at depth 2 by default.** For a deeper
+   view, run `logmind file-structure --max-depth N` (or
+   `logmind tree --max-depth 0` for fully unbounded).
 
 ```bash
-logmind show               # recent decisions on the current branch
-logmind show --all         # include archive
-logmind search "postgres"  # full-text across both files
+logmind show                       # recent decisions on the current branch
+logmind show --all                 # include archive
+
+# Agent-friendly views (v0.5.2+) — combinable.
+logmind show --brief               # one line per entry: "YYYY-MM-DD HH:MM — title [source]"
+logmind show --brief --limit 10    # last 10 in brief form
+logmind show --json --limit 20     # parseable JSON array
+logmind show --json --all          # JSON across main + archive sources
+
+logmind search "postgres"          # full-text across both files
 ```
+
+## Agent-invocation mode: `LOGMIND_QUIET=1` (v0.5.1+)
+
+When an agent (CI script, Claude Code session, downstream tool) runs
+logmind, the verbose progress chatter (`ℹ Default --stage all`,
+`✓ Logged decision`, sync messages) lands in the agent's context and
+burns tokens. Set `LOGMIND_QUIET=1` (or pass `--quiet` / `-q` on the
+group) to suppress progress and emit a single `ok <key-value>`
+summary line per command. Errors and warnings still print.
+
+```bash
+LOGMIND_QUIET=1 logmind log "..." -r "..."
+# → ok logged: <commit-sha> "<title>"
+
+LOGMIND_QUIET=1 logmind tree --write docs/file-structure.md
+# → ok file-structure: docs/file-structure.md (10240 bytes, depth=2)
+```
+
+`logmind show --json` always emits parseable JSON to stdout
+regardless of `--quiet` (JSON is primary output, not progress). The
+`ok` summary in JSON mode goes to stderr so pipelines like
+`logmind show --json | jq` stay clean. Internally v0.5.3 patched
+`click.secho` so red/yellow error/warning output still prints under
+`LOGMIND_QUIET=1` — only progress chatter (cyan/green) is suppressed.
 
 ## Verifying install health
 


### PR DESCRIPTION
## Summary

Consolidates the 5 auto-generated update PRs (#39 v0.5.0, #40 v0.5.1, #41 v0.5.2, #42 v0.5.3, #43 v0.5.4) into one edit. Auto-PRs all touch the same file (`skills/logmind/SKILL.md`) and would conflict on merge.

Changes:
1. **Reading-prior-context** section: notes `timeline.md` is brief by default (v0.5.4) + `file-structure.md` is depth-2 by default (v0.5.0). Mentions `--full` / `--max-depth N` for opt-out.
2. **`logmind show` examples** expanded to cover `--brief`, `--limit`, `--json` (v0.5.2) — combinable.
3. **New section: Agent-invocation mode `LOGMIND_QUIET=1`** (v0.5.1+) — explains `--quiet`/`-q`/env var, `ok <key-value>` summary contract, JSON-stdout cleanliness invariant, and the v0.5.3 secho patch (red/yellow loud-colors still print).

## Test plan

- [x] SKILL.md still under any size cap consumers enforce (289 lines, well under 500).
- [x] All v0.5.x feature flags + behaviors documented as users would invoke them from a fresh agent session.
- [ ] After merge: close auto-PRs #39–#43 pointing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)