### PR TITLE
logmind v0.5.8 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.8.md
+++ b/.skill-update-todo/v0.5.8.md
@@ -1,0 +1,54 @@
+# logmind v0.5.8 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.8/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.8
+
+## Claude's reasoning
+
+The CHANGELOG for v0.5.8 changes the behavior of `logmind log` on feature branches: previously it skipped regenerating `docs/file-structure.md` on feature branches, but now it regenerates it on every branch (same as `timeline.md`). The SKILL.md currently explicitly documents the old behavior in step 3 of "What `logmind log` does automatically": "Regenerates `docs/file-structure.md` (default branch only — on feature branches the tree snapshot diverges and would conflict)." This is now incorrect and needs to be updated to reflect that feature branches also regen `file-structure.md` as of v0.5.8.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.8] - 2026-05-30
+
+### Fixed — issue #57: `logmind agents update` dry-run output
+
+The pre-fix monolithic "✓ All agent files are current" message conflated
+three distinct cases — no AGENTS.md, AGENTS.md without a logmind marker
+block, AGENTS.md with a current marker — and misled users into thinking
+everything was current when really logmind hadn't been installed at
+all. Split into three case-specific messages:
+
+- **No AGENTS.md**: `✓ No AGENTS.md in this repo — nothing to update.
+  Run `logmind init` to install one.`
+- **AGENTS.md w/o marker block**: `✓ AGENTS.md exists but has no logmind
+  marker block. Run `logmind init` to install one ...`
+- **AGENTS.md w/ current marker**: `✓ AGENTS.md logmind block is current
+  (no update needed).`
+
+Plus refined the dry-run-with-outdated-files prefix from "Found N file(s)
+..." to "Would update N file(s) ..." so the user knows the action is
+prospective, not retrospective.
+
+### Fixed — issue #66: file-structure.md skipped on feature branches
+
+Pre-v0.5.8, `logmind log` on a feature branch regenerated `timeline.md`
+but skipped `docs/file-structure.md`. The skip self-perpetuated a
+1-entry-stale cycle on main: PR adds `docs/decisions-branches/<branch>.md`
+→ squash-merges without an updated file-structure → main's
+`file-structure.md` is one entry behind reality → next PR catches it via
+check-derived-docs, ships a regen + a new decision file → cycle repeats.
+Hit live on `thrillmade/agent-skills` PRs #37 → #38 → (would-be #39).
+
+The original rationale for the skip (per-branch regen would conflict
+against main on rebase) was made obsolete by v0.3.0's merge driver for
+`file-structure.md`, which resolves conflicts by regenerating from the
+merged tree. Feature branches now regen on every `logmind log` — same
+behaviour as `timeline.md`.
+
+### Tests
+
+- 3 new tests in `tests/test_agents_consolidation.py` covering the per-case
+  messaging (no-AGENTS.md / no-marker / dry-run-prefix).
+- `test_log_on_feature_branch_regenerates_file_structure` (renamed +
+  inverted from `_does_not_touch_file_structure`) — pins the v0.5.8
+  behaviour against future regression.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -11,6 +11,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.5.8.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -65,8 +65,11 @@ command, and you do NOT need to run `logmind timeline --write` separately:
 1. Appends the decision entry to the active log file (default branch →
    `docs/decisions.md`; feature branch → `docs/decisions-branches/<branch>.md`).
 2. Archives the oldest decision if `decisions.md` exceeds `max_recent` (rotation).
-3. Regenerates `docs/file-structure.md` (default branch only — on feature
-   branches the tree snapshot diverges and would conflict).
+3. **Regenerates `docs/file-structure.md` on every branch (v0.5.8+)** — the
+   tree snapshot is generated on feature branches as well as the default
+   branch. (Pre-v0.5.8 skipped this on feature branches; the skip was made
+   obsolete by v0.3.0's merge driver, which resolves conflicts by regenerating
+   from the merged tree.)
 4. **Regenerates `docs/timeline.md` on every branch (v0.2.3+)** — the derived
    index that `check-derived-docs` CI verifies.
 5. **`git add` every change in the working tree (default since v0.2.7)** —
@@ -254,6 +257,9 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.3.0**: `logmind init` registers a git merge driver for
   `timeline.md` / `file-structure.md` so parallel-PR merges no longer
   conflict on the derived files. Doctor gains three rows tracking it.
+- **v0.5.8**: `logmind log` now regenerates `docs/file-structure.md` on
+  feature branches as well as the default branch (previously skipped on
+  feature branches; made safe by the v0.3.0 merge driver).
 
 ## Setup (one-time, per project)
 


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.8 shipped.

**CHANGELOG**: [`v0.5.8` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.8/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.8

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The CHANGELOG for v0.5.8 changes the behavior of `logmind log` on feature branches: previously it skipped regenerating `docs/file-structure.md` on feature branches, but now it regenerates it on every branch (same as `timeline.md`). The SKILL.md currently explicitly documents the old behavior in step 3 of "What `logmind log` does automatically": "Regenerates `docs/file-structure.md` (default branch only — on feature branches the tree snapshot diverges and would conflict)." This is now incorrect and needs to be updated to reflect that feature branches also regen `file-structure.md` as of v0.5.8.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.