### PR TITLE
feat(clud-bug-collab skill): cover v0.6.3–v0.6.11 cost-control wiring + new comment format

### DIFF
--- a/docs/decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md
+++ b/docs/decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md
@@ -1,0 +1,5 @@
+## 2026-05-28 11:36 - clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format
+
+**Reasoning:** Plan companion section called for updating clud-bug-collaboration skill with: (1) severity-prefix + <details> comment format from v0.6.5, (2) stats-header pattern + zero-findings case, (3) CLUD_BUG_QUIET=1 env var from v0.6.7. Expanded scope to also document the cost-control wiring agents may wonder about: prompt caching (v0.6.3), per-section byte budgets (v0.6.4), max-turns + MAX_THINKING_TOKENS (v0.6.8), Sonnet 4.6 model pin (v0.6.11), incremental-diff on fix-push + last-reviewed-sha marker (v0.6.10). Three new sections inserted before 'Updating clud-bug itself': Reading review comments, Agent-invocation mode, Why reviews are cheap. SKILL.md went from 126 lines to ~190 lines — still well within reasonable size.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -38,7 +38,9 @@ agent-skills
 │   │   ├── chore__dependabot.md
 │   │   ├── chore__migrate-to-thrillmade.md
 │   │   ├── chore__regen-derived-docs.md
+│   │   ├── chore__regen-fs-post-pr37.md
 │   │   ├── docs__logmind-v0.3.0.md
+│   │   ├── feat__logmind-v0.5-skill-update.md
 │   │   ├── feat__notify-clud-bug-push-trigger.md
 │   │   ├── feat__skill-review-mode.md
 │   │   └── fix__notify-clud-bug-pipefail-grep.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)
 - **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
 - **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
 - **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)

--- a/skills/clud-bug-collaboration/SKILL.md
+++ b/skills/clud-bug-collaboration/SKILL.md
@@ -102,6 +102,91 @@ explaining how to set it. (For bot/fork PRs where the secret legitimately
 isn't passed, the guard posts a one-line advisory comment and exits 0
 instead of failing red.)
 
+## Reading review comments (v0.6.5+ format)
+
+Since v0.6.5, every Clud Bug summary comment leads with a stats line for
+fast triage:
+
+```
+Found: N 🔴 / N 🟡 / N 🟣
+```
+
+Three severity tiers, applied per finding via emoji prefix:
+
+- **🔴 important** — bug, security, performance, missing test coverage. In
+  strict-mode repos these fail the check.
+- **🟡 nit** — style, naming, micro-optimization. Advisory.
+- **🟣 pre-existing** — issue that pre-dates this PR. Don't fix here unless
+  the user asks; flag for a follow-up issue.
+
+Each finding follows this shape:
+
+```
+🔴 [skill-name]: One-line claim anchored to file:line.
+<details><summary>Reasoning</summary>
+
+Longer explanation with quoted evidence.
+
+</details>
+```
+
+Re-reads (other agents picking up the PR) can skip the collapsed `Reasoning`
+block when they trust the headline; expand only when chasing a finding.
+GitHub renders the `<details>` natively for human readers. **If a review
+emits zero findings**, the entire comment is just the `Found: 0 🔴 / 0 🟡 / 0 🟣`
+stats line plus the standard summary header — no per-finding bullets.
+
+## Agent-invocation mode: `CLUD_BUG_QUIET=1` (v0.6.7+)
+
+When invoking the `clud-bug` CLI from an agent session (vs interactively),
+set `CLUD_BUG_QUIET=1` or pass `--quiet` / `-q` to suppress multi-line
+progress chatter. Each command emits a single `ok <key-value>` summary line
+so the agent's context stays lean. Errors still print on stderr.
+
+```bash
+CLUD_BUG_QUIET=1 clud-bug update
+# → ok updated: @v0.6.11, N changed, M unchanged
+
+CLUD_BUG_QUIET=1 clud-bug init
+# → ok initialized: .claude/skills/ N specimens, workflow @v0.6.11
+
+CLUD_BUG_QUIET=1 clud-bug add evidence-based-review
+# → ok added: .claude/skills/evidence-based-review/SKILL.md
+```
+
+## Why reviews are cheap (cost-control wiring, v0.6.3–v0.6.11)
+
+The bot is engineered for token frugality, several layers deep:
+
+- **Prompt caching** (v0.6.3): the stable review-prompt + skill catalog +
+  AGENTS.md from base ref land in the Claude Code CLI's auto-cached system
+  layer. Cached input is billed at 10% of standard input within a 5-minute
+  window. The first review in a fresh window writes the cache (1.25×); the
+  next ones in that window read at 10%. Visible via `cache_read_input_tokens`
+  in the run's result JSON (`show_full_output: true`).
+- **Per-section byte budgets** (v0.6.4): `MAX_DIFF_BYTES=80000`,
+  `MAX_COMMENT_BYTES=20000`, `MAX_SKILL_BYTES=4000`. Caps the PR diff /
+  prior-comment / skill-content section that the bot ingests on each run.
+  When a section hits its cap, an explicit truncation marker appears and
+  the bot is instructed to request the omitted hunks if relevant.
+- **`MAX_THINKING_TOKENS=8000`** + **`--max-turns 15`** (v0.6.8): thinking
+  budget + agentic-loop ceiling. Stops runaway turn-storms.
+- **Model pin** (v0.6.11): clud-bug-review now runs on
+  `claude-sonnet-4-6`, not Opus. Per Anthropic docs: "Sonnet handles most
+  coding tasks well and costs less than Opus." ~80% per-token reduction vs
+  Opus 4.7 default.
+- **Incremental-diff on fix-push** (v0.6.10): on a re-review, the bot reads
+  only the delta since its prior pass (`git diff <prior_sha>..HEAD`),
+  identified via a `<!-- last-reviewed-sha: <sha> -->` HTML marker in the
+  prior summary comment. Force-push or rebase invalidates the ancestry
+  check and falls back to full `gh pr diff`. ~67% fewer bytes ingested
+  across a fix-push-heavy PR's lifetime.
+
+You don't need to invoke any of this — it's wired into every clud-bug
+template. Override per-repo (e.g., `MAX_DIFF_BYTES=999999`) by setting the
+env var in your consuming repo's `clud-bug-review.yml`, which is visible in
+PRs and clud-bug-reviewable.
+
 ## Updating clud-bug itself
 
 `clud-bug-self-update.yml` runs weekly (Mondays 12:00 UTC) and opens a PR


### PR DESCRIPTION
## Summary

Per plan companion-skills section. Updates `skills/clud-bug-collaboration/SKILL.md` to cover the Phase A cost-control story so agents working in a clud-bug-installed repo can read clud-bug review comments fluently and understand why reviews are cheap.

Three new sections inserted before the "Updating clud-bug itself" section:

1. **Reading review comments (v0.6.5+ format)** — stats header (`Found: N 🔴 / N 🟡 / N 🟣`), severity tiers (🔴 important / 🟡 nit / 🟣 pre-existing), per-finding `<details><summary>Reasoning</summary>` collapsibles, zero-findings case.
2. **Agent-invocation mode: `CLUD_BUG_QUIET=1`** (v0.6.7+) — single `ok <key-value>` summary per command; common examples.
3. **Why reviews are cheap** — prompt caching (v0.6.3), per-section budgets (v0.6.4), max-turns + MAX_THINKING_TOKENS (v0.6.8), Sonnet 4.6 pin (v0.6.11), incremental-diff on fix-push + `last-reviewed-sha` marker (v0.6.10).

## Test plan

- [x] SKILL.md still readable (210 lines, well under any practical cap).
- [x] All v0.6.3–v0.6.11 user-visible behaviors documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)