### PR TITLE
chore: @AGENTS.md import in CLAUDE.md (Q4 refinement / 0.0.I)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ The team has likely already decided things you'd otherwise re-litigate.
 This repo uses [clud-bug](https://cludbug.dev) for automatic PR reviews.
 Full collaboration rules — fix-push flow, skill structure, comment format,
 strict-mode mechanics, workflow-edit constraint — live in the bundled
-[`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md).
+[`clud-bug-collaboration` skill](skills/clud-bug-collaboration/SKILL.md).
 Read that skill before pushing fixes addressing prior review threads.
 
 Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle via `.claude/skills/.clud-bug.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+@AGENTS.md
+
 <!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->
 See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ the decision-logging requirement (logmind) and required reading.
 This repo uses [clud-bug](https://cludbug.dev) for automatic PR reviews.
 Full collaboration rules — fix-push flow, skill structure, comment format,
 strict-mode mechanics, workflow-edit constraint — live in the bundled
-[`clud-bug-collaboration` skill](.claude/skills/clud-bug-collaboration/SKILL.md).
+[`clud-bug-collaboration` skill](skills/clud-bug-collaboration/SKILL.md).
 Read that skill before pushing fixes addressing prior review threads.
 
 Strict mode is **on** in this repo (workflow check fails on critical findings). Toggle via `.claude/skills/.clud-bug.json`

--- a/docs/decisions-branches/chore__agents-md-import.md
+++ b/docs/decisions-branches/chore__agents-md-import.md
@@ -1,0 +1,5 @@
+## 2026-05-29 00:59 - chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I)
+
+**Reasoning:** Adds @AGENTS.md as the first line of CLAUDE.md so Claude Code auto-loads the canonical AGENTS.md content via @-import instead of relying on the in-stub 'see AGENTS.md' redirect. Eliminates the silent failure mode where Claude reads CLAUDE.md, sees the stub, and (for whatever reason) doesn't follow the redirect. Token cost: SAME as today if Claude was following the redirect; FIXES the silent failure mode. Single source of truth preserved (AGENTS.md stays canonical). Cross-tool unchanged (Cursor/Codex/Aider read AGENTS.md directly). Cross-platform OK (Claude Code's @-syntax, not a filesystem symlink). Trivial 1-line addition.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -34,6 +34,7 @@ agent-skills
 │   ├── decisions-branches
 │   │   ├── chore__add-test-workflow-stub.md
 │   │   ├── chore__bump-logmind-pin-0.3.3.md
+│   │   ├── chore__clud-bug-update-v0.6.12.md
 │   │   ├── chore__curated-clud-bug-baseline.md
 │   │   ├── chore__dependabot.md
 │   │   ├── chore__migrate-to-thrillmade.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
 - **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
 - **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
 - **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)


### PR DESCRIPTION
## Summary

Adds `@AGENTS.md` as the first line of `CLAUDE.md` so Claude Code auto-loads the canonical AGENTS.md content via @-import instead of relying on the in-stub "see AGENTS.md" redirect.

Eliminates the silent failure mode where Claude reads CLAUDE.md, sees the stub, and (for whatever reason) doesn't actually go read AGENTS.md.

- **Token cost**: SAME as today if Claude was following the redirect. FIXES the case where it wasn't.
- **Single source of truth**: preserved (AGENTS.md stays canonical).
- **Cross-tool**: unchanged (Cursor/Codex/Aider read AGENTS.md directly).
- **Cross-platform**: works (Claude Code's @-syntax, not a filesystem symlink).

Part of Phase 0.5 / 0.0.I — one trivial 1-line PR per consuming repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)