### PR TITLE
logmind v0.5.5 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.5.md
+++ b/.skill-update-todo/v0.5.5.md
@@ -1,0 +1,49 @@
+# logmind v0.5.5 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.5/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.5
+
+## Claude's reasoning
+
+The v0.5.5 changes are internal implementation improvements: the parser now emits a stderr warning for malformed dates instead of silently dropping them (a bug fix for previously invisible silent failures), and `atomic_write_text` now cleans up orphaned `.tmp` files on failure. Neither change affects CLI commands, flags, agent-facing behaviors, defaults, or any "do/don't" guidance an agent would need to follow. The warning output is a passive informational signal, not a new command or workflow step. Tests and quality improvements are also skill-irrelevant.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.5] - 2026-05-29
+
+### Added — RTK-inspired fail-safe patterns (Phase 0.5 / 0.0.T, logmind side)
+
+Two surgical patterns lifted from RTK (MIT-licensed) into logmind's
+parser + atomic-write paths. RTK is not adopted as a dependency; only
+the patterns ship.
+
+**Parser warn-not-silent** (`src/logmind/core/parser.py`):
+`iter_decisions` previously caught `ValueError` on malformed decision
+header dates (e.g. `"## 2026-13-45 25:99 - title"` — regex matches but
+the date doesn't parse) and silently dropped the entry. Now emits a
+stderr warning naming the file + lineno + parse error, then skips.
+Silent drops were the Phase 0 hindsight bug this addresses.
+
+```
+  ! logmind: skipping malformed decision header at
+  docs/decisions-branches/foo.md:14: month must be in 1..12
+```
+
+**Atomic-write orphan cleanup** (`src/logmind/core/atomic_io.py`):
+`atomic_write_text` previously left an orphaned `.tmp` sibling behind
+if the write failed mid-flight. Now catches `BaseException` (covers
+`KeyboardInterrupt`), unlinks the orphan with `missing_ok=True`, then
+re-raises the original exception. Cleanup is best-effort: if the
+unlink ALSO fails, the original exception still propagates so the
+real error is never masked.
+
+### Tests
+
++6 tests in `tests/test_fail_safe_0_0_T.py`: malformed-date warning,
+no warning on clean / missing files, tmp cleanup on write failure,
+original exception preserved when cleanup also fails, happy path
+unchanged. Full suite: 614 passed, 1 skipped.
+
+### Impact
+
+Quality boost (Q6 — never silent-drop warnings). No measurable token
+cost change.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.5 shipped.

**CHANGELOG**: [`v0.5.5` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.5/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.5

## Shape of this PR

TODO context only (Claude judged release skill-irrelevant)

## Claude's reasoning

The v0.5.5 changes are internal implementation improvements: the parser now emits a stderr warning for malformed dates instead of silently dropping them (a bug fix for previously invisible silent failures), and `atomic_write_text` now cleans up orphaned `.tmp` files on failure. Neither change affects CLI commands, flags, agent-facing behaviors, defaults, or any "do/don't" guidance an agent would need to follow. The warning output is a passive informational signal, not a new command or workflow step. Tests and quality improvements are also skill-irrelevant.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.