### PR TITLE
feat(skill): new token-frugal-tooling meta-skill (quick-reference for repos using both logmind + clud-bug)

### DIFF
--- a/docs/decisions-branches/feat__token-frugal-tooling-skill.md
+++ b/docs/decisions-branches/feat__token-frugal-tooling-skill.md
@@ -1,0 +1,5 @@
+## 2026-05-28 11:38 - new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference)
+
+**Reasoning:** Plan companion section called for a NEW meta-skill linking the two updated skills (logmind + clud-bug-collaboration). 108-line quick reference covering: agent-mode env vars (LOGMIND_QUIET, CLUD_BUG_QUIET) with command examples + table; on-disk artifact defaults (file-structure depth-2, timeline brief); reading clud-bug review comments (severity tiers + Reasoning collapsibles); show --brief/--limit/--json (JSON-stdout-clean contract); what-you-don't-need-to-do section listing the 4 cost-control layers that just-work (budgets, caching, model pin, incremental-diff); pointer to per-tool skills for detail. Targets repos with BOTH logmind + clud-bug installed — detection via .logmind/config.yml + .github/workflows/clud-bug-review.yml.
+
+---

--- a/docs/decisions-branches/feat__token-frugal-tooling-skill.md
+++ b/docs/decisions-branches/feat__token-frugal-tooling-skill.md
@@ -3,3 +3,8 @@
 **Reasoning:** Plan companion section called for a NEW meta-skill linking the two updated skills (logmind + clud-bug-collaboration). 108-line quick reference covering: agent-mode env vars (LOGMIND_QUIET, CLUD_BUG_QUIET) with command examples + table; on-disk artifact defaults (file-structure depth-2, timeline brief); reading clud-bug review comments (severity tiers + Reasoning collapsibles); show --brief/--limit/--json (JSON-stdout-clean contract); what-you-don't-need-to-do section listing the 4 cost-control layers that just-work (budgets, caching, model pin, incremental-diff); pointer to per-tool skills for detail. Targets repos with BOTH logmind + clud-bug installed — detection via .logmind/config.yml + .github/workflows/clud-bug-review.yml.
 
 ---
+## 2026-05-28 12:50 - PR #46: regen derived docs after merge with main
+
+**Reasoning:** check-derived-docs failed on the merge-commit because docs/file-structure.md + docs/timeline.md were stale relative to the new combined branch state (after merging main with #45 into the branch). Regenerated both via logmind. Cosmetic CI fix only — no source-code change.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -40,9 +40,11 @@ agent-skills
 │   │   ├── chore__regen-derived-docs.md
 │   │   ├── chore__regen-fs-post-pr37.md
 │   │   ├── docs__logmind-v0.3.0.md
+│   │   ├── feat__clud-bug-collab-v0.6-skill-update.md
 │   │   ├── feat__logmind-v0.5-skill-update.md
 │   │   ├── feat__notify-clud-bug-push-trigger.md
 │   │   ├── feat__skill-review-mode.md
+│   │   ├── feat__token-frugal-tooling-skill.md
 │   │   └── fix__notify-clud-bug-pipefail-grep.md
 │   ├── decisions-archive.md
 │   ├── decisions.md
@@ -67,7 +69,9 @@ agent-skills
 │   │   └── SKILL.md
 │   ├── skill-frontmatter-quality
 │   │   └── SKILL.md
-│   └── test-discipline
+│   ├── test-discipline
+│   │   └── SKILL.md
+│   └── token-frugal-tooling
 │       └── SKILL.md
 ├── .cursorrules
 ├── .gitattributes

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
 - **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
 - **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
 - **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,7 +15,9 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
 - **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
+- **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)
 - **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
 - **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
 - **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)

--- a/skills/token-frugal-tooling/SKILL.md
+++ b/skills/token-frugal-tooling/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: token-frugal-tooling
+description: |
+  Use in any project that has BOTH logmind (`.logmind/config.yml` or
+  `docs/decisions.md`) AND clud-bug (`.github/workflows/clud-bug-review.yml`)
+  installed. Quick-reference for the org's token-frugal conventions: env vars,
+  artifact defaults, and the "agent mode" flags both CLIs accept. Detail lives
+  in the per-tool skills — load `logmind` and `clud-bug-collaboration`
+  alongside this one when you actually need to invoke them.
+review_mode: shared
+---
+
+# Token-frugal tooling — quick reference
+
+This project uses logmind + clud-bug, both engineered for token frugality.
+The defaults below land automatically; this skill is just so you don't
+re-learn them every session.
+
+## Agent-mode env vars (set once per command or session)
+
+| Var | Tool | Effect |
+|---|---|---|
+| `LOGMIND_QUIET=1` | logmind ≥ v0.5.1 | Suppresses progress chatter; emits one `ok <key-value>` line per command. v0.5.3 patched `click.secho` so error/warning output (red/yellow) still prints. `--quiet` / `-q` on the group is equivalent. |
+| `CLUD_BUG_QUIET=1` | clud-bug ≥ v0.6.7 | Same pattern for clud-bug CLI (`init` / `update` / `add` / `refresh` / `edit-workflow` / `review-mode`). `--quiet` / `-q` is equivalent. |
+
+Prefer these for agent invocations even when chaining commands — every
+command emits a single parseable line, so the next step can grep/parse
+without re-running.
+
+```bash
+LOGMIND_QUIET=1 logmind log "..." -r "..." --no-push
+# → ok logged: <sha> "<title>"
+
+CLUD_BUG_QUIET=1 clud-bug update
+# → ok updated: @v0.6.11, N changed, M unchanged
+```
+
+## On-disk artifacts default to brief
+
+When you read these files, expect compact format — the legacy verbose
+view is opt-in. Both apply org-wide on next regen after a logmind upgrade.
+
+| File | Default since | Shape |
+|---|---|---|
+| `docs/file-structure.md` | logmind v0.5.0 | Tree capped at **depth 2**. Override per-invocation: `logmind file-structure --max-depth N` or `logmind tree --max-depth 0` for unbounded. |
+| `docs/timeline.md` | logmind v0.5.4 | Per month: header with `(N decisions)`, newest entry + `... N-2 more decisions ...` elision + oldest entry. ≤2-entry months show all entries. `logmind timeline --full` recovers the legacy per-decision listing. |
+
+## Reading clud-bug review comments (v0.6.5+)
+
+Every Clud Bug summary comment leads with `Found: N 🔴 / N 🟡 / N 🟣` —
+read this line first to triage.
+
+- 🔴 important — bug / security / performance / missing test coverage
+- 🟡 nit — style / naming / micro-optimization (advisory)
+- 🟣 pre-existing — issue that pre-dates this PR; don't fix here unless asked
+
+Per-finding shape:
+
+```
+🔴 [skill-name]: One-line claim anchored to file:line.
+<details><summary>Reasoning</summary>
+
+…
+
+</details>
+```
+
+On a re-read, you can usually trust the headline and skip the collapsed
+`Reasoning`. Expand only when the headline is ambiguous or you want the
+evidence trail.
+
+## Show + search are agent-friendly (v0.5.2+)
+
+`logmind show` carries three combinable flags for fast scans:
+
+```bash
+logmind show --brief --limit 10      # last 10 in one-line form
+logmind show --json --limit 20       # parseable JSON
+logmind show --json --all            # JSON across main + archive
+```
+
+`--json` stdout stays pipeline-clean regardless of `--quiet` — the `ok`
+summary line goes to stderr in JSON mode so `logmind show --json | jq`
+works without extra plumbing.
+
+## What you don't need to do
+
+- **Don't override clud-bug budgets** (`MAX_DIFF_BYTES`, etc.) unless
+  you have a documented reason. Defaults cover 95%+ of real PRs.
+- **Don't worry about caching** — clud-bug v0.6.3+ writes its stable
+  prefix into the Claude Code CLI's auto-cached system layer. Cached
+  input is billed at 10% of standard. Visible via
+  `cache_read_input_tokens` in the run JSON.
+- **Don't worry about the model** — pinned to `claude-sonnet-4-6`
+  (v0.6.11). PR review fits Sonnet's profile; Opus would be ~5× the
+  cost per the Anthropic pricing table.
+- **Don't worry about fix-push diff cost** — clud-bug v0.6.10 reads
+  only the delta since its prior review (handshake via
+  `<!-- last-reviewed-sha: <sha> -->` marker in the prior summary
+  comment).
+
+## Where to look for detail
+
+- **`logmind` skill** — when / how to log decisions; reading prior
+  context; agent-invocation flags.
+- **`clud-bug-collaboration` skill** — fix-push flow, strict mode,
+  modifying skills, editing the workflow, full comment format, full
+  cost-control wiring.


### PR DESCRIPTION
## Summary

Per plan companion-skills section. Creates a new ~108-line meta-skill at `skills/token-frugal-tooling/SKILL.md` that auto-loads when a repo has BOTH logmind + clud-bug installed and surfaces the org's token-frugal conventions as a quick-reference.

Detection criteria (in the description frontmatter):
- `.logmind/config.yml` or `docs/decisions.md` present (logmind)
- AND `.github/workflows/clud-bug-review.yml` present (clud-bug)

Content:
- Agent-mode env vars table (`LOGMIND_QUIET`, `CLUD_BUG_QUIET`) with command examples
- On-disk artifact defaults (`file-structure.md` depth-2, `timeline.md` brief) + override flags
- Reading clud-bug review comments (severity tiers, `<details>` Reasoning collapsibles)
- `logmind show --brief/--limit/--json` examples (JSON-stdout-clean contract)
- "What you don't need to do" section listing the 4 cost-control layers that just-work (budgets, caching, model pin, incremental-diff handshake)
- Pointer to `logmind` and `clud-bug-collaboration` skills for detail

Independent of PR #45 (clud-bug-collab update). Could ship either order.

## Test plan

- [x] SKILL.md frontmatter follows existing skill convention (`name`, `description`, `review_mode: shared`).
- [x] `validate skills` CI job should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)