### PR TITLE
logmind v0.5.9 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.9.md
+++ b/.skill-update-todo/v0.5.9.md
@@ -1,0 +1,45 @@
+# logmind v0.5.9 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.9/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.9
+
+## Claude's reasoning
+
+This release is a bug fix to the `check-links` command's internal parsing logic (`_strip_code_regions()`). It changes how the link checker handles markdown syntax inside backticks/code fences, but this is invisible to agents using the skill: agents don't invoke `check-links` directly via the skill guidance, there are no new CLI flags or commands, no new defaults affecting agent behavior, and no new "always do X / never do Y" guidance. The fix resolves a CI false-positive but doesn't alter any skill-relevant workflow.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.9] - 2026-05-30
+
+### Fixed — issue #60: check-links parses markdown links inside backticks / code fences
+
+Pre-fix, mentioning markdown link syntax inside backticks (a
+documentation-of-the-syntax pattern, e.g. `` `[text](path)` ``) tripped
+the link checker even though the bracket-paren wasn't a live link.
+Recursion: writing a decision-log entry explaining "I fixed broken
+`[text](missing.md)` examples" persisted that very example as plain
+markdown, breaking the next CI run. Hit constantly by agents writing
+decision-log reasoning that needed to discuss link syntax.
+
+Other markdown linters (markdown-link-check, lychee, etc.) skip code
+regions because that's specifically where you discuss the syntax.
+logmind now matches that convention via `_strip_code_regions()` which
+substitutes fenced blocks (` ``` ... ``` `) and inline-code spans
+(`` `...` ``) with whitespace of equivalent length before scanning
+for link patterns. Whitespace-replacement (vs. deletion) preserves
+line numbers + byte offsets so any broken-link error messages still
+point at the correct location in the original file.
+
+### Tests
+
+4 new tests in `tests/test_link_check.py`:
+- `test_links_inside_inline_code_span_are_ignored`
+- `test_links_inside_fenced_code_block_are_ignored`
+- `test_links_outside_code_still_detected_alongside_code_examples`
+  (regression guard against silencing legitimate broken-link detection)
+- `test_strip_code_regions_preserves_line_numbers`
+
+### Note on v0.5.8
+
+This release is v0.5.9 because v0.5.8 (#82) is in parallel review;
+v0.5.9's #60 fix is independent and can ship without depending on
+v0.5.8's changes. Once v0.5.8 lands, v0.5.9 rebases cleanly atop it.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -11,6 +11,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.5.9.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.9 shipped.

**CHANGELOG**: [`v0.5.9` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.9/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.9

## Shape of this PR

TODO context only (Claude judged release skill-irrelevant)

## Claude's reasoning

This release is a bug fix to the `check-links` command's internal parsing logic (`_strip_code_regions()`). It changes how the link checker handles markdown syntax inside backticks/code fences, but this is invisible to agents using the skill: agents don't invoke `check-links` directly via the skill guidance, there are no new CLI flags or commands, no new defaults affecting agent behavior, and no new "always do X / never do Y" guidance. The fix resolves a CI false-positive but doesn't alter any skill-relevant workflow.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.