### PR TITLE
logmind v0.5.11 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.11.md
+++ b/.skill-update-todo/v0.5.11.md
@@ -1,0 +1,64 @@
+# logmind v0.5.11 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.11/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.11
+
+## Claude's reasoning
+
+The changelog introduces a new `post-rewrite` git hook (installed by `logmind init`) that regenerates `timeline.md` and `file-structure.md` after rebases and amends. This is user-visible behavior: `logmind init` now installs an additional hook, `logmind doctor` gains a new reporting row for `post-rewrite hook`, and the existing guidance about the merge driver/hook infrastructure needs to mention this new hook. Additionally, the Don'ts section should be updated to clarify that manual `logmind timeline --write` after a rebase is no longer needed (the hook handles it).
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.11] - 2026-05-30
+
+### Fixed — issue #58: multi-commit rebases left `docs/timeline.md` stale
+
+Pre-fix, rebasing a feature branch with 2+ `logmind log` commits
+against a moved `main` produced a stale `docs/timeline.md`. The
+merge driver in `.gitattributes` only fires when a merge produces
+conflicts on the derived files; a clean rebase replays multiple
+commits without ever invoking the driver. The companion
+`post-merge` hook (added in v0.3.0) also doesn't fire on rebases —
+it's strictly a merge-time sweep. Result: only the FIRST rebased
+commit's regen survived; subsequent commits left `timeline.md`
+unsynced relative to the replayed `docs/decisions-branches/<branch>.md`
+entries. `check-derived-docs` failed the resulting PR.
+
+Hit live on agent-skills PRs #21 + #22 during the 2026-05-27
+merge cascade. Manual recovery required `logmind timeline --write
+docs/timeline.md && git add docs/timeline.md && git commit -m
+'chore: regen timeline'`.
+
+logmind now installs a `post-rewrite` hook (companion to
+`post-merge`) that regenerates `timeline.md` + `file-structure.md`
+after every `git rebase` or `git commit --amend`. Git invokes
+post-rewrite once at end-of-rewrite with `$1 = "rebase"` or
+`"amend"` — the regen behaviour is identical in both cases, so we
+don't branch on `$1`. Same idempotency contract as the post-merge
+hook (refuses to overwrite a foreign user-authored hook; canonical
+body re-installed on every `logmind init`).
+
+### Added
+
+- `gitattributes.install_post_rewrite_hook(repo_root)` — mirrors
+  `install_post_merge_hook`. Idempotent; preserves foreign hooks.
+- `gitattributes.post_rewrite_hook_installed(repo_root)` —
+  detection helper for `logmind doctor`.
+- `logmind doctor` reports `post-rewrite hook` drift alongside
+  the existing `post-merge hook` row.
+- `logmind init` (both refresh and main paths) installs the
+  post-rewrite hook on every invocation — idempotent, so existing
+  projects pick it up the next time they re-run `init`.
+
+### Tests
+
+6 new tests in `tests/test_merge_driver.py`:
+
+- `test_install_post_rewrite_hook_creates_executable_hook`
+- `test_install_post_rewrite_hook_is_idempotent`
+- `test_install_post_rewrite_hook_does_not_overwrite_foreign_hook`
+- `test_post_rewrite_hook_installed_detects_logmind_hook`
+- `test_post_rewrite_hook_installed_returns_false_for_foreign_hook`
+- `test_doctor_surfaces_post_rewrite_hook_status` —
+  before-install reports `missing`, after-install reports `current`.
+- `test_logmind_init_installs_post_rewrite_hook` — end-to-end via
+  `CliRunner` that `logmind init` wires the hook into a fresh repo.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -11,6 +11,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.5.11.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -187,11 +187,11 @@ body changed. **If `doctor` reports an `AGENTS.md` stale row, your repo's
 embedded logmind instructions are older than what the installed logmind
 would write — re-run `logmind init` to refresh in place.**
 
-## Parallel-PR merges: timeline + file-structure merge driver (v0.3.0+)
+## Parallel-PR merges and rebases: merge driver + hooks (v0.3.0+, v0.5.11+)
 
 Two PRs that both run `logmind log` no longer textually conflict on
-`docs/timeline.md` or `docs/file-structure.md` on rebase. v0.3.0's
-`logmind init` installs three pieces that handle this together:
+`docs/timeline.md` or `docs/file-structure.md` on merge or rebase.
+`logmind init` installs four pieces that handle this together:
 
 - **`.gitattributes` block** (idempotent, marker-bracketed) — registers
   `merge=logmind-timeline` and `merge=logmind-file-structure` for the
@@ -207,12 +207,20 @@ Two PRs that both run `logmind log` no longer textually conflict on
   per-file mid-merge before the other branch's `docs/decisions-branches/`
   files are checked out, so its output can miss decisions; the hook
   sweeps any incomplete regen at end-of-merge.
+- **`.git/hooks/post-rewrite`** (v0.5.11+) — companion to `post-merge`;
+  re-regenerates `timeline.md` and `file-structure.md` after every
+  `git rebase` (including multi-commit rebases) and `git commit --amend`.
+  Git invokes this hook once at end-of-rewrite regardless of how many
+  commits were replayed, so all derived files are fully synced. Same
+  idempotency contract as `post-merge` — refuses to overwrite a
+  foreign user-authored hook; canonical body re-installed on every
+  `logmind init`.
 
-`logmind doctor` reports three new rows for these (v0.3.0+):
-`.gitattributes (merge driver)`, `git config (merge driver)`, and
-`post-merge hook`. Missing rows are not drift — they're "not yet
-installed for this logmind version" — the next `logmind init` resolves
-them silently.
+`logmind doctor` reports rows for all of these (v0.3.0+ / v0.5.11+):
+`.gitattributes (merge driver)`, `git config (merge driver)`,
+`post-merge hook`, and `post-rewrite hook`. Missing rows are not drift —
+they're "not yet installed for this logmind version" — the next
+`logmind init` resolves them silently.
 
 The merge driver invokes `logmind file-structure --write <path>`
 (v0.3.0+), the mirror of `logmind timeline --write`. Like the timeline
@@ -254,6 +262,10 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.3.0**: `logmind init` registers a git merge driver for
   `timeline.md` / `file-structure.md` so parallel-PR merges no longer
   conflict on the derived files. Doctor gains three rows tracking it.
+- **v0.5.11**: `logmind init` installs a `post-rewrite` hook so
+  multi-commit rebases and `git commit --amend` keep `timeline.md` and
+  `file-structure.md` in sync automatically. Doctor gains a
+  `post-rewrite hook` row.
 
 ## Setup (one-time, per project)
 
@@ -261,7 +273,7 @@ If the project doesn't yet have logmind:
 
 ```bash
 pip install logmind
-logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block, merge drivers + post-merge hook (v0.3.0+)
+logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block, merge drivers + post-merge hook (v0.3.0+) + post-rewrite hook (v0.5.11+)
 logmind doctor             # confirm clean install
 ```
 
@@ -282,6 +294,12 @@ logmind doctor             # confirm clean install
   log`** — it's already regenerated and staged. The standalone command is
   an escape hatch for unusual situations (a corrupted timeline, a tree
   someone touched outside logmind), not part of the normal flow.
+- **Don't run `logmind timeline --write docs/timeline.md` manually after a
+  rebase.** Since v0.5.11 the `post-rewrite` hook regenerates derived
+  files automatically at the end of every rebase or amend. Manual
+  recovery (`logmind timeline --write … && git add … && git commit`) is
+  only needed on pre-v0.5.11 installs or if the hook is missing (check
+  `logmind doctor`).
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.11 shipped.

**CHANGELOG**: [`v0.5.11` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.11/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.11

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The changelog introduces a new `post-rewrite` git hook (installed by `logmind init`) that regenerates `timeline.md` and `file-structure.md` after rebases and amends. This is user-visible behavior: `logmind init` now installs an additional hook, `logmind doctor` gains a new reporting row for `post-rewrite hook`, and the existing guidance about the merge driver/hook infrastructure needs to mention this new hook. Additionally, the Don'ts section should be updated to clarify that manual `logmind timeline --write` after a rebase is no longer needed (the hook handles it).

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.