### PR TITLE
chore: clud-bug self-update v0.5.16 → v0.6.12 (Phase A wins propagated)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -23,8 +23,10 @@
       "description": "(baseline)"
     }
   ],
-  "excludedBaselines": ["clud-bug-collaboration"],
-  "lastUpdateVersion": "0.5.16",
-  "lastUpdate": "2026-05-27T01:44:59.280Z",
+  "excludedBaselines": [
+    "clud-bug-collaboration"
+  ],
+  "lastUpdateVersion": "0.6.12",
+  "lastUpdate": "2026-05-28T17:14:23.138Z",
   "strictMode": true
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -3,46 +3,21 @@ See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.
 
 <!-- clud-bug-start -->
-<!-- clud-bug-block-version: v1 -->
+<!-- clud-bug-block-version: v2 -->
 ## clud-bug — Claude PR review
 
-This repository uses [clud-bug](https://cludbug.dev) to review pull requests
-automatically. Three things matter when other agents (or future-you) work
-in this repo:
+This repo uses [clud-bug](https://cludbug.dev) for automatic PR reviews.
+Full collaboration rules — fix-push flow, skill structure, comment format,
+strict-mode mechanics, workflow-edit constraint — live in the bundled
+[`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md).
+Read that skill before pushing fixes addressing prior review threads.
 
-### When you push fixes addressing prior Clud Bug review threads
+Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle via `.claude/skills/.clud-bug.json`
+(read from PR **base ref**, so PRs can't disable strict-mode on themselves).
 
-The bot resolves its own prior review threads on the next pass when it can
-verify the fix in the diff. You don't need to manually resolve threads it
-opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
-left isn't auto-resolved after a fix, the bot judged the issue still open;
-read its latest review comment for what it's still flagging.
+For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
+(or pass `--quiet`) — suppresses progress chatter and emits a single
+`ok <key-value>` summary line per command.
 
-### Strict mode
-
-Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle by editing `.claude/skills/.clud-bug.json`:
-
-```json
-{ "strictMode": true | false, ... }
-```
-
-The setting is read from the **base ref** of any open PR, so PRs cannot
-disable strict mode on themselves. Changes take effect on PRs opened after
-they merge to the base branch.
-
-### Where the skills live
-
-Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
-small baseline kit ships with every install — see
-`.claude/skills/.clud-bug.json` for the current set. Add more via
-`clud-bug add <source/name>` (from skills.sh) or by dropping your own
-`.md` files there. They auto-load into the reviewer.
-
-### Editing the workflow
-
-Anthropic's `claude-code-action` refuses to run on PRs that modify its own
-workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
-their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
-
-_Installed at clud-bug v0.5.16._
+_Installed at clud-bug v0.6.12._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-audit.yml
+++ b/.github/workflows/clud-bug-audit.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0   # full history needed for git --since
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -80,12 +80,38 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md)"
-          prompt: |
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          # HEAD_SHA (v0.6.10+) — emitted as `<!-- last-reviewed-sha: ... -->`
+          # marker at the end of every summary comment. The next review pass
+          # reads the marker and switches `gh pr diff` (full) → `git diff
+          # <prior_sha>..HEAD` (delta) when the SHA is still in HEAD's
+          # ancestry. Fix-push reviews ingest only the new bytes.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Per-section byte budgets (v0.6.4). The system-prompt instructs
+          # Claude to cap each per-PR input fetch with `head -c`. Caching
+          # covers the stable system prefix; capping covers the variable
+          # suffix (diff, comments, skills). Override per-repo by setting
+          # these env vars in the consuming workflow if defaults don't fit.
+          MAX_DIFF_BYTES: '80000'
+          MAX_COMMENT_BYTES: '20000'
+          MAX_SKILL_BYTES: '4000'
+          # MAX_THINKING_TOKENS caps Claude Code's extended-thinking budget per
+          # turn. Anthropic docs (v0.6.8): "For simpler tasks where deep reasoning
+          # isn't needed, you can reduce costs by lowering MAX_THINKING_TOKENS=8000."
+          # PR review needs some reasoning but not unbounded; default budget is
+          # tens of thousands of tokens. 8000 is the Anthropic-recommended cap
+          # for review-shaped tasks.
+          MAX_THINKING_TOKENS: '8000'
+          # APPEND_SYSTEM_PROMPT lands inside the Claude Code CLI's auto-cached
+          # system layer (system prompt, tools, conversation history). Anthropic
+          # bills cached input tokens at 10% of standard input — within a 5-min
+          # window, the 2nd+ PR review in any consuming repo hits cache.
+          # See: src/entrypoints/run.ts in claude-code-action — `appendSystemPrompt:
+          # process.env.APPEND_SYSTEM_PROMPT` reads this var, threads it into the
+          # SDK's `systemPrompt.append`. Crucial: keep this content byte-stable
+          # across runs (no PR numbers, timestamps, SHAs) or the cache invalidates.
+          APPEND_SYSTEM_PROMPT: |
             A collection of [skills.sh](https://www.skills.sh)-compatible agent skills published by [thrillmot](https://thrillmot.com).
 
             Review this pull request for critical issues only. Focus on:
@@ -93,10 +119,75 @@ jobs:
             - Security vulnerabilities
             - Performance problems
             - Broken or missing test coverage for new code
-            
+
 
             Skip style suggestions, minor naming issues, or anything that
             doesn't affect correctness, security, or performance.
+
+            Section budgets (token-frugal review — v0.6.4+):
+            The workflow sets env vars MAX_DIFF_BYTES / MAX_COMMENT_BYTES /
+            MAX_SKILL_BYTES. When fetching content via the Bash tool, cap each
+            section with `head -c` to keep your context lean. Caching covers
+            the stable system-prompt prefix (you're reading it now) at 10% of
+            standard input cost, but variable per-PR content is NOT cached, so
+            size discipline on those fetches pays back directly.
+
+              - PR diff (incremental on fix-push — v0.6.10+):
+                On a re-review (not first pass), fetch only the delta between
+                your prior pass and HEAD instead of the full PR. The handshake
+                state lives in your PRIOR SUMMARY COMMENT as an HTML marker:
+                `<!-- last-reviewed-sha: <sha> -->`.
+
+                CRITICAL — identifying the PRIOR SUMMARY (not the progress comment):
+                `anthropics/claude-code-action` posts an in-progress
+                `[claude]: Claude Code is working…` comment BEFORE this prompt
+                runs. That comment IS authored by claude[bot] but is NOT your
+                prior summary — it has no marker. Walking "the LAST claude[bot]
+                comment" would always land on the progress comment and the
+                handshake would never fire. Instead, identify the prior summary
+                by its HEADER LINE: it begins with `## 🐛 Clud Bug review`
+                (same anchor the strict-mode gate uses for classification).
+
+                Detection in three steps:
+
+                  1. Fetch claude[bot] comments newest-first:
+                     `gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=100&sort=created&direction=desc"`
+                     Walk them in order; find the FIRST whose body starts
+                     (after any `**Claude finished …**` preamble the action
+                     prepends) with `## 🐛 Clud Bug review`. THAT is your prior
+                     summary. In its body, look for `last-reviewed-sha: <sha>`.
+
+                  2. If a SHA was found, verify it's still in HEAD's ancestry:
+                     `git merge-base --is-ancestor <prior_sha> $HEAD_SHA`
+                     (exit 0 = yes, ancestry intact; non-zero = rebased/force-pushed).
+
+                  3. Branch:
+                       - Marker present AND ancestor intact (well-behaved fix-push):
+                         `git diff <prior_sha>..$HEAD_SHA | head -c "$MAX_DIFF_BYTES"`
+                       - Marker missing OR not an ancestor (first review or rebase):
+                         `gh pr diff "$PR_NUMBER" | head -c "$MAX_DIFF_BYTES"`
+
+                Default cap is 80,000 bytes — covers ~95% of real PRs unbruised.
+                If output looks truncated mid-line, request the omitted hunks via
+                `gh pr diff "$PR_NUMBER" --name-only` + a targeted re-fetch.
+
+                Edge case — span check: if a delta-review surfaces a finding that
+                might affect unchanged code outside the delta (a fix-push edits a
+                function whose callers were fine in the prior pass), do a one-time
+                `gh pr diff "$PR_NUMBER"` to confirm before flagging. The
+                incremental view is for fast re-confirmation, not for blind trust.
+
+              - Skill files: `head -c "$MAX_SKILL_BYTES" .claude/skills/<name>/SKILL.md`
+                per file (default 4,000 bytes). Baseline skills fit easily;
+                bloated user-added skills get truncated.
+
+              - PR comments: `gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/comments?per_page=20" --jq '.[] | select(.user.login != "claude[bot]")' | head -c "$MAX_COMMENT_BYTES"`
+                (default 20,000 bytes, 20 most-recent). Skips your own prior
+                comments — the FIX-PUSH FLOW handles those via reviewThreads
+                GraphQL instead.
+
+            If you genuinely cannot review safely without the elided content,
+            say so plainly in the summary comment instead of speculating.
 
             Skills are not background context — they are review rules with
             authority. Before flagging any finding, scan the loaded skills in
@@ -119,13 +210,27 @@ jobs:
 
             Before writing the review, scan each loaded skill's frontmatter
             (the first `---`-delimited block of its SKILL.md) to identify
-            its review_mode. You can read them with:
-              cat .claude/skills/*/SKILL.md
+            its review_mode. Read each one capped at MAX_SKILL_BYTES:
+              head -c "$MAX_SKILL_BYTES" .claude/skills/*/SKILL.md
 
             At the end of every review, append a single-line footer:
               Skills referenced: [skill-name-1, skill-name-2, ...]
             If you genuinely cited none, list "[none]" and explain why no
             installed skill applied to this diff.
+
+            Incremental-diff handshake (v0.6.10+) — emit the SHA marker:
+            At the very end of the summary comment (after the Skills-referenced
+            footer, on its own line), append the HTML marker that the next
+            review pass will read to decide between full-diff vs incremental:
+
+              <!-- last-reviewed-sha: $HEAD_SHA -->
+
+            (`$HEAD_SHA` is provided via the workflow env block; literal value
+            goes in the comment, not the variable name.) The marker is silent
+            to human readers (HTML comment) but load-bearing for cost: every
+            subsequent fix-push review re-fetches only the delta since this
+            SHA instead of the full PR. If you omit the marker, the next
+            review falls back to a full `gh pr diff` — correct but wasteful.
 
             Strict-mode header (opt-in): if .claude/skills/.clud-bug.json
             contains { "strictMode": true }, the comment header you post
@@ -227,6 +332,42 @@ jobs:
             open" are both 0. On follow-up reviews after a fix-push,
             "resolved from prior" should typically be positive.
 
+            Stats header (required, immediately under **This round:**):
+            Lead with ONE single-line stats header that uses severity emoji
+            so agents re-reading this comment on a future review pass can
+            triage at a glance (and skip parsing the body on the common
+            zero-findings case). Three tiers:
+
+              🔴 important — bugs / security / perf / missing test coverage
+              🟡 nit       — minor suggestions, style nits, observations
+              🟣 pre-existing — issues that pre-date this PR (not its author's
+                                fault, but worth surfacing for awareness)
+
+            Emit exactly this shape on the line immediately after **This round:**:
+
+              Found: N 🔴 / N 🟡 / N 🟣
+
+            When all three are 0 the entire substantive body is optional —
+            agents reading this header on a future re-review can stop here.
+
+            Per-finding format (severity emoji + collapsible reasoning):
+            Each finding in critical/minor/per-skill sections uses this
+            write-time-compressed format. The summary line is the load-bearing
+            claim; the long-form reasoning lives in a `<details>` block that
+            humans expand inline (GitHub renders it natively) but future agent
+            re-reads can skip token-cheaply.
+
+              🔴 [skill-name]: One-line claim (file:line).
+              <details><summary>Reasoning</summary>
+
+              Longer explanation: evidence anchors, suggested fix, edge cases.
+
+              </details>
+
+            Use 🔴 for important findings (the ones strict-mode gates on),
+            🟡 for nits, 🟣 for pre-existing issues. The severity emoji
+            makes the finding's tier scannable without parsing prose.
+
             Per-skill scan block (required, immediately under the status line):
             After the **This round:** counters, emit a "### Per-skill scan"
             section with ONE line per loaded skill — even silent ones. This
@@ -300,6 +441,22 @@ jobs:
             comment with the H2 header and "**This round:** 0 critical · …"
             status line — strict mode + the status counters need the
             comment to exist for every review pass.
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          # show_full_output: exposes cache_read_input_tokens /
+          # cache_creation_input_tokens in the run's result JSON so we can
+          # measure caching effectiveness post-rollout (per v0.6.3 plan).
+          show_full_output: true
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 15
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
+          prompt: |
+            Review this pull request following the discipline in your
+            system prompt — every rule about skill routing, comment
+            format, the strict-mode header, the two-surface review
+            shape, and the FIX-PUSH FLOW applies.
 
       # Strict-mode gate. Fails the check when the BASE ref's manifest
       # has { "strictMode": true } AND the latest clud-bug review's first
@@ -316,6 +473,6 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.5.16
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clud-bug-self-update.yml
+++ b/.github/workflows/clud-bug-self-update.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -83,8 +83,13 @@ jobs:
           git add -A
           git commit -m "🐛 Clud Bug self-update: ${INSTALLED} → ${LATEST}"
           git push -u origin "$BRANCH"
+          # Build the PR body via printf so the embedded newlines don't break
+          # the YAML `run: |` literal-block parser. v0.6.11 and earlier put a
+          # blank line directly inside the --body string; some YAML parsers
+          # (GitHub Actions among them) ended the block scalar at that blank
+          # line and rejected the next line as an unexpected top-level value,
+          # which broke `workflow_dispatch` on every consuming repo.
+          BODY=$(printf 'Automated update from clud-bug %s → %s. Custom and skills.sh-installed specimens were left alone; only baseline specimens and the workflow templates were refreshed.\n\nReview the diff. To stay on this version permanently, add `"pinVersion": "%s"` to `.claude/skills/.clud-bug.json` before merging.' "${INSTALLED}" "${LATEST}" "${INSTALLED}")
           gh pr create \
             --title "🐛 Clud Bug self-update: ${INSTALLED} → ${LATEST}" \
-            --body "Automated update from clud-bug ${INSTALLED} → ${LATEST}. Custom and skills.sh-installed specimens were left alone; only baseline specimens and the workflow templates were refreshed.
-
-Review the diff. To stay on this version permanently, add \`\"pinVersion\": \"${INSTALLED}\"\` to \`.claude/skills/.clud-bug.json\` before merging."
+            --body "$BODY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,46 +64,21 @@ The team has likely already decided things you'd otherwise re-litigate.
 <!-- Common commands a contributor needs (build, test, lint, run). -->
 
 <!-- clud-bug-start -->
-<!-- clud-bug-block-version: v1 -->
+<!-- clud-bug-block-version: v2 -->
 ## clud-bug — Claude PR review
 
-This repository uses [clud-bug](https://cludbug.dev) to review pull requests
-automatically. Three things matter when other agents (or future-you) work
-in this repo:
+This repo uses [clud-bug](https://cludbug.dev) for automatic PR reviews.
+Full collaboration rules — fix-push flow, skill structure, comment format,
+strict-mode mechanics, workflow-edit constraint — live in the bundled
+[`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md).
+Read that skill before pushing fixes addressing prior review threads.
 
-### When you push fixes addressing prior Clud Bug review threads
+Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle via `.claude/skills/.clud-bug.json`
+(read from PR **base ref**, so PRs can't disable strict-mode on themselves).
 
-The bot resolves its own prior review threads on the next pass when it can
-verify the fix in the diff. You don't need to manually resolve threads it
-opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
-left isn't auto-resolved after a fix, the bot judged the issue still open;
-read its latest review comment for what it's still flagging.
+For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
+(or pass `--quiet`) — suppresses progress chatter and emits a single
+`ok <key-value>` summary line per command.
 
-### Strict mode
-
-Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle by editing `.claude/skills/.clud-bug.json`:
-
-```json
-{ "strictMode": true | false, ... }
-```
-
-The setting is read from the **base ref** of any open PR, so PRs cannot
-disable strict mode on themselves. Changes take effect on PRs opened after
-they merge to the base branch.
-
-### Where the skills live
-
-Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
-small baseline kit ships with every install — see
-`.claude/skills/.clud-bug.json` for the current set. Add more via
-`clud-bug add <source/name>` (from skills.sh) or by dropping your own
-`.md` files there. They auto-load into the reviewer.
-
-### Editing the workflow
-
-Anthropic's `claude-code-action` refuses to run on PRs that modify its own
-workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
-their own isolated PR — see [README](https://github.com/thrillmade/clud-bug#when-you-edit-the-workflow).
-
-_Installed at clud-bug v0.5.16._
+_Installed at clud-bug v0.6.12._
 <!-- clud-bug-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,46 +3,21 @@ See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.
 
 <!-- clud-bug-start -->
-<!-- clud-bug-block-version: v1 -->
+<!-- clud-bug-block-version: v2 -->
 ## clud-bug — Claude PR review
 
-This repository uses [clud-bug](https://cludbug.dev) to review pull requests
-automatically. Three things matter when other agents (or future-you) work
-in this repo:
+This repo uses [clud-bug](https://cludbug.dev) for automatic PR reviews.
+Full collaboration rules — fix-push flow, skill structure, comment format,
+strict-mode mechanics, workflow-edit constraint — live in the bundled
+[`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md).
+Read that skill before pushing fixes addressing prior review threads.
 
-### When you push fixes addressing prior Clud Bug review threads
+Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle via `.claude/skills/.clud-bug.json`
+(read from PR **base ref**, so PRs can't disable strict-mode on themselves).
 
-The bot resolves its own prior review threads on the next pass when it can
-verify the fix in the diff. You don't need to manually resolve threads it
-opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
-left isn't auto-resolved after a fix, the bot judged the issue still open;
-read its latest review comment for what it's still flagging.
+For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
+(or pass `--quiet`) — suppresses progress chatter and emits a single
+`ok <key-value>` summary line per command.
 
-### Strict mode
-
-Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle by editing `.claude/skills/.clud-bug.json`:
-
-```json
-{ "strictMode": true | false, ... }
-```
-
-The setting is read from the **base ref** of any open PR, so PRs cannot
-disable strict mode on themselves. Changes take effect on PRs opened after
-they merge to the base branch.
-
-### Where the skills live
-
-Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
-small baseline kit ships with every install — see
-`.claude/skills/.clud-bug.json` for the current set. Add more via
-`clud-bug add <source/name>` (from skills.sh) or by dropping your own
-`.md` files there. They auto-load into the reviewer.
-
-### Editing the workflow
-
-Anthropic's `claude-code-action` refuses to run on PRs that modify its own
-workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
-their own isolated PR — see [README](https://github.com/thrillmade/clud-bug#when-you-edit-the-workflow).
-
-_Installed at clud-bug v0.5.16._
+_Installed at clud-bug v0.6.12._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/chore__clud-bug-update-v0.6.12.md
+++ b/docs/decisions-branches/chore__clud-bug-update-v0.6.12.md
@@ -1,0 +1,8 @@
+## 2026-05-28 13:14 - chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix)
+
+**Reasoning:** First end-to-end propagation of Phase A wins to this consuming repo. Six files changed: clud-bug-{audit,review,self-update}.yml workflows re-rendered to v0.6.12 templates; AGENTS.md + CLAUDE.md block trimmed to v0.6.6 v2 format; .cursorrules updated; .clud-bug.json lastUpdateVersion stamped. Brings in: APPEND_SYSTEM_PROMPT caching, per-section byte budgets (MAX_DIFF/COMMENT/SKILL_BYTES), severity-prefix + collapsible Reasoning comment format, CLUD_BUG_QUIET CLI, --max-turns 15 + MAX_THINKING_TOKENS=8000, Sonnet 4.6 model pin, incremental-diff handshake via last-reviewed-sha marker, fixed self-update.yml.tmpl (workflow_dispatch unblocked).
+
+**Implications:**
+- First PR in any consuming repo to be reviewed by clud-bug on the UPDATED v0.6.12 templates after merge. The PR's OWN review still uses the v0.5.16 templates because the workflow on base ref hasn't changed yet (chicken-and-egg). After merge, every future PR in this repo benefits from the new cost-control regime.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
 - **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
 - **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
 - **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)


### PR DESCRIPTION
## Summary

Brings this repo's clud-bug install from `v0.5.16` up to `v0.6.12`, propagating the full Phase A token-cost rollout in one PR.

What lands across the 6 changed files:

- **`.github/workflows/clud-bug-{review,audit,self-update}.yml`** — re-rendered from v0.6.12 templates. Picks up:
  - Anthropic prompt caching via `APPEND_SYSTEM_PROMPT` (v0.6.3, 10% cost on cache hits)
  - Per-section byte budgets `MAX_DIFF_BYTES=80000` / `MAX_COMMENT_BYTES=20000` / `MAX_SKILL_BYTES=4000` (v0.6.4)
  - `--max-turns 15` runaway-protection ceiling + `MAX_THINKING_TOKENS=8000` (v0.6.8)
  - `--model claude-sonnet-4-6` pin — ~80% cost reduction vs Opus (v0.6.11)
  - Incremental-diff handshake on fix-push via `<!-- last-reviewed-sha: <sha> -->` marker + `git diff <sha>..HEAD` (v0.6.10, ~67% fewer bytes ingested per fix-push)
  - Fixed `self-update.yml.tmpl` YAML literal-block bug (v0.6.12 — `workflow_dispatch` unblocked)
- **`AGENTS.md` + `CLAUDE.md`** — block trimmed to v0.6.6 v2 format (~44 → ~10 lines pointing at the `clud-bug-collaboration` skill).
- **`.cursorrules`** — same trim.
- **`.claude/skills/.clud-bug.json`** — `lastUpdateVersion: 0.6.12`.

## Test plan

- [x] Local `npx clud-bug@latest update` ran cleanly: `ok updated: @v0.6.12, 6 changed, 3 unchanged`.
- [x] No source-code changes in this repo — purely workflow + AGENTS-block refresh.
- [ ] This PR's own `clud-bug-review` runs under the **old** v0.5.16 workflow (base-ref ⇒ chicken-and-egg). After merge, every future PR in this repo benefits from the new regime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)