### PR TITLE
feat: add applies_to to 3 scoped skills (companion to clud-bug 0.0.K / v0.6.21)

### DIFF
--- a/docs/decisions-branches/chore__applies-to-scoped-skills.md
+++ b/docs/decisions-branches/chore__applies-to-scoped-skills.md
@@ -1,0 +1,10 @@
+## 2026-05-29 10:15 - 0.0.K companion: add applies_to to brand-voice-review, api-contract-enforcement, test-discipline
+
+**Reasoning:** Companion to clud-bug#113 (0.0.K). With applies_to landing in clud-bug v0.6.21, scoped skills can declare path/extension globs that gate body fetch. Three skills get applies_to blocks: brand-voice-review (UI paths + .tsx/.jsx/.vue/.svelte/.html/.md/.mdx extensions), api-contract-enforcement (api/routes/handlers paths + .proto/.graphql/.thrift extensions), test-discipline (test/spec paths + .test.* / .spec.* / _test.* extensions). Each skill's existing description already telegraphs the right scope — the applies_to block makes it executable. The fourth dedicated skill, pii-and-compliance, INTENTIONALLY stays un-scoped because PII can leak from any code path that emits data outward (logs, telemetry, external API calls), and the false-negative cost of skipping it on a PR with hidden logging would be high. Cost of universal-apply for PII: one frontmatter scan.
+
+**Alternatives considered:** Add applies_to to pii-and-compliance with logging/telemetry/db globs. Rejected: PII leaks frequently happen inside unrelated code paths (a backend handler that suddenly starts logging a user object). Better to always-apply for compliance-critical skills until per-line filtering is feasible.
+
+**Implications:**
+- Once clud-bug#113 (v0.6.21) is published, consumers running clud-bug update will pick up the new prompt instruction. From there, agents loading these skills via clud-bug-review will only fetch matching skill bodies — measurable savings will appear in 'clud-bug usage' output ($/LOC will drop on PRs that don't match dedicated skills).
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -41,6 +41,7 @@ agent-skills
 │   │   ├── chore__migrate-to-thrillmade.md
 │   │   ├── chore__regen-derived-docs.md
 │   │   ├── chore__regen-fs-post-pr37.md
+│   │   ├── chore__token-frugal-tooling-phase-0.5.md
 │   │   ├── docs__logmind-v0.3.0.md
 │   │   ├── feat__clud-bug-collab-v0.6-skill-update.md
 │   │   ├── feat__logmind-v0.5-skill-update.md

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-29** — 0.0.K companion: add applies_to to brand-voice-review, api-contract-enforcement, test-discipline *(chore/applies-to-scoped-skills)* — [decisions-branches/chore__applies-to-scoped-skills.md](decisions-branches/chore__applies-to-scoped-skills.md)
 - **2026-05-29** — Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E) *(chore/token-frugal-tooling-phase-0.5)* — [decisions-branches/chore__token-frugal-tooling-phase-0.5.md](decisions-branches/chore__token-frugal-tooling-phase-0.5.md)
 - **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
 - **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)

--- a/skills/api-contract-enforcement/SKILL.md
+++ b/skills/api-contract-enforcement/SKILL.md
@@ -2,6 +2,24 @@
 name: api-contract-enforcement
 description: Flag PRs that change the shape, semantics, or error behavior of a public API without versioning, deprecation, or migration notes. Catches removed fields, renamed parameters, changed status codes, broken pagination, and silent enum drift. Apply when reviewing HTTP routes, gRPC services, GraphQL schemas, SDK exports, CLI flags, or any other interface a downstream consumer depends on.
 review_mode: dedicated
+applies_to:
+  paths:
+    - "api/**"
+    - "src/api/**"
+    - "lib/api/**"
+    - "internal/api/**"
+    - "**/routes/**"
+    - "**/handlers/**"
+    - "**/controllers/**"
+    - "**/endpoints/**"
+    - "**/resolvers/**"
+    - "src/index.ts"
+    - "src/index.js"
+    - "src/__init__.py"
+    - "openapi/**"
+    - "schema/**"
+    - "schemas/**"
+  extensions: [".proto", ".graphql", ".graphqls", ".gql", ".thrift"]
 ---
 
 # API contract enforcement

--- a/skills/brand-voice-review/SKILL.md
+++ b/skills/brand-voice-review/SKILL.md
@@ -2,6 +2,24 @@
 name: brand-voice-review
 description: Review user-facing strings for brand-voice consistency. Catch dead phrases ("click here", "you should"), accidental shouting (exclamation marks, ALL CAPS), and jargon that leaks past the design team. Apply to button labels, error messages, marketing copy, headings — not to internal code identifiers or logs.
 review_mode: dedicated
+applies_to:
+  paths:
+    - "src/ui/**"
+    - "src/components/**"
+    - "lib/ui/**"
+    - "lib/components/**"
+    - "components/**"
+    - "app/**"
+    - "pages/**"
+    - "marketing/**"
+    - "docs/**"
+    - "README.md"
+    - "**/copy/**"
+    - "**/microcopy/**"
+    - "**/strings/**"
+    - "**/i18n/**"
+    - "**/locales/**"
+  extensions: [".tsx", ".jsx", ".vue", ".svelte", ".html", ".md", ".mdx", ".pug", ".hbs", ".liquid"]
 ---
 
 # Brand voice review

--- a/skills/test-discipline/SKILL.md
+++ b/skills/test-discipline/SKILL.md
@@ -2,6 +2,17 @@
 name: test-discipline
 description: Review test changes for the patterns that hollow out a test suite over time — overly-mocked tests, snapshot churn, asserting on the implementation, deleted tests without replacement, skipped tests left in the diff, and "fix the test to match the new behavior" without thinking about whether the old assertion was load-bearing. Apply to any PR that adds, deletes, or modifies test files.
 review_mode: dedicated
+applies_to:
+  paths:
+    - "test/**"
+    - "tests/**"
+    - "spec/**"
+    - "specs/**"
+    - "**/__tests__/**"
+    - "**/__test__/**"
+    - "e2e/**"
+    - "integration/**"
+  extensions: [".test.ts", ".test.tsx", ".test.js", ".test.jsx", ".test.py", ".test.go", ".test.rb", ".spec.ts", ".spec.tsx", ".spec.js", ".spec.jsx", "_test.py", "_test.go", "_spec.rb"]
 ---
 
 # Test discipline


### PR DESCRIPTION
## Summary

Companion to thrillmade/clud-bug#113 (0.0.K). Adds `applies_to:` blocks to three dedicated skills so they only load on PRs whose changed files match their scope. Leaves `pii-and-compliance` un-scoped (universal) — PII leaks can hide in any code path that emits data outward, and the false-negative cost of skipping is too high.

## Per-skill applies_to

### `brand-voice-review`
**Paths**: `src/ui/**`, `src/components/**`, `lib/ui/**`, `lib/components/**`, `components/**`, `app/**`, `pages/**`, `marketing/**`, `docs/**`, `README.md`, `**/copy/**`, `**/microcopy/**`, `**/strings/**`, `**/i18n/**`, `**/locales/**`
**Extensions**: `.tsx`, `.jsx`, `.vue`, `.svelte`, `.html`, `.md`, `.mdx`, `.pug`, `.hbs`, `.liquid`

### `api-contract-enforcement`
**Paths**: `api/**`, `src/api/**`, `lib/api/**`, `internal/api/**`, `**/routes/**`, `**/handlers/**`, `**/controllers/**`, `**/endpoints/**`, `**/resolvers/**`, `src/index.{ts,js}`, `src/__init__.py`, `openapi/**`, `schema/**`, `schemas/**`
**Extensions**: `.proto`, `.graphql`, `.graphqls`, `.gql`, `.thrift`

### `test-discipline`
**Paths**: `test/**`, `tests/**`, `spec/**`, `specs/**`, `**/__tests__/**`, `**/__test__/**`, `e2e/**`, `integration/**`
**Extensions**: `.test.{ts,tsx,js,jsx,py,go,rb}`, `.spec.{ts,tsx,js,jsx}`, `_test.{py,go}`, `_spec.rb`

### `pii-and-compliance` — UN-SCOPED (intentional)

The skill's value is catching PII leaks across the entire codebase. Scoping it by path would create false negatives whenever logging or telemetry sneaks into an unexpected directory. Cost of universal-apply is one frontmatter scan per PR.

## Test plan

- [x] Skills' descriptions already telegraph the right scope; the `applies_to` blocks make that scope executable.
- [x] Match semantics: paths OR extensions — any single hit applies.
- [ ] CI green (check-links / clud-bug-review).
- [ ] After clud-bug v0.6.21 publishes: consuming repos will skip body fetch for skills whose declared paths don't match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)