### PR TITLE
feat: typography skills (type-scale, line-height-grid)

### DIFF
--- a/docs/decisions-branches/skills__typography.md
+++ b/docs/decisions-branches/skills__typography.md
@@ -1,0 +1,10 @@
+## 2026-05-29 23:24 - feat: PR-C2 typography skills (type-scale, line-height-grid)
+
+**Reasoning:** Phase C / PR-C2 of the UDTS / token.design rollout. Each skill encodes one typography algorithm from the foundations/typography.md spec. type-scale codifies the canonical preset ratios (1.067–1.618), the −2 to +8 stops range, the rounding rule (round px first, derive rem from rounded value), and the 1.5 upper bound for product UI. line-height-grid codifies the two-track model (lh-ui = ceil(font × 1.20) + snap; lh-prose = ceil(font × 1.50) + snap) with worked examples for 4/8, 2/4, 4/16 grids
+
+**Alternatives considered:** ship typography as a single mega-skill — rejected, type-scale and line-height-grid have different triggers (designing the scale vs picking line-heights for an existing scale); separating lets agents load only what they need
+
+**Implications:**
+- 2 new SKILL.md files under skills/. Baselines run: type-scale baseline picked 1.200 reasonably but didn't codify the full preset table or the rounding-first-then-derive-rem rule; line-height-grid baseline picked sensible ranges (1.10–1.25 ui, 1.45–1.55 prose) but UDTS specifies exactly 1.20 / 1.50. Skills cross-reference each other and back to oklch-color-space (none — typography is orthogonal to color) and forward to spacing-system (PR-C3 dependency on minor-unit). After PR-C2 merges, PR-C3 (spacing) becomes unblocked.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -25,6 +25,7 @@ agent-skills
 │   ├── clud-bug-collaboration
 │   ├── critical-issues-only
 │   ├── evidence-based-review
+│   ├── line-height-grid
 │   ├── logmind
 │   ├── oklch-color-space
 │   ├── palette-relationships
@@ -33,6 +34,7 @@ agent-skills
 │   ├── skill-frontmatter-quality
 │   ├── test-discipline
 │   ├── token-frugal-tooling
+│   ├── type-scale
 │   └── wcag-contrast
 ├── .cursorrules
 ├── .gitattributes

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,36 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05
+## 2026-05 (31 decisions)
 
 - **2026-05-29** — feat: PR-C2 typography skills (type-scale, line-height-grid) *(skills/typography)* — [decisions-branches/skills__typography.md](decisions-branches/skills__typography.md)
-- **2026-05-29** — fix: stale SC 2.4.13 (AAA) label in Sources footer; add SC 2.4.12 (AAA Enhanced) reference *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- **2026-05-29** — fix wcag-contrast: pt vs px thresholds + SC 2.4.13 level *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- **2026-05-29** — feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships) *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.25 (Smart Budget Phase 1) *(chore/clud-bug-v0.6.25)* — [decisions-branches/chore__clud-bug-v0.6.25.md](decisions-branches/chore__clud-bug-v0.6.25.md)
-- **2026-05-29** — Fix publisher SKILL.md path in AGENTS.md (gotcha #2) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.23 (adaptive --max-turns) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
-- **2026-05-29** — Fix two CI failures on PR #53: bump logmind workflow pin 0.3.3 → 0.5.6 + fix SKILL.md path overwritten by clud-bug update *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
-- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.22 + logmind v0.5.6 (Phase 0.5 propagation §1) *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
-- **2026-05-29** — 0.0.K companion: add applies_to to brand-voice-review, api-contract-enforcement, test-discipline *(chore/applies-to-scoped-skills)* — [decisions-branches/chore__applies-to-scoped-skills.md](decisions-branches/chore__applies-to-scoped-skills.md)
-- **2026-05-29** — Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E) *(chore/token-frugal-tooling-phase-0.5)* — [decisions-branches/chore__token-frugal-tooling-phase-0.5.md](decisions-branches/chore__token-frugal-tooling-phase-0.5.md)
-- **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
-- **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
-- **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
-- **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
-- **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)
-- **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
-- **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
-- **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)
-- **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)
-- **2026-05-27** — fix(notify-clud-bug.yml): pipefail-safe the detect grep (zero-matches no-op) *(fix/notify-clud-bug-pipefail-grep)* — [decisions-branches/fix__notify-clud-bug-pipefail-grep.md](decisions-branches/fix__notify-clud-bug-pipefail-grep.md)
-- **2026-05-27** — chore: add test.yml stub for org ruleset uniformity *(chore/add-test-workflow-stub)* — [decisions-branches/chore__add-test-workflow-stub.md](decisions-branches/chore__add-test-workflow-stub.md)
-- **2026-05-27** — fix: fetch-depth 2→0 + handle first-push zero-ref BEFORE (clud-bug critical) *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
-- **2026-05-27** — feat(notify-clud-bug.yml): add push trigger with matrix strategy over changed baselines *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
-- **2026-05-27** — chore: bump logmind pin 0.3.0 → 0.3.3 *(chore/bump-logmind-pin-0.3.3)* — [decisions-branches/chore__bump-logmind-pin-0.3.3.md](decisions-branches/chore__bump-logmind-pin-0.3.3.md)
-- **2026-05-27** — Rewrite notify-clud-bug.yml as mechanical PR-opener (workflow_dispatch only) *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
-- **2026-05-27** — Add review_mode: shared to all baseline-type skill frontmatters *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
-- **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
-- **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
-- **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
+- *... 29 more decisions ...*
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,36 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (30 decisions)
+## 2026-05
 
+- **2026-05-29** — feat: PR-C2 typography skills (type-scale, line-height-grid) *(skills/typography)* — [decisions-branches/skills__typography.md](decisions-branches/skills__typography.md)
 - **2026-05-29** — fix: stale SC 2.4.13 (AAA) label in Sources footer; add SC 2.4.12 (AAA Enhanced) reference *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
-- *... 28 more decisions ...*
+- **2026-05-29** — fix wcag-contrast: pt vs px thresholds + SC 2.4.13 level *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
+- **2026-05-29** — feat: PR-C1 color algorithm skills (oklch-color-space, apca-contrast, wcag-contrast, chroma-harmonization, palette-relationships) *(skills/color-algorithms)* — [decisions-branches/skills__color-algorithms.md](decisions-branches/skills__color-algorithms.md)
+- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.25 (Smart Budget Phase 1) *(chore/clud-bug-v0.6.25)* — [decisions-branches/chore__clud-bug-v0.6.25.md](decisions-branches/chore__clud-bug-v0.6.25.md)
+- **2026-05-29** — Fix publisher SKILL.md path in AGENTS.md (gotcha #2) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
+- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.23 (adaptive --max-turns) *(chore/clud-bug-v0.6.23)* — [decisions-branches/chore__clud-bug-v0.6.23.md](decisions-branches/chore__clud-bug-v0.6.23.md)
+- **2026-05-29** — Fix two CI failures on PR #53: bump logmind workflow pin 0.3.3 → 0.5.6 + fix SKILL.md path overwritten by clud-bug update *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
+- **2026-05-29** — Upgrade agent-skills to clud-bug v0.6.22 + logmind v0.5.6 (Phase 0.5 propagation §1) *(chore/clud-bug-v0.6.22-+-logmind-v0.5.6)* — [decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md](decisions-branches/chore__clud-bug-v0.6.22-+-logmind-v0.5.6.md)
+- **2026-05-29** — 0.0.K companion: add applies_to to brand-voice-review, api-contract-enforcement, test-discipline *(chore/applies-to-scoped-skills)* — [decisions-branches/chore__applies-to-scoped-skills.md](decisions-branches/chore__applies-to-scoped-skills.md)
+- **2026-05-29** — Update token-frugal-tooling skill with Phase 0.5 patterns (0.0.T, 0.0.W, 0.0.R, 0.0.X, 0.0.E) *(chore/token-frugal-tooling-phase-0.5)* — [decisions-branches/chore__token-frugal-tooling-phase-0.5.md](decisions-branches/chore__token-frugal-tooling-phase-0.5.md)
+- **2026-05-29** — chore: add @AGENTS.md import to CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
+- **2026-05-28** — chore: clud-bug v0.5.16 → v0.6.12 (Sonnet pin, caching, budgets, brief CLI, incremental-diff, AGENTS trim, self-update YAML fix) *(chore/clud-bug-update-v0.6.12)* — [decisions-branches/chore__clud-bug-update-v0.6.12.md](decisions-branches/chore__clud-bug-update-v0.6.12.md)
+- **2026-05-28** — PR #46: regen derived docs after merge with main *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
+- **2026-05-28** — new token-frugal-tooling meta-skill (links logmind + clud-bug-collaboration; quick-reference) *(feat/token-frugal-tooling-skill)* — [decisions-branches/feat__token-frugal-tooling-skill.md](decisions-branches/feat__token-frugal-tooling-skill.md)
+- **2026-05-28** — clud-bug-collaboration skill update: cover v0.6.3–v0.6.11 cost-control wiring + CLUD_BUG_QUIET + new comment format *(feat/clud-bug-collab-v0.6-skill-update)* — [decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md](decisions-branches/feat__clud-bug-collab-v0.6-skill-update.md)
+- **2026-05-28** — logmind skill update: cover v0.5.0–v0.5.4 features (file-structure depth-2, quiet/ok, show flags, timeline brief) *(feat/logmind-v0.5-skill-update)* — [decisions-branches/feat__logmind-v0.5-skill-update.md](decisions-branches/feat__logmind-v0.5-skill-update.md)
+- **2026-05-27** — chore: regen docs/file-structure.md (post-PR#37 staleness) *(chore/regen-fs-post-pr37)* — [decisions-branches/chore__regen-fs-post-pr37.md](decisions-branches/chore__regen-fs-post-pr37.md)
+- **2026-05-27** — Add skill-frontmatter-quality + exclude clud-bug-collaboration from this repo's clud-bug baseline *(chore/curated-clud-bug-baseline)* — [decisions-branches/chore__curated-clud-bug-baseline.md](decisions-branches/chore__curated-clud-bug-baseline.md)
+- **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)
+- **2026-05-27** — fix(notify-clud-bug.yml): pipefail-safe the detect grep (zero-matches no-op) *(fix/notify-clud-bug-pipefail-grep)* — [decisions-branches/fix__notify-clud-bug-pipefail-grep.md](decisions-branches/fix__notify-clud-bug-pipefail-grep.md)
+- **2026-05-27** — chore: add test.yml stub for org ruleset uniformity *(chore/add-test-workflow-stub)* — [decisions-branches/chore__add-test-workflow-stub.md](decisions-branches/chore__add-test-workflow-stub.md)
+- **2026-05-27** — fix: fetch-depth 2→0 + handle first-push zero-ref BEFORE (clud-bug critical) *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
+- **2026-05-27** — feat(notify-clud-bug.yml): add push trigger with matrix strategy over changed baselines *(feat/notify-clud-bug-push-trigger)* — [decisions-branches/feat__notify-clud-bug-push-trigger.md](decisions-branches/feat__notify-clud-bug-push-trigger.md)
+- **2026-05-27** — chore: bump logmind pin 0.3.0 → 0.3.3 *(chore/bump-logmind-pin-0.3.3)* — [decisions-branches/chore__bump-logmind-pin-0.3.3.md](decisions-branches/chore__bump-logmind-pin-0.3.3.md)
+- **2026-05-27** — Rewrite notify-clud-bug.yml as mechanical PR-opener (workflow_dispatch only) *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
+- **2026-05-27** — Add review_mode: shared to all baseline-type skill frontmatters *(feat/skill-review-mode)* — [decisions-branches/feat__skill-review-mode.md](decisions-branches/feat__skill-review-mode.md)
+- **2026-05-27** — Add .github/dependabot.yml for github-actions ecosystem only *(chore/dependabot)* — [decisions-branches/chore__dependabot.md](decisions-branches/chore__dependabot.md)
+- **2026-05-27** — Document logmind v0.3.0 merge-driver surface in skills/logmind/SKILL.md *(docs/logmind-v0.3.0)* — [decisions-branches/docs__logmind-v0.3.0.md](decisions-branches/docs__logmind-v0.3.0.md)
+- **2026-05-26** — chore: migrate to thrillmade org + install logmind v0.3.0 + clud-bug *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)

--- a/skills/line-height-grid/SKILL.md
+++ b/skills/line-height-grid/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: line-height-grid
+description: Use when calculating line-height for any font size in a grid-aligned design system. Names the two-track model (lh-ui = ceil(font × 1.20) snapped to the minor unit; lh-prose = ceil(font × 1.50) snapped to the minor unit), the picking heuristic per role (ui-track for headings / buttons / labels; prose-track for paragraph body), and worked examples for 4/8, 2/4, and 4/16 grids. Cite when an agent picks a unitless line-height multiplier without snapping to the system's grid.
+---
+
+# Line-height grid
+
+Line-height in a token-driven system is not a free multiplier — it's a snapped value on the spacing grid. UDTS uses two tracks: `lh-ui` (tight, for headings / labels / buttons) and `lh-prose` (loose, for paragraph body). Both derive from the font size and snap to the minor grid unit so adjacent paragraphs and successive lines preserve rhythm.
+
+## When to use
+
+- Picking line-height for any font size in a system that has a defined spacing grid.
+- Auditing line-heights that "look right but feel off" — usually a sign they're not snapped.
+- Setting up a foundation theme that needs both UI and editorial copy on the same grid.
+- Code review: flag any unitless line-height (`line-height: 1.5`) on a system token; replace with a snapped px value from the appropriate track.
+
+## When NOT to use
+
+- One-off display elements (hero marketing splashes) where the line-height is hand-tuned by a typographer and the grid doesn't apply.
+- Inline contexts where line-height inherits from the parent — the parent owns the grid alignment.
+
+## The two-track formulas
+
+```
+lh-ui(size)    = ceil(size × 1.20) snapped UP to nearest minor-unit multiple
+lh-prose(size) = ceil(size × 1.50) snapped UP to nearest minor-unit multiple
+```
+
+The ratios are intentional:
+
+- **1.20 for UI**: keeps headings, button labels, and control text tight enough that they don't take excess vertical space in dense layouts. Tighter than 1.20 starts clipping diacritics on large sizes.
+- **1.50 for prose**: matches the canonical typographic recommendation for fluent paragraph reading. Looser than 1.50 starts feeling spaced-out; tighter than 1.45 fatigues the eye.
+
+The `ceil` step ensures the line-height is never *less* than the natural typographic ratio; the snap step puts it on the grid for downstream rhythm.
+
+## When to use which track
+
+| Role | Track | Why |
+|---|---|---|
+| Body paragraphs (long-form reading) | `prose` | Fluent reading requires 1.5× space |
+| Lead paragraphs | `prose` | Same as body |
+| Headings (display through H6) | `ui` | Tight space; headings stand on their own line |
+| Button labels, link text, navigation | `ui` | Dense, single-line; no fluent-reading constraint |
+| Form labels, helper text | `ui` | Compact |
+| Code blocks | `ui` (or `code-tight` variant) | Code rows shouldn't have paragraph-style breathing room |
+| Captions, metadata | `ui` | Compact |
+
+When in doubt, ask: "is the user going to read multiple consecutive lines fluently?" If yes, `prose`; if no, `ui`.
+
+## Worked examples
+
+**14 px font, 4/8 grid (minor unit = 4, major = 8):**
+
+```
+lh-ui    = ceil(14 × 1.20) = ceil(16.8) = 17 → snap up to 20 (next multiple of 4)
+lh-prose = ceil(14 × 1.50) = ceil(21.0) = 21 → snap up to 24 (next multiple of 4)
+```
+
+**16 px font, 4/8 grid:**
+
+```
+lh-ui    = ceil(16 × 1.20) = ceil(19.2) = 20 → snap up to 20 (already on grid)
+lh-prose = ceil(16 × 1.50) = ceil(24.0) = 24 → snap up to 24 (already on grid)
+```
+
+**14 px font, 2/4 grid (denser; minor = 2, major = 4):**
+
+```
+lh-ui    = ceil(14 × 1.20) = ceil(16.8) = 17 → snap up to 18 (next multiple of 2)
+lh-prose = ceil(14 × 1.50) = ceil(21.0) = 21 → snap up to 22 (next multiple of 2)
+```
+
+**24 px font, 4/16 grid (spacious; minor = 4, major = 16):**
+
+```
+lh-ui    = ceil(24 × 1.20) = ceil(28.8) = 29 → snap up to 32 (next multiple of 4)
+lh-prose = ceil(24 × 1.50) = ceil(36.0) = 36 → snap up to 36 (already on grid)
+```
+
+## Why "ceil then snap," not "snap to nearest"
+
+Rounding down can put the resolved line-height *below* the natural ratio, which produces:
+
+- Diacritic clipping on larger sizes.
+- Visually cramped paragraphs in the prose track.
+- Inconsistent rhythm — sometimes you snap up, sometimes down, breaking baseline alignment.
+
+`ceil` + snap-up is monotonic: line-height is always at least the ratio-derived value, and always on the grid.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** `type-scale` — provides the font sizes this skill snaps line-heights for. The two skills are paired.
+- **For the unit primitive that drives snapping:** `spacing-system` — the minor / major grid is what `snap up to nearest minor-unit multiple` refers to.
+
+## Verification
+
+After computing line-heights:
+
+1. **Grid check:** every lh value is a multiple of the minor unit.
+2. **Ratio floor:** `lh(font) ≥ ceil(font × ratio)` for both tracks. Never below.
+3. **Monotonicity:** lh values grow with font size (no decreases between adjacent steps).
+4. **Track separation:** at every font size, `lh-prose > lh-ui` (or equal at very small sizes where they collapse).
+5. **Multi-line stack check:** stack two paragraphs at the prose track. The total height = `(lines × lh) + paragraph-margin` lands on the major grid.
+
+If any check fails, recompute with stricter ceiling + snap-up.
+
+## Sources
+
+- The UDTS / token.design typography foundations spec.
+- Classical typography (Bringhurst, *The Elements of Typographic Style*) — the 1.5× rule for prose pre-dates digital systems.
+- [CSS line-height: where things go wrong](https://hacks.mozilla.org/2024/06/css-line-height/) — modern browser handling caveats.

--- a/skills/type-scale/SKILL.md
+++ b/skills/type-scale/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: type-scale
+description: Use when designing, auditing, or extending a typography size scale built on a modular ratio. Names the canonical preset ratios (1.067 minor second → 1.618 golden), the picking heuristic by context (UI vs editorial vs marketing), the stops-up / stops-down convention (−2 to +8 default), the rounding rule (round to nearest integer px, rem derived after), and the upper-bound on ratios for product UI. Cite when an agent proposes a ratio above 1.5 for a product system or hand-picks scale steps outside a modular ratio.
+---
+
+# Type scale
+
+A modular type scale derives every font size from a single ratio applied to a base size. The discipline is choosing the ratio for the system's *typical* surface — UI density, editorial reading, marketing impact — then committing to it across the whole scale rather than per-role.
+
+## When to use
+
+- Designing a new typography scale from a base font size and a context (product UI / editorial / marketing).
+- Auditing an existing scale where sizes feel off-rhythm or step gaps look inconsistent.
+- Extending a scale up or down (e.g. adding a display rung above the existing max).
+- Code review: flag hand-picked sizes outside a modular ratio, ratios above 1.5 in product systems, or rems-as-source-of-truth (always derive rem from rounded px, not the other way around).
+
+## When NOT to use
+
+- Editorial-only books / long-form prose where the ratio is a typographer's pick and a modular scale would over-constrain. The discipline still applies to documenting the choices, not to forcing a ratio.
+- Single-size systems (rare; usually a stopgap during initial system definition).
+
+## Canonical preset ratios
+
+| Ratio | Name | Best for |
+|---|---|---|
+| 1.067 | Minor second | Very dense UI; gaps so small that most stops feel near-identical |
+| 1.125 | Major second | Dense UI (admin consoles, data-heavy tools); subtle hierarchy |
+| 1.200 | Minor third | **Default for product UI** — balanced, readable, distinct headings |
+| 1.250 | Major third | Slightly more dramatic UI; comfortable for mixed product + marketing |
+| 1.333 | Perfect fourth | Editorial leaning; large gap between body and H1 |
+| 1.414 | Augmented fourth | Editorial; sharp hierarchy |
+| 1.500 | Perfect fifth | Marketing-leaning; aggressive but still usable |
+| 1.618 | Golden | Hero / display only; ratios above ~1.5 break down for product UI because step gaps grow too fast |
+
+**Upper bound:** ratios above 1.5 rarely work for product UI — by step +5 the size is huge, and H4/H5 stop feeling distinct from body. Reserve 1.5 / 1.618 for editorial or marketing systems.
+
+## Stops-up / stops-down
+
+UDTS's default range is **step −2 to step +8**. Step 0 is the base size.
+
+```
+size(n) = round(base × ratio^n)
+rem(n)  = size(n) / 16
+```
+
+Typical role mapping for a 16 px base, 1.200 ratio:
+
+| Step | px | rem | Typical role |
+|---|---|---|---|
+| −2 | 11 | 0.6875 | Micro, legal, fine print |
+| −1 | 13 | 0.8125 | Small UI, metadata |
+| 0  | 16 | 1.0000 | Body, base |
+| +1 | 19 | 1.1875 | Lead paragraph, H5 |
+| +2 | 23 | 1.4375 | H4 |
+| +3 | 28 | 1.7500 | H3 |
+| +4 | 33 | 2.0625 | H2 |
+| +5 | 40 | 2.5000 | H1 |
+| +6 | 48 | 3.0000 | Display |
+| +7 | 57 | 3.5625 | Hero |
+| +8 | 69 | 4.3125 | Marketing splash |
+
+The range is generous so a single scale spans dense UI through marketing without per-surface forking.
+
+## Rounding rules
+
+UDTS rounds font sizes by default:
+
+1. Compute the raw size: `base × ratio^n`.
+2. Round to the **nearest integer px**. Sub-pixel sizes render inconsistently across browsers and OS hinting.
+3. If two adjacent steps would round to the same px, bump the larger one up by 1 px to preserve monotonic spacing.
+4. Derive rem **from the rounded px**, not from the raw value. `rem = rounded_px / 16`. The other direction (round the rem) compounds with the px round and produces drift.
+
+Rounding can be disabled for math-pure systems where fractional sizes are tolerated downstream. Document the choice if you turn it off.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** `line-height-grid` — every size in the scale needs a line-height; the lh-ui (× 1.20) / lh-prose (× 1.50) tracks pair with this scale.
+- **For role assignment after picking sizes:** the typography-styles spec (compound tokens combining size + lh + tracking + weight + paragraph margin).
+- **For the base size choice:** UDTS bases default to 16 px; smaller bases (14 px) are valid for dense product UI but require revisiting line-heights and tap targets.
+
+## Verification
+
+After picking a ratio and emitting the scale:
+
+1. **Monotonicity:** every step is strictly larger than the previous; no two adjacent steps share a px value after rounding.
+2. **Round-trip:** `rem(n) × 16 = px(n)` exactly (no drift from re-rounding).
+3. **Distinguishability at small sizes:** −1 and −2 are visually distinct (a ratio + base combo where they round to the same px is broken; pick a tighter ratio or larger base).
+4. **Upper-bound sanity:** if the +5 step is unusable for headings in your system, the ratio is too aggressive; drop to a tighter preset.
+
+## Sources
+
+- [Modular Scale by Tim Brown](https://www.modularscale.com/) — interactive picker for the canonical ratios.
+- [Type Scale](https://typescale.com/) — same idea with live preview.
+- The UDTS / token.design typography foundations spec.


### PR DESCRIPTION
## Summary

**Phase C / PR-C2** of the UDTS / token.design skills rollout. Two reusable typography skills covering the modular-scale derivation and the two-track line-height grid model UDTS standardizes.

| Skill | Trigger | Codifies |
|---|---|---|
| `type-scale` | Designing or auditing a typography size scale around a base + ratio | Preset ratio table (1.067 → 1.618), −2/+8 stops range, integer-px rounding, rem-derived-from-rounded-px rule, 1.5 upper-bound for product UI |
| `line-height-grid` | Picking line-height for any font size in a grid-aligned system | Two tracks: `lh-ui = ceil(font × 1.20)` snap-up; `lh-prose = ceil(font × 1.50)` snap-up. Worked examples for 4/8, 2/4, 4/16 grids |

### Authoring discipline

Each went through `superpowers:writing-skills` RED-GREEN-REFACTOR:

- **RED:** baseline subagents picked 1.200 / 1.10–1.25 / 1.45–1.55 — reasonable defaults, but didn't codify the canonical preset table, the rems-from-rounded-px rule, or UDTS's specific 1.20 / 1.50 line-height ratios.
- **GREEN:** each SKILL.md fills the gaps with concrete preset tables, exact formulas, and worked examples spanning multiple grid systems.
- **REFACTOR:** cross-references between the two skills + forward reference to `spacing-system` (PR-C3 dependency on minor-unit).

### Cross-reference graph

```
type-scale  ↔  line-height-grid (paired — every size needs an lh)
line-height-grid  →  spacing-system (PR-C3 — minor-unit drives the snap)
```

No cross-references back to PR-C1 (color); typography is orthogonal to color in UDTS.

## Test plan

- [ ] All required checks green
- [ ] `validate skills` confirms well-formed frontmatter
- [ ] No skill exceeds technique-skill envelope (~1000 words)
- [ ] Cross-refs to `spacing-system` are stated as forward references (skill ships in PR-C3) — not broken claims