### PR TITLE
feat: color algorithm skills (oklch, apca, wcag, chroma-harmonization, palette-relationships)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,16 +7,52 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v6-pointer -->
+<!-- logmind-block-version: v5-slim -->
 ## Decision logging — `logmind log` is the commit primitive
 
-This project uses [logmind](https://logmind.dev). **`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
+This project uses [logmind](https://logmind.dev) for decision logging. **`logmind log` replaces `git add`, `git commit`, and `git push`** for any change that carries a decision. Do not run those git commands directly when logging a decision — `logmind log` does all three in one step.
 
 ```bash
-logmind log "summary" -r "why" -a "alternative" -i "implication"
+logmind log "decision summary" -r "why" -a "alternative" -i "implication"
 ```
 
-What counts as a decision, branch routing, `--stage scoped` for unrelated WIP, `logmind doctor`, and the required-reading list ([`docs/timeline.md`](docs/timeline.md), [`docs/decisions.md`](docs/decisions.md), [`docs/file-structure.md`](docs/file-structure.md), `docs/decisions-branches/<branch>.md`) all live in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind.
+That single command:
+
+1. Writes the decision file (default branch → `docs/decisions.md`, feature branch → `docs/decisions-branches/<branch>.md`).
+2. Regenerates `docs/timeline.md` (and `file-structure.md` on the default branch).
+3. **`git add`** every change in the working tree (default `--stage all` since v0.2.7).
+4. **`git commit`** with message `logmind: <decision>`.
+5. **`git push`** to remote.
+
+That's it. No follow-up `git add`, no follow-up `git commit`, no follow-up `git push`, no follow-up `logmind timeline --write`.
+
+### When NOT to use `logmind log`
+
+- **The change has no decision worth recording** (typo fix, formatting, dependency-only patch bump) — use plain `git commit` then.
+- **You have unrelated WIP in the working tree** you don't want to commit — pass `--stage scoped` to stage only the decision files (rare for automated agents; they should be working on one thing at a time).
+
+### The full skill
+
+The complete procedure (when something counts as a decision, branch routing, doctor, refresh patterns) lives in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind. Most agent runtimes auto-load it. If yours doesn't:
+
+```bash
+npx skills add https://github.com/thrillmade/agent-skills --skill logmind
+```
+
+### Required reading before non-trivial work
+
+1. **[docs/timeline.md](docs/timeline.md)** — chronological overview across all branches; start here.
+2. **[docs/decisions.md](docs/decisions.md)** — recent decisions on the default branch.
+3. **`docs/decisions-branches/<your-branch>.md`** if present — earlier decisions on this branch.
+4. **[docs/file-structure.md](docs/file-structure.md)** — current project tree.
+
+```bash
+logmind show               # recent decisions on the current branch
+logmind search "keyword"   # full-text across recent + archive
+logmind doctor             # check installed version + workflow template drift
+```
+
+The team has likely already decided things you'd otherwise re-litigate.
 <!-- logmind-end -->
 
 ## Project Overview

--- a/docs/decisions-branches/skills__color-algorithms.md
+++ b/docs/decisions-branches/skills__color-algorithms.md
@@ -18,3 +18,13 @@
 - wcag-contrast/SKILL.md table now includes Level column; 1.4.3 rows state thresholds in points with the CSS px conversion alongside; 2.4.13 row moved to AA; new 2.4.12 row added at AAA for the focus-not-obscured criterion. Description and Verification sections updated to mirror
 
 ---
+## 2026-05-29 23:18 - fix: stale SC 2.4.13 (AAA) label in Sources footer; add SC 2.4.12 (AAA Enhanced) reference
+
+**Reasoning:** clud-bug found Sources footer still showed AAA for SC 2.4.13 after the table was corrected
+
+**Alternatives considered:** leave Sources and rely on table — rejected, agents reading only Sources still see wrong level
+
+**Implications:**
+- Sources line 78 now AA; new SC 2.4.12 entry covers the AAA Focus Not Obscured (Enhanced) criterion
+
+---

--- a/docs/decisions-branches/skills__color-algorithms.md
+++ b/docs/decisions-branches/skills__color-algorithms.md
@@ -8,3 +8,13 @@
 - 5 new SKILL.md files under skills/. Each names its trigger surface (When to use / When NOT to use), cross-references siblings via 'REQUIRED BACKGROUND:' phrasing per superpowers:writing-skills convention, includes a verification step, cites sources. Skills cross-link: oklch ← apca, wcag, chroma-harmonization, palette-relationships; apca ↔ wcag; chroma-harmonization references oklch + apca + palette-relationships. After this PR merges (PR-C1), PR-C2 (typography) and PR-C3 (spacing) become unblocked.
 
 ---
+## 2026-05-29 23:12 - fix wcag-contrast: pt vs px thresholds + SC 2.4.13 level
+
+**Reasoning:** clud-bug found two real WCAG-spec errors: (1) SC 2.4.13 Focus Appearance is Level AA in WCAG 2.2 (October 2023), not AAA — the AAA criterion is 2.4.12 Focus Not Obscured (Enhanced). agents following the skill would skip a legally-required AA check; (2) the large-text threshold is in POINTS not pixels — 18 pt regular ≈ 24 CSS px and 14 pt bold ≈ 18.67 CSS px. writing 14 px / 18 px sets the threshold ~25% too low, so text at 15–18 px bold would incorrectly pass at 3:1 when it requires 4.5:1
+
+**Alternatives considered:** leave as-is and let consumers translate — rejected, the whole point of the skill is to give agents the correct threshold; (b) reference WCAG by SC number only and skip the threshold value — rejected, the threshold IS the load-bearing piece of the skill
+
+**Implications:**
+- wcag-contrast/SKILL.md table now includes Level column; 1.4.3 rows state thresholds in points with the CSS px conversion alongside; 2.4.13 row moved to AA; new 2.4.12 row added at AAA for the focus-not-obscured criterion. Description and Verification sections updated to mirror
+
+---

--- a/docs/decisions-branches/skills__color-algorithms.md
+++ b/docs/decisions-branches/skills__color-algorithms.md
@@ -1,0 +1,10 @@
+## 2026-05-29 23:03 - feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships)
+
+**Reasoning:** Phase C of the UDTS / token.design rollout: each skill encodes one algorithm from the foundations/color.md spec so any agent doing color work in any project can install it. Authored via superpowers:writing-skills RED-GREEN-REFACTOR (subagent baselines run for each skill; key gaps observed: baseline agents default to WCAG over APCA, pick-and-test instead of inverse composition, use Tailwind/Radix semantic names instead of UDTS hue-angle naming, reinvent chroma harmonization without crediting Evil Martians, conflate tetradic-square with tetradic-rectangle)
+
+**Alternatives considered:** ship reusable skills as a 5-PR sequence per-skill — rejected, batched by topic family for review-token economy. ship them inside the tokenomics repo as project-internal — rejected, they're reusable across any color-using project and belong in thrillmade/agent-skills so npx skills add finds them. defer writing skills until APCA standardizes — rejected, the skill cites the APCA exploratory status; UDTS uses APCA + WCAG cross-check today
+
+**Implications:**
+- 5 new SKILL.md files under skills/. Each names its trigger surface (When to use / When NOT to use), cross-references siblings via 'REQUIRED BACKGROUND:' phrasing per superpowers:writing-skills convention, includes a verification step, cites sources. Skills cross-link: oklch ← apca, wcag, chroma-harmonization, palette-relationships; apca ↔ wcag; chroma-harmonization references oklch + apca + palette-relationships. After this PR merges (PR-C1), PR-C2 (typography) and PR-C3 (spacing) become unblocked.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -18,17 +18,22 @@ agent-skills
 │   ├── file-structure.md
 │   └── timeline.md
 ├── skills
+│   ├── apca-contrast
 │   ├── api-contract-enforcement
 │   ├── brand-voice-review
+│   ├── chroma-harmonization
 │   ├── clud-bug-collaboration
 │   ├── critical-issues-only
 │   ├── evidence-based-review
 │   ├── logmind
+│   ├── oklch-color-space
+│   ├── palette-relationships
 │   ├── pii-and-compliance
 │   ├── respect-existing-conventions
 │   ├── skill-frontmatter-quality
 │   ├── test-discipline
-│   └── token-frugal-tooling
+│   ├── token-frugal-tooling
+│   └── wcag-contrast
 ├── .cursorrules
 ├── .gitattributes
 ├── .gitignore

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,35 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (29 decisions)
+## 2026-05
 
+- **2026-05-29** — fix: stale SC 2.4.13 (AAA) label in Sources footer; add SC 2.4.12 (AAA Enhanced) reference *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
 - **2026-05-29** — fix wcag-contrast: pt vs px thresholds + SC 2.4.13 level *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- *... 27 more decisions ...*
+- **2026-05-29** — feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships) *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
+- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.25 (Smart Budget Phase 1) *(chore/clud-bug-v0.6.25)* — [decisions-branches/chore__clud-bug-v0.6.25.md](decisions-branches/chore__clud-bug-v0.6.25.md)
+- **2026-05-29** — Fix publisher SKILL.md path in AGENTS.md (gotcha #2) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
+- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.23 (adaptive --max-turns) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
+- **2026-05-29** — Fix two CI failures on PR #53: bump logmind workflow pin 0.3.3 → 0.5.6 + fix SKILL.md path overwritten by clud-bug update *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
+- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.22 + logmind v0.5.6 (Phase 0.5 propagation §1) *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
+- **2026-05-29** — 0.0.K companion: add applies_to to brand-voice-review, api-contract-enforcement, test-discipline *(chore/applies-to-scoped-skills)* — [decisions-branches/chore__applies-to-scoped-skills.md](decisions-branches/chore__applies-to-scoped-skills.md)
+- **2026-05-29** — Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E) *(chore/token-frugal-tooling-phase-0.5)* — [decisions-branches/chore__token-frugal-tooling-phase-0.5.md](decisions-branches/chore__token-frugal-tooling-phase-0.5.md)
+- **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
+- **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
+- **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
+- **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
+- **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)
+- **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
+- **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
+- **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)
+- **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)
+- **2026-05-27** — fix(notify-clud-bug.yml): pipefail-safe the detect grep (zero-matches no-op) *(fix/notify-clud-bug-pipefail-grep)* — [decisions-branches/fix__notify-clud-bug-pipefail-grep.md](decisions-branches/fix__notify-clud-bug-pipefail-grep.md)
+- **2026-05-27** — chore: add test.yml stub for org ruleset uniformity *(chore/add-test-workflow-stub)* — [decisions-branches/chore__add-test-workflow-stub.md](decisions-branches/chore__add-test-workflow-stub.md)
+- **2026-05-27** — fix: fetch-depth 2→0 + handle first-push zero-ref BEFORE (clud-bug critical) *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
+- **2026-05-27** — feat(notify-clud-bug.yml): add push trigger with matrix strategy over changed baselines *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
+- **2026-05-27** — chore: bump logmind pin 0.3.0 → 0.3.3 *(chore/bump-logmind-pin-0.3.3)* — [decisions-branches/chore__bump-logmind-pin-0.3.3.md](decisions-branches/chore__bump-logmind-pin-0.3.3.md)
+- **2026-05-27** — Rewrite notify-clud-bug.yml as mechanical PR-opener (workflow_dispatch only) *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
+- **2026-05-27** — Add review_mode: shared to all baseline-type skill frontmatters *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
+- **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
+- **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
+- **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,35 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05
+## 2026-05 (30 decisions)
 
 - **2026-05-29** — fix: stale SC 2.4.13 (AAA) label in Sources footer; add SC 2.4.12 (AAA Enhanced) reference *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- **2026-05-29** — fix wcag-contrast: pt vs px thresholds + SC 2.4.13 level *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- **2026-05-29** — feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships) *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.25 (Smart Budget Phase 1) *(chore/clud-bug-v0.6.25)* — [decisions-branches/chore__clud-bug-v0.6.25.md](decisions-branches/chore__clud-bug-v0.6.25.md)
-- **2026-05-29** — Fix publisher SKILL.md path in AGENTS.md (gotcha #2) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.23 (adaptive --max-turns) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
-- **2026-05-29** — Fix two CI failures on PR #53: bump logmind workflow pin 0.3.3 → 0.5.6 + fix SKILL.md path overwritten by clud-bug update *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.22 + logmind v0.5.6 (Phase 0.5 propagation §1) *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
-- **2026-05-29** — 0.0.K companion: add applies_to to brand-voice-review, api-contract-enforcement, test-discipline *(chore/applies-to-scoped-skills)* — [decisions-branches/chore__applies-to-scoped-skills.md](decisions-branches/chore__applies-to-scoped-skills.md)
-- **2026-05-29** — Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E) *(chore/token-frugal-tooling-phase-0.5)* — [decisions-branches/chore__token-frugal-tooling-phase-0.5.md](decisions-branches/chore__token-frugal-tooling-phase-0.5.md)
-- **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
-- **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
-- **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
-- **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
-- **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)
-- **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
-- **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
-- **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)
-- **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)
-- **2026-05-27** — fix(notify-clud-bug.yml): pipefail-safe the detect grep (zero-matches no-op) *(fix/notify-clud-bug-pipefail-grep)* — [decisions-branches/fix__notify-clud-bug-pipefail-grep.md](decisions-branches/fix__notify-clud-bug-pipefail-grep.md)
-- **2026-05-27** — chore: add test.yml stub for org ruleset uniformity *(chore/add-test-workflow-stub)* — [decisions-branches/chore__add-test-workflow-stub.md](decisions-branches/chore__add-test-workflow-stub.md)
-- **2026-05-27** — fix: fetch-depth 2→0 + handle first-push zero-ref BEFORE (clud-bug critical) *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
-- **2026-05-27** — feat(notify-clud-bug.yml): add push trigger with matrix strategy over changed baselines *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
-- **2026-05-27** — chore: bump logmind pin 0.3.0 → 0.3.3 *(chore/bump-logmind-pin-0.3.3)* — [decisions-branches/chore__bump-logmind-pin-0.3.3.md](decisions-branches/chore__bump-logmind-pin-0.3.3.md)
-- **2026-05-27** — Rewrite notify-clud-bug.yml as mechanical PR-opener (workflow_dispatch only) *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
-- **2026-05-27** — Add review_mode: shared to all baseline-type skill frontmatters *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
-- **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
-- **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
-- **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
+- *... 28 more decisions ...*
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,33 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05
+## 2026-05 (28 decisions)
 
 - **2026-05-29** — feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships) *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.25 (Smart Budget Phase 1) *(chore/clud-bug-v0.6.25)* — [decisions-branches/chore__clud-bug-v0.6.25.md](decisions-branches/chore__clud-bug-v0.6.25.md)
-- **2026-05-29** — Fix publisher SKILL.md path in AGENTS.md (gotcha #2) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.23 (adaptive --max-turns) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
-- **2026-05-29** — Fix two CI failures on PR #53: bump logmind workflow pin 0.3.3 → 0.5.6 + fix SKILL.md path overwritten by clud-bug update *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.22 + logmind v0.5.6 (Phase 0.5 propagation §1) *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
-- **2026-05-29** — 0.0.K companion: add applies_to to brand-voice-review, api-contract-enforcement, test-discipline *(chore/applies-to-scoped-skills)* — [decisions-branches/chore__applies-to-scoped-skills.md](decisions-branches/chore__applies-to-scoped-skills.md)
-- **2026-05-29** — Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E) *(chore/token-frugal-tooling-phase-0.5)* — [decisions-branches/chore__token-frugal-tooling-phase-0.5.md](decisions-branches/chore__token-frugal-tooling-phase-0.5.md)
-- **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
-- **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
-- **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
-- **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
-- **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)
-- **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
-- **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
-- **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)
-- **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)
-- **2026-05-27** — fix(notify-clud-bug.yml): pipefail-safe the detect grep (zero-matches no-op) *(fix/notify-clud-bug-pipefail-grep)* — [decisions-branches/fix__notify-clud-bug-pipefail-grep.md](decisions-branches/fix__notify-clud-bug-pipefail-grep.md)
-- **2026-05-27** — chore: add test.yml stub for org ruleset uniformity *(chore/add-test-workflow-stub)* — [decisions-branches/chore__add-test-workflow-stub.md](decisions-branches/chore__add-test-workflow-stub.md)
-- **2026-05-27** — fix: fetch-depth 2→0 + handle first-push zero-ref BEFORE (clud-bug critical) *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
-- **2026-05-27** — feat(notify-clud-bug.yml): add push trigger with matrix strategy over changed baselines *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
-- **2026-05-27** — chore: bump logmind pin 0.3.0 → 0.3.3 *(chore/bump-logmind-pin-0.3.3)* — [decisions-branches/chore__bump-logmind-pin-0.3.3.md](decisions-branches/chore__bump-logmind-pin-0.3.3.md)
-- **2026-05-27** — Rewrite notify-clud-bug.yml as mechanical PR-opener (workflow_dispatch only) *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
-- **2026-05-27** — Add review_mode: shared to all baseline-type skill frontmatters *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
-- **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
-- **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
-- **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
+- *... 26 more decisions ...*
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,9 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (28 decisions)
+## 2026-05 (29 decisions)
 
 - **2026-05-29** — fix wcag-contrast: pt vs px thresholds + SC 2.4.13 level *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- **2026-05-29** — feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships) *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- *... 26 more decisions ...*
+- *... 27 more decisions ...*
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,33 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (27 decisions)
+## 2026-05
 
+- **2026-05-29** — feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships) *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
 - **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.25 (Smart Budget Phase 1) *(chore/clud-bug-v0.6.25)* — [decisions-branches/chore__clud-bug-v0.6.25.md](decisions-branches/chore__clud-bug-v0.6.25.md)
-- *... 25 more decisions ...*
+- **2026-05-29** — Fix publisher SKILL.md path in AGENTS.md (gotcha #2) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
+- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.23 (adaptive --max-turns) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
+- **2026-05-29** — Fix two CI failures on PR #53: bump logmind workflow pin 0.3.3 → 0.5.6 + fix SKILL.md path overwritten by clud-bug update *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
+- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.22 + logmind v0.5.6 (Phase 0.5 propagation §1) *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
+- **2026-05-29** — 0.0.K companion: add applies_to to brand-voice-review, api-contract-enforcement, test-discipline *(chore/applies-to-scoped-skills)* — [decisions-branches/chore__applies-to-scoped-skills.md](decisions-branches/chore__applies-to-scoped-skills.md)
+- **2026-05-29** — Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E) *(chore/token-frugal-tooling-phase-0.5)* — [decisions-branches/chore__token-frugal-tooling-phase-0.5.md](decisions-branches/chore__token-frugal-tooling-phase-0.5.md)
+- **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
+- **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
+- **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
+- **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
+- **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)
+- **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
+- **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
+- **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)
+- **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)
+- **2026-05-27** — fix(notify-clud-bug.yml): pipefail-safe the detect grep (zero-matches no-op) *(fix/notify-clud-bug-pipefail-grep)* — [decisions-branches/fix__notify-clud-bug-pipefail-grep.md](decisions-branches/fix__notify-clud-bug-pipefail-grep.md)
+- **2026-05-27** — chore: add test.yml stub for org ruleset uniformity *(chore/add-test-workflow-stub)* — [decisions-branches/chore__add-test-workflow-stub.md](decisions-branches/chore__add-test-workflow-stub.md)
+- **2026-05-27** — fix: fetch-depth 2→0 + handle first-push zero-ref BEFORE (clud-bug critical) *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
+- **2026-05-27** — feat(notify-clud-bug.yml): add push trigger with matrix strategy over changed baselines *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
+- **2026-05-27** — chore: bump logmind pin 0.3.0 → 0.3.3 *(chore/bump-logmind-pin-0.3.3)* — [decisions-branches/chore__bump-logmind-pin-0.3.3.md](decisions-branches/chore__bump-logmind-pin-0.3.3.md)
+- **2026-05-27** — Rewrite notify-clud-bug.yml as mechanical PR-opener (workflow_dispatch only) *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
+- **2026-05-27** — Add review_mode: shared to all baseline-type skill frontmatters *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
+- **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
+- **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
+- **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05 (28 decisions)
 
+- **2026-05-29** — fix wcag-contrast: pt vs px thresholds + SC 2.4.13 level *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
 - **2026-05-29** — feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships) *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
 - *... 26 more decisions ...*
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/skills/apca-contrast/SKILL.md
+++ b/skills/apca-contrast/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: apca-contrast
+description: Use when picking text-on-surface contrast, auditing an accessibility budget, or generating a color against a specific contrast target. Names the APCA Lc target table (Lc 90 fluent body, 75 body minimum, 60 secondary, 45 large, 30 spot, 15 non-text), the APCACH inverse-composition rule, and the cross-check policy with WCAG 2.2 AA. Cite when an agent reaches for WCAG 2.x as the primary contrast model — APCA is the perceptual model UDTS composes against; WCAG is the cross-check.
+---
+
+# APCA contrast
+
+APCA (Accessible Perceptual Contrast Algorithm) is UDTS's primary contrast model. It reports contrast as **Lc** (lightness contrast) on a 0–105+ scale and is perceptually uniform across light and dark modes — unlike WCAG 2.x's luminance-ratio model, which over-reports contrast for dark colors and under-reports for light ones.
+
+## When to use
+
+- Picking a foreground color for a known background at a specific readability target.
+- Auditing a token catalog's contrast budget.
+- Generating a palette ladder where each stop targets a specific Lc band.
+- Code review: flag any contrast pick that uses WCAG 2.x as the primary model instead of as a cross-check.
+
+## When NOT to use
+
+- Free-class tokens (illustration, decorative, brand-spot) that have no pairing obligation. APCA doesn't apply.
+- Single-shot demos or one-off prototypes outside a token catalog where the result won't ship.
+
+## Lc target table
+
+| Lc | Role | Typical use |
+|---|---|---|
+| **90** | Fluent body | Body text intended for long-form reading. Preferred for paragraphs. |
+| **75** | Body minimum | Smallest readable text — ≥ 24 px / 300 wt or ≥ 18 px / 400 wt. |
+| **60** | Secondary content | Callouts, secondary headings, button labels at standard weights. |
+| **45** | Large display | Display headings (32 px+). Quick scanning, not fluent reading. |
+| **30** | Spot-readable | Placeholders, helper text, captions on dim surfaces. Absolute minimum. |
+| **15** | Non-text UI | Dividers, focus rings, borders. Threshold for discernible non-text controls. |
+
+Source: APCA spec at [git.apcacontrast.com](https://git.apcacontrast.com/documentation/README). The table maps directly to UDTS's default 11-stop palette ladder (see [foundations/color.md in token.design / UDTS docs](https://token.design)).
+
+## Use APCACH inverse composition — don't pick a color and test
+
+The default failure mode is **pick L and C, convert to hex, run APCA, eyeball Lc, adjust**. Don't.
+
+UDTS uses the [APCACH](https://github.com/antiflasher/apcach) library, which inverts the APCA problem: declare the target Lc, hue, chroma cap, and background; the library binary-searches for the OKLCH lightness that hits the target. The output is guaranteed to satisfy the contrast obligation within ± 1 Lc — no test-and-adjust loop.
+
+```
+INPUT  target_lc=75, hue=220, chroma_cap=auto, bg=oklch(0.99 0 0)
+OUTPUT oklch(L, c_max, 220) — hits Lc 75 against the near-white surface
+```
+
+## WCAG 2.2 AA cross-check (not primary)
+
+After APCACH composition, also verify WCAG 2.2 AA:
+
+- **4.5:1** for normal text (< 18 px or < 14 px bold)
+- **3:1** for large text (≥ 18 px or ≥ 14 px bold) and non-text UI
+
+UDTS will not emit a contrast-bound token whose Lc satisfies APCA but whose WCAG ratio fails its declared role. Both must pass.
+
+**Why both:** APCA is the better perceptual model but is exploratory at W3C (removed from the WCAG 3.0 Working Draft in 2023). WCAG 2.2 is the operative legal standard until WCAG 3 ships (≥ 2029). Requiring both means UDTS-generated systems pass current audits *and* are forward-compatible.
+
+## Verification
+
+After composing a contrast-bound color:
+
+1. **APCA check:** `apca_contrast(fg, bg) ≈ declared_lc_target` within ± 1 Lc.
+2. **WCAG check:** `wcag_ratio(fg, bg) ≥ declared_role_threshold` (4.5:1 or 3:1).
+3. **Direction check:** UDTS Lc is unsigned and direction-aware; ensure the polarity matches the declared role (light text on dark surface vs dark text on light surface use the same Lc magnitude).
+
+If APCA passes but WCAG fails (or vice versa), reject the value and recompose.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** `oklch-color-space` for the underlying perceptual model and the APCACH library context.
+- **For multi-hue palette generation:** `chroma-harmonization` (the chroma cap at each Lc target is the cross-hue minimum).
+- **For the WCAG side:** `wcag-contrast` for the cross-check thresholds and large-text rules.
+
+## Sources
+
+- [APCA spec and Lc tables](https://git.apcacontrast.com/documentation/README) — the canonical reference.
+- [APCACH library](https://github.com/antiflasher/apcach) — inverse-composition primitive.
+- [Myndex APCA discussion](https://github.com/Myndex/apca-w3) — historical context for WCAG 3 removal.

--- a/skills/chroma-harmonization/SKILL.md
+++ b/skills/chroma-harmonization/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: chroma-harmonization
+description: Use when constructing or auditing a multi-hue palette where all hues should appear equally saturated at each contrast stop. Names the per-stop chroma cap rule (take the minimum achievable chroma across hues at the stop), the sRGB-gamut bottleneck pattern (blue at mid-L is usually the limiter), and the relationship to UDTS's default `harmony` palette variant. Generalizes Evil Martians' Harmony algorithm.
+---
+
+# Chroma harmonization
+
+Multi-hue palettes look unbalanced when one hue is more saturated than the rest at the same brightness stop — a neon outlier in a calm set, a washed-out blue next to a vibrant red. Chroma harmonization is the fix: at each stop, cap every hue at the **lowest-achievable chroma** across the set so the palette reads as a coherent family.
+
+## When to use
+
+- Constructing a multi-hue palette (3+ hues at the same set of contrast stops).
+- Auditing an existing palette where one hue looks "off" against the others.
+- Generating UDTS's default `harmony` palette variant.
+- Code review: flag per-hue chroma values picked independently — propose the cross-hue cap.
+
+## When NOT to use
+
+- Single-hue palettes (no other hues to harmonize against — chroma is unconstrained by the procedure).
+- Brand-spot or accent palettes where one hue *should* dominate. Use the `max` palette variant instead — see `oklch-color-space`.
+- Palettes designed for Display P3 only where the wider gamut changes the bottleneck calculus (the procedure still applies, just with P3 boundaries).
+
+## The algorithm
+
+For each contrast stop in the palette (each L value):
+
+1. For each hue in the set, find the maximum in-gamut chroma at that (L, H) in the target color space (sRGB by default; figma-p3 for wider gamut).
+2. Take the **minimum** of those per-hue maxima. This is the stop's chroma ceiling.
+3. Emit every hue at the stop using that ceiling.
+
+```
+for each stop L:
+  c_max_per_hue = { h: max_chroma_in_gamut(L, h)  for h in hues }
+  c_ceiling = min(c_max_per_hue.values())
+  for each h in hues:
+    emit oklch(L, c_ceiling, h)
+```
+
+The bottleneck pattern: at moderate lightness (L ≈ 0.5), **blue (~220°)** is usually the limiter in sRGB — its gamut is narrowest there. At the extremes (L near 0 or 1) the gamut shrinks for all hues, so the ceiling collapses naturally.
+
+## Why the *minimum*, not the average
+
+Average would push half the hues out of gamut at the bottleneck. Maximum would push the bottleneck hue out of gamut. Minimum is the only value where every hue can hit the target chroma in-gamut — which is the constraint that has to hold for emission.
+
+## Headroom rule
+
+Stay ≥ 10% below the computed ceiling. Rounding from OKLCH to hex, downstream conversions (P3 → sRGB at consumption), and display-driver quirks can push a borderline-in-gamut value out of gamut. A headroom margin prevents those failures.
+
+## Relationship to UDTS palette variants
+
+- **`harmony`** (UDTS default): this algorithm exactly. Every hue capped to the cross-hue minimum.
+- **`max`**: each hue uncapped at its own gamut ceiling. Useful for brand or accent palettes where consistency yields to vibrancy.
+- **`muted`**: harmony or max with an additional user-supplied flat chroma cap (e.g. C ≤ 0.06) — produces tonal greys like sand, stone, slate.
+- **`flat`**: a single chroma across all stops for one hue (no cross-hue constraint).
+- **`grey`**: zero chroma, always generated.
+
+A UDTS catalog can ship multiple variants per hue and bind theme roles to specific (hue, variant) pairs — see the UDTS theme docs.
+
+## Verification
+
+After harmonizing a stop:
+
+1. **Gamut check:** every emitted `oklch(L, c_ceiling, h)` is `displayable()` in the target color space.
+2. **Visual check:** at the same stop, all hues should report identical (or near-identical) saturation in a side-by-side swatch. Use [oklch.com](https://oklch.com) or a culori-based tool.
+3. **Headroom check:** the actual ceiling sits ≥ 10% below the computed sRGB-gamut maximum at every (L, H) in the set.
+
+If any hue clips at the ceiling or visually "pops," recompute with a tighter chroma cap.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** `oklch-color-space` — the OKLCH primitive, the gamut-mapping rule.
+- **For the contrast targets at each stop:** `apca-contrast` — the Lc targets that fix each L value.
+- **For starting-hue palette construction before harmonization:** `palette-relationships`.
+
+## Sources
+
+- [Evil Martians' Harmony](https://evilmartians.com/opensource/harmony) — the original algorithm + interactive demo.
+- [Evil Martians' Harmonizer](https://github.com/evilmartians/harmonizer) — Figma plugin implementation.
+- UDTS's `harmony` palette variant — the canonical productized form of this algorithm.

--- a/skills/oklch-color-space/SKILL.md
+++ b/skills/oklch-color-space/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: oklch-color-space
+description: Use when picking color values for a design-token system, constructing a palette around a starting hue, or generating colors against an accessibility contrast target. Names the OKLCH primitive ranges, the hue-angle naming convention, the gamut-mapping rule for sRGB vs Display P3, and the APCACH inverse-composition approach for guaranteed-contrast color generation. Cite when an agent reaches for "pick a color then check contrast" — the inversion is the load-bearing move.
+---
+
+# OKLCH color space
+
+OKLCH is the canonical perceptual color space for design-token work: L (lightness 0–1), C (chroma 0–~0.4), H (hue 0–360°). Equal numeric deltas in any channel produce equal perceived deltas, unlike HSL. Chroma is independent of lightness, so two stops of a palette can share saturation without sharing brightness.
+
+## When to use
+
+- Picking color values for any token system that will be exported as DTCG, CSS variables, Tailwind, etc.
+- Constructing or auditing a palette around a starting hue.
+- Generating a foreground color that must pair against a known background at a specific APCA Lc target.
+- Reviewing color-picking decisions in code review — flag pick-and-test patterns and propose inverse composition.
+
+## When NOT to use
+
+- Single one-off color picks that aren't entering a token catalog (a marketing landing-page splash, a one-time illustration). The convention overhead isn't earned.
+- Color *spaces* (gradients, interpolation) where the design choice is the interpolation curve, not a fixed value — see the host platform's documentation for `color()` interpolation.
+
+## Primitive ranges and naming
+
+Every OKLCH primitive that lands in a catalog uses the hue-angle naming convention: `<name>-<angle>` (e.g. `red-30`, `teal-180`, `purple-280`). The name is mnemonic; the angle is load-bearing — adding a new hue does not renumber existing ones. Reserve generic accent labels (`accent-teal`, `primary`) for the theme layer above primitives, not the primitives themselves.
+
+| Channel | Range | Notes |
+|---|---|---|
+| L | 0–1 | 0 = pure black, 1 = pure white; UDTS palette stops typically land 0.10–0.99 |
+| C | 0–~0.4 | Theoretical max varies by hue; in sRGB-gamut the practical ceiling is ~0.16–0.20 at moderate L |
+| H | 0–360° | Cyclic; 0 ≈ red, 90 ≈ yellow, 180 ≈ teal/cyan, 270 ≈ blue, 360 = 0 |
+
+## Compose to a contrast target — don't pick L and test
+
+The default failure mode is **pick L and C, convert to hex, run APCA, adjust, repeat**. Don't.
+
+UDTS uses **APCACH inverse composition** (the [APCACH](https://github.com/antiflasher/apcach) library): declare the target Lc, hue, chroma cap, and background; the library binary-searches for the L that hits the target within ± 1 Lc. The output is guaranteed to satisfy the contrast obligation — without a test-and-adjust loop.
+
+```
+INPUT  target_lc=75, hue=220, chroma_cap=auto, bg=oklch(0.99 0 0)
+PROCESS  binary-search L over [0, 1] for apca_contrast(oklch(L, c_max, 220), bg) ≈ 75
+OUTPUT  oklch(L, c_max, 220) — hits Lc 75 against the near-white surface
+```
+
+This applies to every contrast-bound token (text, surface, border, ui). For free-class tokens (illustration, decorative, brand-spot) the contrast obligation doesn't apply — compose freely.
+
+**REQUIRED BACKGROUND:** Use `apca-contrast` for the Lc target table (Lc 90 fluent body, 75 body minimum, 60 secondary, etc.) and the WCAG 2.2 AA cross-check rule.
+
+## Gamut mapping
+
+When emitting hex, gamut-map from OKLCH source into the output color space. For sRGB output, clamp chroma at the gamut boundary at the given (L, H). For Display P3 / figma-p3 output, the gamut is wider; emit the OKLCH value directly when the target supports it, fall back to sRGB clamp otherwise.
+
+Practical rule for picking a chroma cap: stay ≥10% below the sRGB gamut ceiling at your declared (L, H) so rounding errors and downstream conversions don't push the color out of gamut. Use a culori/`displayable()` style check before shipping.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** `apca-contrast` for the Lc target table, when contrast Lc applies, and the WCAG cross-check.
+- **REQUIRED for multi-hue palettes:** `chroma-harmonization` — cap chroma at the lowest-achievable value across all hues at the same stop, so no hue is a neon outlier.
+- **For starting-hue palette construction:** `palette-relationships` — analogous, complementary, triadic, etc., as hue-angle math.
+
+## Verification
+
+After picking an OKLCH value:
+
+1. **Range check:** `0 ≤ L ≤ 1`, `0 ≤ C ≤ 0.4`, `0 ≤ H < 360`.
+2. **Gamut check:** `displayable(oklch(L C H))` returns true for the target color space (sRGB by default).
+3. **Round-trip check:** convert OKLCH → hex → OKLCH; the round-trip delta on L and C should be < 0.01.
+4. **Contrast check (contrast-bound tokens):** APCA Lc against the declared pairing background hits the target ± 1 Lc.
+
+If any of the four fails, fix the value before emitting the token.
+
+## Sources
+
+- [Björn Ottosson's OKLCH spec](https://bottosson.github.io/posts/oklab/) — the math.
+- [APCACH library](https://github.com/antiflasher/apcach) — inverse composition primitive.
+- [oklch.com](https://oklch.com) — interactive picker for sanity-checks.
+- The `apca-contrast` and `chroma-harmonization` skills in this catalog.

--- a/skills/palette-relationships/SKILL.md
+++ b/skills/palette-relationships/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: palette-relationships
+description: Use when proposing a palette around a single seed hue and needing to pick which relationship model (monochromatic / analogous / complementary / split-complementary / triadic / tetradic / compound) fits the brief. Names the hue-angle math for each, when each is appropriate (analogous for restraint; triadic for vibrance; complementary for tension), and the role assignment heuristic.
+---
+
+# Palette relationships
+
+When a designer hands an agent a single starting hue and asks for "the rest of the palette," the choice is which **relationship model** to apply. Each model is a hue-angle pattern with a different emotional and functional register. Knowing the patterns is most of the job.
+
+## When to use
+
+- A designer or agent has a starting hue and needs additional hues to fill a palette.
+- Proposing a palette for a brief that uses words like "balanced," "vibrant," "calm," "tense," "restrained," "dynamic."
+- Reviewing a palette proposal — name the implicit relationship and check whether the brief asked for it.
+
+## When NOT to use
+
+- The palette is already specified (all hues given). Use `chroma-harmonization` to balance them, not this skill.
+- The brief is for a single-hue system (just stops of one palette). No relationship to pick.
+
+## The relationships
+
+Hue angle math is on the OKLCH 0–360° wheel, anchored at the seed hue `H₀`.
+
+| Relationship | Hues | Use when | Hue math |
+|---|---|---|---|
+| **Monochromatic** | 1 | calm, single-brand voice, editorial | `H₀` (vary L and C across stops) |
+| **Analogous** | 2–5 | restrained, coherent, "family" | `H₀ ± 15°`, `H₀ ± 30°` |
+| **Complementary** | 2 | tension, before/after, success/danger pairing | `H₀`, `H₀ + 180°` |
+| **Split-complementary** | 3 | softer tension than complementary, more usable | `H₀`, `H₀ + 150°`, `H₀ + 210°` |
+| **Triadic** | 3 | vibrant, balanced, distinct primary/secondary/tertiary | `H₀`, `H₀ + 120°`, `H₀ + 240°` |
+| **Tetradic — square** | 4 | bold, energetic, four equal roles | `H₀`, `H₀ + 90°`, `H₀ + 180°`, `H₀ + 270°` |
+| **Tetradic — rectangle** | 4 | dynamic but balanced, two complement pairs | `H₀`, `H₀ + 60°`, `H₀ + 180°`, `H₀ + 240°` |
+| **Compound (analogous + complement)** | 3–4 | warm core + cool accent (or vice versa) | `H₀ ± 30°`, `H₀ + 180°` |
+
+For matching briefs to relationships:
+
+- **"calm, monochrome editorial"** → monochromatic
+- **"restrained, family-feel"** → analogous
+- **"tension, success vs danger"** → complementary
+- **"vibrant, distinct roles"** → triadic
+- **"dynamic and balanced"** → tetradic-rectangle (the square is harder to balance at usable chromas)
+- **"warm with one cool accent"** → compound
+
+## Role assignment after picking the relationship
+
+The number of hues dictates the role count, but not the assignment. A triadic palette has three hues; which becomes `primary`, `secondary`, `tertiary` is a design decision driven by intent.
+
+Default heuristic (60/30/10 + accent):
+
+- **60% — primary** = the seed hue (`H₀`). The dominant brand voice.
+- **30% — secondary** = the relationship hue closest to the seed in temperature.
+- **10% — tertiary / accent** = the relationship hue furthest from the seed.
+
+For complementary pairs, the seed is `primary`; the complement is `danger` or `info` depending on hue (warm → danger, cool → info).
+
+## Pitfalls
+
+- **Square tetrads at usable chromas often read garish** — chartreuse (90°) and magenta (270°) next to the seed and its complement tend to fight. Prefer rectangle tetrads (60° / 120° offsets) when the brief is "balanced."
+- **Analogous past 60° total spread starts to read as triadic** — keep analogous ranges tight.
+- **Complementary pairs work for two hues only** — padding to four forces a near-duplicate and breaks the relationship.
+
+## Verification
+
+After picking hues:
+
+1. **Spread check:** every hue is within the relationship's declared offset from the seed.
+2. **Distinguishability check:** at the palette's typical contrast stop (e.g. 500), neighboring hues are visually distinguishable (rule of thumb: ≥ 20° apart at the same L and C).
+3. **Brief match:** the relationship matches the brief's adjective (calm / vibrant / tense / dynamic). If not, pick a different relationship.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** `oklch-color-space` — hues are OKLCH angles; the relationship math operates on those.
+- **For palette balance after picking hues:** `chroma-harmonization` — cap chroma at the cross-hue minimum.
+- **For contrast targets across stops:** `apca-contrast`.
+
+## Sources
+
+- [Adobe Color wheel](https://color.adobe.com/create/color-wheel) — the canonical interactive picker for relationships.
+- [Coolors palette generator](https://coolors.co/) — applies the same relationship taxonomy.
+- Itten's color wheel theory (foundational; predates digital tools but supplies the taxonomy).

--- a/skills/wcag-contrast/SKILL.md
+++ b/skills/wcag-contrast/SKILL.md
@@ -75,5 +75,6 @@ For each contrast-bound pairing:
 
 - [WCAG 2.2 Recommendation — SC 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum) — text contrast.
 - [SC 1.4.11 — non-text contrast](https://www.w3.org/TR/WCAG22/#non-text-contrast).
-- [SC 2.4.13 — focus appearance (AAA, new in 2.2)](https://www.w3.org/TR/WCAG22/#focus-appearance).
+- [SC 2.4.13 — focus appearance (AA, added in 2.2)](https://www.w3.org/TR/WCAG22/#focus-appearance).
+- [SC 2.4.12 — focus not obscured, enhanced (AAA, added in 2.2)](https://www.w3.org/TR/WCAG22/#focus-not-obscured-enhanced).
 - [Contrast Checker, WebAIM](https://webaim.org/resources/contrastchecker/) — sanity-check tool that matches the spec.

--- a/skills/wcag-contrast/SKILL.md
+++ b/skills/wcag-contrast/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: wcag-contrast
+description: Use when verifying a color pair meets WCAG 2.2 AA contrast requirements as a cross-check on APCA-driven generation, or when auditing a token catalog or design for legal-baseline accessibility compliance. Names the 4.5:1 normal-text rule, the 3:1 large-text rule, the size threshold for "large" (≥ 18 px or ≥ 14 px bold), the SC 1.4.11 non-text rule, and the role this check plays alongside APCA. Cite when an agent treats WCAG as the *primary* contrast model — UDTS uses it as a cross-check, with APCA as primary.
+---
+
+# WCAG 2.2 AA contrast
+
+WCAG 2.2 Level AA is the **legal-baseline** contrast standard for most jurisdictions until WCAG 3 ships (≥ 2029). UDTS uses it as a cross-check alongside its primary model, APCA. Every UDTS-emitted contrast-bound token passes both.
+
+## When to use
+
+- Verifying a foreground / background pair after APCA composition.
+- Auditing an existing token catalog or design for legal-baseline compliance.
+- Code review on PRs that change color tokens, hover states, or focus indicators.
+
+## When NOT to use
+
+- As the *primary* contrast model when generating new colors. APCACH inverse composition against an APCA Lc target is the generator; this is the cross-check.
+- For free-class tokens (illustration, decorative, brand-spot) — they carry no pairing obligation. See `apca-contrast` for the class system.
+
+## The rules
+
+| SC | Rule | Threshold | Applies to |
+|---|---|---|---|
+| 1.4.3 | Normal text | **4.5:1** | Text < 18 px regular OR < 14 px bold |
+| 1.4.3 | Large text | **3:1** | Text ≥ 18 px regular OR ≥ 14 px bold |
+| 1.4.11 | Non-text contrast | **3:1** | UI components, focus indicators, graphical objects |
+| 2.4.13 | Focus appearance (AAA only) | Specific minimums | New in 2.2 — verify ring is ≥ 2 px and meets 3:1 |
+
+The bold-text threshold is **14 px bold**, not 18 px bold — a common miss. The 18 px threshold is for regular weight only.
+
+## Computing the ratio
+
+```
+L = 0.2126·R_lin + 0.7152·G_lin + 0.0722·B_lin   (sRGB-linearized)
+ratio = (L_lighter + 0.05) / (L_darker + 0.05)
+```
+
+Always linearize the RGB channels before computing luminance (apply the sRGB gamma reversal: `c <= 0.04045 ? c/12.92 : ((c + 0.055)/1.055)^2.4`). Skipping linearization gives wrong answers — usually undercounting contrast for mid-tones.
+
+For OKLCH-source colors, gamut-map to sRGB first (clamp out-of-gamut chroma at the (L, H) boundary), then apply the formula.
+
+## When WCAG and APCA disagree
+
+WCAG's relative-luminance model over-reports contrast for dark colors and under-reports for very light ones, so APCA and WCAG diverge at the extremes (very dark + very dark, very light + very light, very saturated mid-tones). UDTS finds the safe middle: a token passes only if **both** models pass.
+
+In practice:
+
+- **WCAG passes, APCA fails:** the pairing meets the legal threshold but is *perceptually* hard to read. Reject. (Most common in the dark-on-dark range.)
+- **APCA passes, WCAG fails:** the pairing reads fine perceptually but doesn't meet the legal baseline. Reject. (Most common in the very-light range.)
+- **Both pass:** ship.
+
+## Verification
+
+For each contrast-bound pairing:
+
+1. Compute the WCAG ratio with sRGB-linearized luminance.
+2. Apply the role-appropriate threshold (4.5:1 normal text, 3:1 large text or non-text).
+3. Confirm the bold-text size rule — 14 px bold counts as large; 14 px regular does not.
+4. Cross-check the APCA Lc (see `apca-contrast`).
+5. Reject if either model fails.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** `apca-contrast` — the primary contrast model. WCAG is the cross-check; APCA is the generator target.
+- **For the underlying color space:** `oklch-color-space` — OKLCH source values must be gamut-mapped to sRGB before applying the WCAG formula.
+
+## Sources
+
+- [WCAG 2.2 Recommendation — SC 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum) — text contrast.
+- [SC 1.4.11 — non-text contrast](https://www.w3.org/TR/WCAG22/#non-text-contrast).
+- [SC 2.4.13 — focus appearance (AAA, new in 2.2)](https://www.w3.org/TR/WCAG22/#focus-appearance).
+- [Contrast Checker, WebAIM](https://webaim.org/resources/contrastchecker/) — sanity-check tool that matches the spec.

--- a/skills/wcag-contrast/SKILL.md
+++ b/skills/wcag-contrast/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wcag-contrast
-description: Use when verifying a color pair meets WCAG 2.2 AA contrast requirements as a cross-check on APCA-driven generation, or when auditing a token catalog or design for legal-baseline accessibility compliance. Names the 4.5:1 normal-text rule, the 3:1 large-text rule, the size threshold for "large" (≥ 18 px or ≥ 14 px bold), the SC 1.4.11 non-text rule, and the role this check plays alongside APCA. Cite when an agent treats WCAG as the *primary* contrast model — UDTS uses it as a cross-check, with APCA as primary.
+description: Use when verifying a color pair meets WCAG 2.2 AA contrast requirements as a cross-check on APCA-driven generation, or when auditing a token catalog or design for legal-baseline accessibility compliance. Names the 4.5:1 normal-text rule, the 3:1 large-text rule, the size threshold for "large" stated in points (≥ 18 pt regular ≈ 24 CSS px, OR ≥ 14 pt bold ≈ 18.67 CSS px — not pixels), the SC 1.4.11 non-text rule, SC 2.4.13 focus appearance (AA in 2.2), and the role this check plays alongside APCA. Cite when an agent treats WCAG as the *primary* contrast model, or writes the large-text threshold as "14 px bold / 18 px regular" — UDTS uses WCAG as a cross-check with APCA as primary, and WCAG sizes are in points.
 ---
 
 # WCAG 2.2 AA contrast
@@ -20,14 +20,20 @@ WCAG 2.2 Level AA is the **legal-baseline** contrast standard for most jurisdict
 
 ## The rules
 
-| SC | Rule | Threshold | Applies to |
-|---|---|---|---|
-| 1.4.3 | Normal text | **4.5:1** | Text < 18 px regular OR < 14 px bold |
-| 1.4.3 | Large text | **3:1** | Text ≥ 18 px regular OR ≥ 14 px bold |
-| 1.4.11 | Non-text contrast | **3:1** | UI components, focus indicators, graphical objects |
-| 2.4.13 | Focus appearance (AAA only) | Specific minimums | New in 2.2 — verify ring is ≥ 2 px and meets 3:1 |
+| SC | Level | Rule | Threshold | Applies to |
+|---|---|---|---|---|
+| 1.4.3 | AA | Normal text | **4.5:1** | Text < 18 pt (24 CSS px) regular OR < 14 pt (~18.67 CSS px) bold |
+| 1.4.3 | AA | Large text | **3:1** | Text ≥ 18 pt (24 CSS px) regular OR ≥ 14 pt (~18.67 CSS px) bold |
+| 1.4.11 | AA | Non-text contrast | **3:1** | UI components, focus indicators, graphical objects |
+| 2.4.13 | **AA** (added in 2.2) | Focus appearance | Specific minimums | Verify the focus indicator is ≥ 2 px and meets 3:1 contrast against the focused control and adjacent background |
+| 2.4.12 | AAA (added in 2.2) | Focus not obscured (enhanced) | n/a | Focus indicator must not be obscured by author content |
 
-The bold-text threshold is **14 px bold**, not 18 px bold — a common miss. The 18 px threshold is for regular weight only.
+**WCAG sizes are in points, not pixels** — a frequent miss. 1 pt = 1.333 CSS px, so:
+
+- 18 pt regular = **24 CSS px** (not 18 px)
+- 14 pt bold = **~18.67 CSS px** (not 14 px)
+
+Text at 16 CSS px is *not* "large" even when bold; it falls under the 4.5:1 normal-text rule.
 
 ## Computing the ratio
 
@@ -56,7 +62,7 @@ For each contrast-bound pairing:
 
 1. Compute the WCAG ratio with sRGB-linearized luminance.
 2. Apply the role-appropriate threshold (4.5:1 normal text, 3:1 large text or non-text).
-3. Confirm the bold-text size rule — 14 px bold counts as large; 14 px regular does not.
+3. Confirm the bold-text size rule in **points** — 14 pt bold (~18.67 CSS px) counts as large; 14 CSS px bold does not. Same for 18 pt regular (= 24 CSS px), not 18 CSS px.
 4. Cross-check the APCA Lc (see `apca-contrast`).
 5. Reject if either model fails.
 


### PR DESCRIPTION
## Summary

**Phase C / PR-C1** of the UDTS / token.design skills rollout, per the [tokenomics plan](https://github.com/thrillmade/tokenomics/blob/main/docs/skills/inventory.md). Five reusable design-system skills covering the color algorithms UDTS standardizes. Each skill is portable — any project doing color work can install it via `npx skills add` regardless of whether it uses Tokenomics.

| Skill | Trigger | Sources |
|---|---|---|
| `oklch-color-space` | Picking color values for a token system, palette construction, contrast-targeted generation | OKLCH spec (Björn Ottosson), APCACH library, oklch.com |
| `apca-contrast` | Picking text-on-surface contrast, auditing accessibility budget, generating against an Lc target | APCA spec, APCACH library, Myndex APCA discussion |
| `wcag-contrast` | Verifying a color pair meets WCAG 2.2 AA as a cross-check (NOT primary) | WCAG 2.2 SC 1.4.3 / 1.4.11 / 2.4.13 |
| `chroma-harmonization` | Multi-hue palette where all hues should appear equally saturated per stop | Evil Martians' Harmony + Harmonizer |
| `palette-relationships` | Proposing a palette around a single seed hue (analogous / complementary / triadic / tetradic / etc.) | Adobe Color, Coolors, Itten color theory |

### Authoring discipline

Each skill went through the `superpowers:writing-skills` RED-GREEN-REFACTOR loop:

- **RED:** baseline subagent ran a representative task without the skill loaded. Observed gaps (per skill): default to WCAG over APCA; pick-and-test instead of inverse composition; Tailwind/Radix semantic names instead of UDTS hue-angle naming; reinvent chroma harmonization without citing Evil Martians; tetradic-square/rectangle distinction made but not codified.
- **GREEN:** each `SKILL.md` addresses the observed gaps with concrete procedures + tables + verification steps.
- **REFACTOR:** cross-references between siblings (`REQUIRED BACKGROUND:` phrasing per writing-skills convention; no `@`-loads); word counts kept inside the technique-skill envelope.

### Cross-reference graph

```
oklch-color-space  ←  apca-contrast (primary contrast model)
                  ←  wcag-contrast (cross-check)
                  ←  chroma-harmonization (gamut/chroma rules)
                  ←  palette-relationships (hue angles)

apca-contrast     ↔  wcag-contrast (primary + cross-check)
chroma-harmonization  →  oklch + apca + palette-relationships
```

### Out of scope (later Phase C PRs)

- Typography skills (PR-C2): `type-scale`, `line-height-grid`
- Spacing skills (PR-C3): `spacing-system`, `component-sizing`
- Token-format skills (PR-C4): `design-token-naming`, `dtcg-format`, `semver-design-tokens`
- Design-review skill (PR-C5): `web-interface-guidelines-review`

## Test plan

- [ ] All checks green (`check-decisions`, `check-derived-docs`, `check-doc-links`, `validate-skills`, `test`, `clud-bug-review`)
- [ ] `validate-skills` confirms each SKILL.md has well-formed frontmatter
- [ ] Cross-references between the 5 new skills resolve internally (no `@`-links, all `REQUIRED BACKGROUND:` references name a sibling skill that exists in this PR)
- [ ] No skill exceeds the technique-skill envelope (~800 words/body)