### PR TITLE
feat(skills): update clud-bug-collaboration + logmind for Phase 0.5 / 0.0.O (§4)

### DIFF
--- a/docs/decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md
+++ b/docs/decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md
@@ -8,3 +8,11 @@
 - 5 new sections in clud-bug-collaboration/SKILL.md (~100 lines). 1 new subsection in logmind/SKILL.md (~30 lines). Companion §4b.2 (AGENTS.md.slim.template logmind-block lead-line promotion) NOT in this PR — separate logmind PR. Total diff: small, +130 lines across 2 skill files.
 
 ---
+## 2026-05-29 16:47 - fix(0.5 §4): correct API-endpoint distinction in bot-identity section (PR #55 review)
+
+**Reasoning:** Reviewer caught a factual error: I described repos/.../issues/N/comments as returning inline findings, then showed a 'WRONG' filter on that endpoint that supposedly dropped them. But issues/N/comments returns only ISSUE-LEVEL comments (the summary H2 thread) — inline findings live in pulls/N/comments / GraphQL reviewThreads. The 'WRONG' example dropped nothing because nothing was there to drop. Replaced with the correct two-endpoint distinction + the GraphQL reviewThreads pointer for the resolution flow.
+
+**Implications:**
+- Skill section now reflects reality. Agents grepping 'what did the bot say already?' need to read BOTH endpoints; this is now explicit. Pin pre-existing inline-finding examples still work because they're keyed by login, not endpoint.
+
+---

--- a/docs/decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md
+++ b/docs/decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md
@@ -1,0 +1,10 @@
+## 2026-05-29 16:39 - Update clud-bug-collaboration + logmind skills for Phase 0.5 / 0.0.O (§4)
+
+**Reasoning:** Two skills in this repo carry agent-facing collaboration guidance that v0.6.22 changed: (1) clud-bug-collaboration MUST now describe the bot-identity contract (claude[bot] for inline threads, github-actions[bot] for the summary comment under GITHUB_TOKEN), the --json-schema structured-output flow, the fallback to bare H2 when schema validation exhausts retries, the bot-login override consuming workflows must pass to strict-mode-gate, and the status_header: bare default for non-strict-mode repos. (2) logmind/SKILL.md needs an explicit 'Token cost: git vs logmind log' subsection — Phase 0.5 user-raised concern that agents running git add/commit/push instead of logmind log are net spenders. The bench provides the numbers; the skill needs to make the heuristic explicit so agents don't fall back to git by default.
+
+**Alternatives considered:** Defer §4b.1 token-cost subsection to a future logmind-skill rev — rejected: the bench numbers are already shipping in v0.5.7; pin the heuristic now while propagation is fresh, Bundle the AGENTS.md.slim.template promotion (§4b.2) into this PR — rejected: that lives in logmind repo, not agent-skills; will ship as a separate logmind PR after #81 lands
+
+**Implications:**
+- 5 new sections in clud-bug-collaboration/SKILL.md (~100 lines). 1 new subsection in logmind/SKILL.md (~30 lines). Companion §4b.2 (AGENTS.md.slim.template logmind-block lead-line promotion) NOT in this PR — separate logmind PR. Total diff: small, +130 lines across 2 skill files.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (24 decisions)
+## 2026-05 (25 decisions)
 
-- **2026-05-29** — Fix two CI failures on PR #53: bump logmind workflow pin 0.3.3 → 0.5.6 + fix SKILL.md path overwritten by clud-bug update *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
-- *... 22 more decisions ...*
+- **2026-05-29** — Update clud-bug-collaboration + logmind skills for Phase 0.5 / 0.0.O (§4) *(feat/0.5-S4-skill-updates-for-0.0.O)* — [decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md](decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md)
+- *... 23 more decisions ...*
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (25 decisions)
+## 2026-05 (26 decisions)
 
-- **2026-05-29** — Update clud-bug-collaboration + logmind skills for Phase 0.5 / 0.0.O (§4) *(feat/0.5-S4-skill-updates-for-0.0.O)* — [decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md](decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md)
-- *... 23 more decisions ...*
+- **2026-05-29** — fix(0.5 §4): correct API-endpoint distinction in bot-identity section (PR #55 review) *(feat/0.5-S4-skill-updates-for-0.0.O)* — [decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md](decisions-branches/feat__0.5-S4-skill-updates-for-0.0.O.md)
+- *... 24 more decisions ...*
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/skills/clud-bug-collaboration/SKILL.md
+++ b/skills/clud-bug-collaboration/SKILL.md
@@ -102,6 +102,101 @@ explaining how to set it. (For bot/fork PRs where the secret legitimately
 isn't passed, the guard posts a one-line advisory comment and exits 0
 instead of failing red.)
 
+## Bot identity contract (v0.6.22+)
+
+Two different bot accounts post to a clud-bug PR — knowing which is
+which matters when you grep / filter prior comments:
+
+- **`claude[bot]`** authors **inline review threads** (every 🔴 / 🟡
+  finding posts here). Authentication: composite-action exchanges
+  the `claude-code-oauth-token` for a short-lived App token; comments
+  post under the App's identity.
+- **`github-actions[bot]`** authors the **summary comment** (the
+  `## 🐛 Clud Bug review` H2 block with the stats line + collapsed
+  per-skill scan + per-section findings). Authentication: workflow
+  post-step uses the workflow's own `GITHUB_TOKEN`, which posts under
+  `github-actions[bot]`.
+
+When you scan prior comments to decide what was already said, your
+filter must accept BOTH logins. Example incremental-diff handshake:
+
+```bash
+# CORRECT — accept both identities
+gh api "repos/$REPO/issues/$PR/comments" --jq '
+  [.[] | select(.user.login == "github-actions[bot]" or .user.login == "claude[bot]")]
+  | sort_by(.created_at)
+'
+
+# WRONG — drops every inline finding ever posted
+gh api "repos/$REPO/issues/$PR/comments" --jq '
+  [.[] | select(.user.login == "github-actions[bot]")]
+'
+```
+
+## Structured output schema (v0.6.22+ / 0.0.O)
+
+The summary comment is no longer free-form prose. The LLM emits a
+JSON object matching the workflow-defined `--json-schema` (see
+`templates/workflow.yml.tmpl`); the workflow post-step renders that
+JSON to GitHub-flavored markdown.
+
+What this means for collaborating agents:
+
+- The shape is **stable**. Stats counts, per-skill scan rows, per-
+  finding objects (`skill`, `file`, `line`, `summary`, `reasoning`)
+  always appear in the same order; the H2 header always matches the
+  documented enum (`critical findings` / `clean` / `bare`).
+- Inline review threads still post one-per-finding via the MCP tool
+  `mcp__github_inline_comment__create_inline_comment` — those are
+  NOT in the structured output. The structured object describes them
+  (for the renderer's collapsed scan + counts), but the actual
+  GitHub inline-comment placement is the MCP tool's job.
+- The structured output also carries `last_reviewed_sha` — the HEAD
+  SHA at review time, used by the incremental-diff handshake
+  (v0.6.10) on the next fix-push. The renderer embeds it as
+  `<!-- last-reviewed-sha: <sha> -->` in the summary body.
+
+## Fallback when structured output is empty
+
+If `claude-code-action` retried schema validation up to its limit
+and never produced a valid object, `structured_output` arrives at
+the post-step empty. The post-step then posts a **bare-H2 advisory
+comment** (no body, just `## 🐛 Clud Bug review`) and exits 0.
+
+- Strict-mode gate falls open in this case — the gate post-step
+  greps for `## 🐛 Clud Bug review` and the bare header matches, so
+  the check turns green ADVISORY (not red). Q6 invariant: missing
+  signal must not block merge silently.
+- The job-summary panel surfaces the fallback so an operator can
+  see why no findings rendered. Look for "structured-output empty;
+  fell back to bare H2" if you find a PR where the bot ran but
+  emitted nothing.
+
+## `bot-login` override (v0.6.22+)
+
+Each consuming workflow passes `bot-login: 'github-actions[bot]'`
+to the `strict-mode-gate` composite action. The composite's default
+is still `claude[bot]` (pre-v0.6.22 back-compat), but every freshly-
+rendered consumer workflow overrides to `github-actions[bot]` because
+THAT is now the identity that authors the H2 summary the gate
+inspects.
+
+If you write a custom workflow that calls the gate directly, set
+`bot-login: 'github-actions[bot]'` — using the composite default
+will silently fail to find the summary on v0.6.22+ posts.
+
+## `status_header: "bare"` (v0.6.22+ default)
+
+Non-strict-mode repos (the default — check
+`.claude/skills/.clud-bug.json` for `strictMode: true`) emit
+`status_header: "bare"` in the structured output. The renderer
+produces `## 🐛 Clud Bug review` with no suffix, matching the v0.6.21-
+behaviour exactly. Strict-mode repos emit `critical findings` or
+`clean` and the renderer appends `— critical findings` / `— clean`.
+
+The strict-mode-gate post-step greps for "critical findings" to
+decide red-or-green; "bare" + "clean" both fall through to green.
+
 ## Reading review comments (v0.6.5+ format)
 
 Since v0.6.5, every Clud Bug summary comment leads with a stats line for

--- a/skills/clud-bug-collaboration/SKILL.md
+++ b/skills/clud-bug-collaboration/SKILL.md
@@ -117,21 +117,38 @@ which matters when you grep / filter prior comments:
   post-step uses the workflow's own `GITHUB_TOKEN`, which posts under
   `github-actions[bot]`.
 
-When you scan prior comments to decide what was already said, your
-filter must accept BOTH logins. Example incremental-diff handshake:
+When you scan prior comments to decide what was already said, two
+endpoints carry distinct comment types — and within each, you may
+encounter either bot identity:
 
 ```bash
-# CORRECT — accept both identities
+# Issue-level / summary thread (the H2 review-summary comment lives
+# here, authored by github-actions[bot]). Agents posting follow-ups
+# at the issue level also show up here.
 gh api "repos/$REPO/issues/$PR/comments" --jq '
   [.[] | select(.user.login == "github-actions[bot]" or .user.login == "claude[bot]")]
   | sort_by(.created_at)
 '
 
-# WRONG — drops every inline finding ever posted
-gh api "repos/$REPO/issues/$PR/comments" --jq '
-  [.[] | select(.user.login == "github-actions[bot]")]
+# Inline review threads (each 🔴 / 🟡 finding lives here, authored by
+# claude[bot] via the MCP tool). This endpoint never contains the
+# summary comment; that's issue-level.
+gh api "repos/$REPO/pulls/$PR/comments" --jq '
+  [.[] | select(.user.login == "claude[bot]")]
+  | sort_by(.created_at)
 '
+
+# GraphQL reviewThreads — same inline data as `pulls/$PR/comments`
+# but grouped into threads, and exposes `isResolved`. Use this when
+# you need to resolve threads programmatically after a fix.
+gh api graphql -f query='{ repository(...) { pullRequest(...) { reviewThreads(...) { ... } } } }'
 ```
+
+Pitfall: don't conflate the two endpoints. `issues/$PR/comments`
+never returns inline findings (they aren't issue-level comments);
+`pulls/$PR/comments` never returns the H2 summary (it's issue-level,
+not anchored to a diff line). A complete picture of "what did the
+bot say already?" reads both.
 
 ## Structured output schema (v0.6.22+ / 0.0.O)
 

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -83,6 +83,37 @@ the working tree gets bundled into the decision commit. No follow-up
 `git add`, no follow-up `git commit`, no follow-up `git push`. One command,
 one commit, working tree clean.
 
+### Token cost: `git` vs `logmind log` (Phase 0.5 finding)
+
+Running `git add` + `git commit` + `git push` directly costs **more
+tokens** than a single `logmind log` for the same decision-bearing
+commit. Three reasons:
+
+1. Each git command emits multi-line stdout (staging list, commit
+   summary with insertions/deletions, push progress with remote refs).
+   The agent reads each one back to confirm — that's 3 round-trips
+   instead of 1.
+2. `logmind log` under `LOGMIND_QUIET=1` emits exactly one line:
+   `ok logged: <sha> "<title>"`. Verifiable by the agent in one
+   read; no narration in the context window.
+3. The `git` flow loses the decision-log entry — future sessions can't
+   grep for the rationale. They re-derive it from the diff (more
+   tokens, lossier signal). `logmind log` writes the entry as a
+   side-effect, so the decision IS preserved without an extra step.
+
+Bench numbers (`bench.per_call`, Q7-logmind): every
+`logmind log` pair is a measurable net saver vs its git equivalent,
+gated by `test_per_call_returns_saver_or_break_even_for_log_command`
+in CI. If this test ever flips red, `logmind log` has become a token
+spender and the change ships as P0.
+
+**Heuristic for the agent**: when about to run `git commit`, ask
+"is this commit decision-bearing?" (architecture, alternatives
+weighed, dependency change, non-obvious behaviour shift). If yes,
+swap to `logmind log "..." -r "..."`. The decision and the code that
+prompted it travel together in one commit, and the bench shows you
+saved tokens too.
+
 If you find yourself running `git add`, `git commit`, `git push`, or
 `logmind timeline --write` **after** a `logmind log`, you're working
 against the design. Two likely causes:


### PR DESCRIPTION
## Summary

- **`clud-bug-collaboration/SKILL.md`** — 5 new sections covering v0.6.22 (0.0.O) behaviour changes that collaborating agents need to know about:
  1. **Bot identity contract** — `claude[bot]` for inline review threads (MCP-routed); `github-actions[bot]` for the summary comment (workflow post-step under `GITHUB_TOKEN`). Filters over prior comments MUST accept both.
  2. **Structured output schema** — the LLM emits JSON via `--json-schema`; the workflow post-step renders to GitHub markdown. Inline review threads still post via the MCP tool one-per-finding.
  3. **Fallback when structured output is empty** — bare-H2 advisory comment + strict-mode gate falls open (advisory not error).
  4. **`bot-login` override** — consuming workflows pass `bot-login: 'github-actions[bot]'` to the gate; composite default still `claude[bot]` for back-compat.
  5. **`status_header: "bare"`** — non-strict-mode repos preserve the v0.6.21- unsuffixed H2.
- **`logmind/SKILL.md`** — new "Token cost: `git` vs `logmind log`" subsection (Phase 0.5 user-raised concern). Makes the heuristic explicit so agents don't fall back to manual `git add`/`commit`/`push` and burn tokens on the multi-line stdout each command emits. Pins the bench guarantee (`test_per_call_returns_saver_or_break_even_for_log_command` in logmind CI) as the source of truth.

## Why now

These changes match the v0.6.22 → consumer-repo propagation that's now landing across the org. Agents in those repos will start seeing both bot identities (from new reviews) and the `bare` header (from non-strict-mode repos) immediately; the skill needs to be current when they look it up.

## Test plan

- [x] `clud-bug-collaboration/SKILL.md` reads cleanly cold (no internal references to the rest of the file); each new section answers one question.
- [x] `logmind/SKILL.md` token-cost subsection makes the cost-avoidance directional (no fabricated numbers — points to the bench as the source).
- [ ] After merge: a fresh agent loading this skill should answer "which bot authors what?" / "what happens when structured_output is empty?" / "when do I use `bot-login` override?" without ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)