### PR TITLE
logmind v0.5.6 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.6.md
+++ b/.skill-update-todo/v0.5.6.md
@@ -1,0 +1,79 @@
+# logmind v0.5.6 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.6/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.6
+
+## Claude's reasoning
+
+The v0.5.6 changes are: (1) a real implementation of an internal benchmark script (`bench/per_session.py`) that is explicitly "internal-only (not shipped to PyPI)" and informational only, and (2) a trim of the AGENTS.md logmind-block from v5-slim to v6-pointer (a compression of inline prose, with full procedure already living in the skill). Neither change introduces new CLI commands, flags, behaviors, defaults, or "do/don't" guidance that agents using the skill need to know — the skill already contains the full procedure that was removed from AGENTS.md. The AGENTS.md block change is a consuming-repo concern handled automatically by `logmind doctor` + `logmind init`, which the skill already documents.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.6] - 2026-05-29
+
+### Added — `bench/per_session.py` real impl (Phase 0.5 Step 1)
+
+The 4th angle of `logmind-bench` (Q7-logmind enforcement) was a stub.
+Now walks `~/.claude/projects/*/*.jsonl`, joins `tool_use: Read` events
+to their `tool_result` siblings via `tool_use_id`, buckets read bytes
+into `docs/decisions.md` / `docs/timeline.md` / `docs/file-structure.md`
+/ `AGENTS.md` (+ AGENTS.md-logmind-block sub-bucket), compares to a
+`git log --oneline -100` baseline.
+
+Per-session is **informational only** (does NOT gate the exit code) —
+the `git log --oneline` baseline is conceptually too thin for the
+`net_pct` sign to be a quality signal. The load-bearing data is the
+per-file shares (`per_file_share`, `agents_md_block_share`), which
+gate the conditional 0.B.5 / 0.B.6 candidates.
+
+Sample output:
+
+```
+ok: 4-angle Q7-logmind compliance
+  per-call       -18% bytes vs git equivalent      ✅ saver
+  worst-case     -58% even on never-read           ✅ saver
+  per-session    +352% bytes amortized (9/14 sessions, AGENTS.md=35%, decisions=38%) ℹ info
+  org-cumulative (stub — not yet implemented)
+```
+
+`bench/` is internal-only (not shipped to PyPI); the change is at the
+repo level for nightly bench + decision-rubric inputs.
+
+### Changed — `AGENTS.md` logmind-block trimmed v5-slim → v6-pointer (Phase 0.5 / 0.B.6)
+
+Block compressed from 2526 bytes / 48 lines to ~770 bytes / 12 lines
+(**~ 69 % reduction**) — drops the inline 5-step procedure +
+"Required reading" list, keeps the load-bearing "logmind log is the
+commit primitive" rule + bash example + skill pointer to
+`agent-skills/skills/logmind`. Full procedure now lives entirely in
+the skill (which most agent runtimes auto-load).
+
+**Per-session data justifying the ship** (`python -m bench` on a real
+machine with 14 sampled logmind-repo sessions, 9 with decision-doc
+reads):
+
+- `per_file_share[AGENTS.md] = 0.36` ≥ 0.20 threshold ✅
+- `agents_md_block_share = 0.51` ≥ 0.30 threshold ✅
+
+(See `/Users/ludlow/.claude/plans/ok-here-is-recent-distributed-chipmunk.md`
+Step 3 rubric.)
+
+**Savings:** ~1.8 KB per repo per AGENTS.md read. Across 6 consuming
+repos × per-session reads, compounds quickly.
+
+### Migration
+
+Consuming repos pick up the v6-pointer block on next `logmind doctor`
++ refresh cycle. `inserter._replace_marker_block` handles the swap
+idempotently. The v6 block is a strict subset of v5's information
+(everything trimmed lives in the linked skill); no agent action lost.
+
+### Tests
+
+`test_get_agents_md_template_returns_slim_when_skills_available` updated
+to assert `v6-pointer` marker, the "commit primitive" rule, the
+git-trio-replacement phrase, the skill-URL pointer, AND a 1500-byte
+hard cap on the slim block to prevent future re-bloating.
+
+### Composite pin
+
+No clud-bug composite changes this release.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.6 shipped.

**CHANGELOG**: [`v0.5.6` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.6/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.6

## Shape of this PR

TODO context only (Claude judged release skill-irrelevant)

## Claude's reasoning

The v0.5.6 changes are: (1) a real implementation of an internal benchmark script (`bench/per_session.py`) that is explicitly "internal-only (not shipped to PyPI)" and informational only, and (2) a trim of the AGENTS.md logmind-block from v5-slim to v6-pointer (a compression of inline prose, with full procedure already living in the skill). Neither change introduces new CLI commands, flags, behaviors, defaults, or "do/don't" guidance that agents using the skill need to know — the skill already contains the full procedure that was removed from AGENTS.md. The AGENTS.md block change is a consuming-repo concern handled automatically by `logmind doctor` + `logmind init`, which the skill already documents.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.