### PR TITLE
logmind v0.5.7 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.7.md
+++ b/.skill-update-todo/v0.5.7.md
@@ -1,0 +1,70 @@
+# logmind v0.5.7 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.7/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.7
+
+## Claude's reasoning
+
+This release only adds a real implementation for the `bench/org_cumulative.py` benchmark stub, updates benchmark exit-gate labels, adds a back-compat alias, and adds tests. None of these changes affect agent-facing CLI commands, flags, defaults, or guidance in SKILL.md — the bench tooling is internal development/validation infrastructure, not part of the logmind user API that agents interact with.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.7] - 2026-05-29
+
+### Added — `bench/org_cumulative.py` real impl (Phase 0.5 §2)
+
+Closes the last Q7-logmind bench stub. The 4-angle frame is now
+fully populated: `per-call` ✅, `worst-case` ✅, `per-session` ✅
+(v0.5.6), `org-cumulative` ✅ (this release).
+
+Same data source as `per-session` (real agent session logs at
+`~/.claude/projects/*/*.jsonl`), but rolls up differently: instead
+of averaging `net_pct` across sessions, sums bytes across all
+sessions and all repos to produce one global cumulative `net_pct`
+plus per-repo share.
+
+Same informational-only treatment as `per-session` — both share the
+`git log --oneline -100` baseline which is too thin to interpret
+sign as a quality signal. The load-bearing data:
+
+- `per_repo_share` (dict by cwd) — which consuming repos contribute
+  most of the sampled byte volume. Used by Step 4 validation to
+  spot per-consumer outliers (>2× median share signals a cache-key
+  regression in that consumer's prompt prefix).
+- `repos_sampled`, `total_logmind_bytes`, `total_git_bytes` —
+  cross-checks against `per-session` (informational invariants
+  hold when both populate cleanly).
+
+Sample output on a real dev machine:
+
+```
+org-cumulative +130% bytes amortized (across 7 repos, 90 KB logmind / 39 KB git) ℹ info (Step 4 / 0.B.5 / 0.B.6 inputs)
+```
+
+### Changed
+
+- `bench/__main__.py` informational set: `per-session` AND
+  `org-cumulative` both excluded from exit-gate (both share the
+  thin baseline). Verdict label updated from "gates 0.B.5/0.B.6 via
+  shares" to "Step 4 / 0.B.5 / 0.B.6 inputs" to reflect the dual
+  consumer (org-cumulative feeds Step 4; per-session gates
+  0.B.5/0.B.6).
+- `run_org_cumulative_stub` retained as a back-compat alias that
+  delegates to `run_org_cumulative`; pin-tested by
+  `test_org_cumulative_stub_shim_calls_real_impl` so the alias
+  can't quietly diverge to the old placeholder shape.
+
+### Tests
+
+3 new tests in `tests/test_bench.py`:
+
+- `test_org_cumulative_no_sessions_returns_stub` — stub-invariant.
+- `test_org_cumulative_aggregates_across_sessions_and_repos` —
+  end-to-end fixture: two sessions across two distinct logmind
+  repos, validates global sum aggregation (not per-session
+  averaging) AND `per_repo_share` keys both repos with correct
+  weights.
+- `test_org_cumulative_per_repo_share_isolates_outlier` — 3:1
+  byte ratio across 2 repos, asserts the dominant repo's share
+  matches `3000 / 3500` and small repo's matches `500 / 3500`.
+  This is the metric Step 4 uses to flag per-consumer cache-key
+  regressions.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -11,6 +11,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.5.7.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.7 shipped.

**CHANGELOG**: [`v0.5.7` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.7/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.7

## Shape of this PR

TODO context only (Claude judged release skill-irrelevant)

## Claude's reasoning

This release only adds a real implementation for the `bench/org_cumulative.py` benchmark stub, updates benchmark exit-gate labels, adds a back-compat alias, and adds tests. None of these changes affect agent-facing CLI commands, flags, defaults, or guidance in SKILL.md — the bench tooling is internal development/validation infrastructure, not part of the logmind user API that agents interact with.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.