### PR TITLE
logmind v0.5.10 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.10.md
+++ b/.skill-update-todo/v0.5.10.md
@@ -1,0 +1,57 @@
+# logmind v0.5.10 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.10/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.10
+
+## Claude's reasoning
+
+The v0.5.10 release adds a user-visible warning when `--stage scoped` is used and there are unstaged tracked modifications. This is directly relevant to agents using `--stage scoped`: they will now see stderr warnings naming unstaged tracked files along with a fix hint (`git add <files> && git commit --amend --no-edit`), and the commit still proceeds (non-blocking). The SKILL.md should document this new warning behavior in the `--stage scoped` section so agents understand what the warning means and how to respond.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.10] - 2026-05-30
+
+### Fixed — issue #59: `--stage scoped` silent-failure on forgotten `git add`
+
+`logmind log "<title>" --stage scoped` stages only logmind-owned
+files (decisions.md, file-structure.md, etc.). When a user forgot
+`git add` before running it — the failure mode that hit clud-bug
+PR #87 and reporulez PR #20 in the 2026-05-27 wrap-up session —
+the commit shipped ONLY the decision-log entry. The intended file
+change stayed unstaged; the PR diff didn't match its description;
+CI reviewed unchanged code; reviewer flagged "PR does not match
+description"; user had to push a follow-up commit.
+
+logmind now detects this case and emits a stderr warning naming
+the unstaged tracked file(s) plus the fix hint
+(`git add <files> && git commit --amend --no-edit`). Warn-not-block
+per the Q6 invariant: the user may legitimately have unrelated
+tracked WIP they want to keep unstaged, so the commit still
+proceeds.
+
+Untracked files (scratch debug artifacts, generated PNGs, etc.) do
+NOT trigger the warning — users opting into `--stage scoped`
+typically have intentional untracked WIP. Only tracked-but-modified
+files surface the warning (i.e., the actual silent-failure
+scenario).
+
+### Added
+
+- `git_handler.unstaged_tracked_modifications(path)` helper —
+  returns the list of tracked files with unstaged modifications.
+  Used by the `--stage scoped` warning code path; reusable for
+  future scoped-stage tooling.
+
+### Tests
+
+4 new tests in `tests/test_logger.py`:
+
+- `test_log_scoped_stage_warns_on_unstaged_tracked_modifications`
+  — the actual silent-failure scenario; warning fires AND commit
+  still proceeds (non-blocking).
+- `test_log_scoped_stage_silent_when_working_tree_clean` —
+  regression guard against warning-spam on clean scoped commits.
+- `test_log_scoped_stage_ignores_untracked_files` — untracked
+  scratch files (the `--stage scoped` raison d'être) do NOT
+  trigger the warning.
+- `test_log_stage_all_never_warns` — `--stage all` sweeps the
+  whole tree so the warning code path must never fire.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -11,6 +11,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.5.10.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -104,6 +104,23 @@ Unrelated working-tree changes stay unstaged. Use when:
 Rare for automated agents — they should be working on one task at a
 time and want the single-commit shape.
 
+**`--stage scoped` unstaged-tracked warning (v0.5.10+):** If you run
+`logmind log --stage scoped` and there are tracked files with unstaged
+modifications, logmind emits a stderr warning naming those files and
+suggests the fix:
+
+```
+Warning: --stage scoped commit may be incomplete.
+Unstaged tracked modifications: src/foo.py, src/bar.py
+To include them: git add src/foo.py src/bar.py && git commit --amend --no-edit
+```
+
+The commit still proceeds (non-blocking) — you may legitimately have
+unrelated tracked WIP. But if the warning names files relevant to the
+decision you just logged, run the suggested `git add … && git commit
+--amend --no-edit` before pushing. Untracked files (scratch artifacts,
+generated outputs) never trigger the warning.
+
 ## Branch-aware routing (automatic)
 
 On a feature branch the entry lands in
@@ -254,6 +271,11 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.3.0**: `logmind init` registers a git merge driver for
   `timeline.md` / `file-structure.md` so parallel-PR merges no longer
   conflict on the derived files. Doctor gains three rows tracking it.
+- **v0.5.10**: `logmind log --stage scoped` warns on stderr when tracked
+  files have unstaged modifications (non-blocking; commit still proceeds).
+  If the warning fires, inspect the named files and run
+  `git add <files> && git commit --amend --no-edit` if they belong in
+  the decision commit.
 
 ## Setup (one-time, per project)
 
@@ -282,6 +304,11 @@ logmind doctor             # confirm clean install
   log`** — it's already regenerated and staged. The standalone command is
   an escape hatch for unusual situations (a corrupted timeline, a tree
   someone touched outside logmind), not part of the normal flow.
+- **When using `--stage scoped`, don't ignore the unstaged-tracked warning
+  (v0.5.10+).** If logmind warns that tracked files are unstaged, check
+  whether those files belong in the decision commit. If they do, run
+  `git add <files> && git commit --amend --no-edit` before pushing —
+  otherwise your PR diff won't match its description.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.10 shipped.

**CHANGELOG**: [`v0.5.10` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.10/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.10

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The v0.5.10 release adds a user-visible warning when `--stage scoped` is used and there are unstaged tracked modifications. This is directly relevant to agents using `--stage scoped`: they will now see stderr warnings naming unstaged tracked files along with a fix hint (`git add <files> && git commit --amend --no-edit`), and the commit still proceeds (non-blocking). The SKILL.md should document this new warning behavior in the `--stage scoped` section so agents understand what the warning means and how to respond.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.