### PR TITLE
docs(token-frugal-tooling): document Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E)

### DIFF
--- a/docs/decisions-branches/chore__token-frugal-tooling-phase-0.5.md
+++ b/docs/decisions-branches/chore__token-frugal-tooling-phase-0.5.md
@@ -1,0 +1,8 @@
+## 2026-05-29 09:58 - Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E)
+
+**Reasoning:** The skill last-revised in PR #46 (token-frugal-tooling meta-skill ship) doesn't yet document the Phase 0.5 wins shipped after v0.6.12. Adds: (1) ### Diagnostics block reading guidance for 0.0.T tee-hint output, (2) four 'Don't worry about...' bullets for 0.0.W workflow-skip, 0.0.R Haiku routing, 0.0.X output brevity directive, 0.0.E golden gate. Net +24 lines, 108 → 132. The skill stays a quick-reference; detail still routes to clud-bug-collaboration.
+
+**Implications:**
+- Other agents reading this skill in the next session will know that a ### Diagnostics block in a Clud Bug summary is intentional (not malformed output) and what it signals. They'll also see the v0.6.14-v0.6.20 cost defaults so they don't 'helpfully' override them.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -33,6 +33,7 @@ agent-skills
 ├── docs
 │   ├── decisions-branches
 │   │   ├── chore__add-test-workflow-stub.md
+│   │   ├── chore__agents-md-import.md
 │   │   ├── chore__bump-logmind-pin-0.3.3.md
 │   │   ├── chore__clud-bug-update-v0.6.12.md
 │   │   ├── chore__curated-clud-bug-baseline.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E) *(chore/token-frugal-tooling-phase-0.5)* — [decisions-branches/chore__token-frugal-tooling-phase-0.5.md](decisions-branches/chore__token-frugal-tooling-phase-0.5.md)
 - **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
 - **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
 - **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)

--- a/skills/token-frugal-tooling/SKILL.md
+++ b/skills/token-frugal-tooling/SKILL.md
@@ -69,6 +69,13 @@ On a re-read, you can usually trust the headline and skip the collapsed
 `Reasoning`. Expand only when the headline is ambiguous or you want the
 evidence trail.
 
+If you see a `### Diagnostics` block before the Skills-referenced footer
+(clud-bug v0.6.18+ / 0.0.T): a `head -c` cap fired during the review.
+The block names which section truncated and the recovery outcome (e.g.
+"recovered with 2x cap", "still truncated"). Treat it as confidence
+calibration — if a finding's section was deferred, the verdict on that
+section is partial.
+
 ## Show + search are agent-friendly (v0.5.2+)
 
 `logmind show` carries three combinable flags for fast scans:
@@ -98,6 +105,23 @@ works without extra plumbing.
   only the delta since its prior review (handshake via
   `<!-- last-reviewed-sha: <sha> -->` marker in the prior summary
   comment).
+- **Don't worry about workflow-only PRs** (clud-bug v0.6.14 / 0.0.W) —
+  PRs touching only `clud-bug-*.yml` or `strict-mode-gate/**` skip the
+  LLM review entirely. The composite-pin lock-step propagation PRs
+  that used to require admin-bypass are now normal merges.
+- **Don't worry about dep-bump PRs** (clud-bug v0.6.15 / 0.0.R) —
+  dependabot/renovate authors AND small-diff dep-manifest-only PRs
+  route to Haiku ($0.80/MTok vs Sonnet's $3) for another ~75%
+  reduction on that class.
+- **Don't worry about review output length** (clud-bug v0.6.16 / 0.0.X)
+  — the prompt has a brevity directive ("Keep total output under
+  ~600 tokens"). Per-finding 1-sentence claim + collapsible reasoning
+  is the shape; you don't need to ask for short output.
+- **Don't worry about prompt drift** (clud-bug v0.6.17 / 0.0.E) — the
+  CI golden gate (`test/golden/{must-contain,must-not-contain,byte-budget}.json`)
+  fails any PR that drops a load-bearing prompt instruction or
+  re-introduces filler patterns. The byte-budget cap is intentionally
+  low post-0.0.P (v0.6.20).
 
 ## Where to look for detail
 


### PR DESCRIPTION
## Summary

Refreshes `skills/token-frugal-tooling/SKILL.md` to cover Phase 0.5 wins shipped since the skill's last update (PR #46). +24 lines: one paragraph + four bullets.

## What's added

1. **`### Diagnostics` block reading guidance** (0.0.T) — explains what the new clud-bug v0.6.18 truncation-audit block in a summary comment signals (and how to read it for confidence calibration).

2. Four new "Don't worry about…" bullets:
   - **Workflow-only PRs skip review** (0.0.W / v0.6.14)
   - **Dep-bump PRs route to Haiku** (0.0.R / v0.6.15)
   - **Output brevity directive** (0.0.X / v0.6.16)
   - **Golden gate prevents prompt drift** (0.0.E / v0.6.17, byte-budget locked low post-0.0.P / v0.6.20)

No content removed. The skill stays the meta-pointer; detailed mechanics still live in `clud-bug-collaboration`.

## Test plan

- [ ] CI check-links / check-decisions / clud-bug-review green.
- [ ] After merge: other agents reading the skill see the Phase 0.5 conventions without having to re-derive them from clud-bug CHANGELOG entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)