### PR TITLE
logmind v0.5.12 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.5.12.md
+++ b/.skill-update-todo/v0.5.12.md
@@ -1,0 +1,67 @@
+# logmind v0.5.12 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.5.12/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.5.12
+
+## Claude's reasoning
+
+This release is a bug fix that makes `logmind log` self-healing by auto-installing merge drivers and hooks on every invocation. However, from an agent's perspective using the skill, the behavior guidance hasn't changed: agents still just run `logmind log` as the single commit primitive. The fix addresses an internal infrastructure gap (fresh clones lacking driver config) that was invisible to agents following the skill correctly — the skill already states that `logmind init` installs the merge drivers, and the new behavior is a transparent self-repair that requires no change in how agents invoke or think about logmind commands. No new CLI flags, no changed defaults, no new Do's/Don'ts are warranted.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.5.12] - 2026-05-30
+
+### Fixed — `timeline.md` auto-resolves on fresh clones / CI / throwaway worktrees
+
+Pre-fix, `logmind init` was the only path that installed the
+per-clone git config + hooks needed for `timeline.md` and
+`file-structure.md` to merge cleanly. Fresh clones, CI runners,
+and agents working in throwaway worktrees had the committed
+`.gitattributes` reference to `merge=logmind-timeline` but no
+driver definition registered locally. Git refuses to invoke an
+unconfigured merge driver (security guard against untrusted
+repos), so it silently fell back to the default ort 3-way merge.
+The result was text-valid but semantically incomplete `timeline.md`
+output that `check-derived-docs` later flagged — failing the PR
+gate even though the merge "succeeded."
+
+Hit live on tokenomics #21 when merging main into a branch
+produced `Auto-merging docs/timeline.md / Merge made by the 'ort'
+strategy` instead of the expected `logmind-timeline` driver
+output. User stance (memory `project_timeline_conflict_should_auto_resolve`):
+_"conflicts bugs like this shouldn't happen on our own timeline
+file and logmind should auto resolve."_
+
+v0.5.12 makes `logmind log` self-healing. Every invocation now
+runs the three idempotent installers from `logmind.core.gitattributes`:
+
+- `configure_merge_drivers(repo_root)` — sets `merge.logmind-timeline.driver` + `merge.logmind-file-structure.driver` in `.git/config`.
+- `install_post_merge_hook(repo_root)` — writes the canonical post-merge hook (v0.3.0+).
+- `install_post_rewrite_hook(repo_root)` — writes the post-rewrite hook (v0.5.11+).
+
+All three are silent no-ops outside a git repo (the fresh-clone
+case isn't always in a git checkout — e.g. when an agent works
+in a temp directory). Cost per `logmind log`: ~3 `git config --get`
+calls + 2 file stats. Negligible.
+
+The first `logmind log` in any fresh clone now leaves the clone
+fully configured for future merges, rebases, and amends. No more
+"why isn't the merge driver firing?" mysteries on CI / agents.
+
+### Added
+
+- `logmind.core.logger.log()` — auto-install block at top of
+  function, runs unconditionally (idempotent + git-safe).
+
+### Tests
+
+3 new tests in `tests/test_logger.py`:
+
+- `test_log_auto_installs_merge_driver_on_fresh_clone` — fresh-clone
+  simulation (.gitattributes committed, no per-clone driver). After
+  `logmind log` with `auto_commit=False`, driver + both hooks are
+  configured.
+- `test_log_auto_install_is_silent_noop_outside_git_repo` — non-git-repo
+  invocation doesn't crash. Decision is still recorded.
+- `test_log_auto_install_is_idempotent_across_repeated_invocations`
+  — second `logmind log` doesn't re-write hook files (regression
+  guard against double-install at log() layer).

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -11,6 +11,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.5.12.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.5.12 shipped.

**CHANGELOG**: [`v0.5.12` on logmind](https://github.com/thrillmade/logmind/blob/v0.5.12/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.5.12

## Shape of this PR

TODO context only (Claude judged release skill-irrelevant)

## Claude's reasoning

This release is a bug fix that makes `logmind log` self-healing by auto-installing merge drivers and hooks on every invocation. However, from an agent's perspective using the skill, the behavior guidance hasn't changed: agents still just run `logmind log` as the single commit primitive. The fix addresses an internal infrastructure gap (fresh clones lacking driver config) that was invisible to agents following the skill correctly — the skill already states that `logmind init` installs the merge drivers, and the new behavior is a transparent self-repair that requires no change in how agents invoke or think about logmind commands. No new CLI flags, no changed defaults, no new Do's/Don'ts are warranted.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.