### PR TITLE
feat: bundle Zak's skillforge SKILL.md (SkDD meta-skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These skills run inside any agent that loads skills.sh — Claude Code, Cursor, 
 | [`api-contract-enforcement`](skills/api-contract-enforcement/SKILL.md) | Flag PRs that change the shape, semantics, or error behavior of a public API without versioning or a migration path. Catches removed fields, renamed parameters, changed status codes, broken pagination, silent enum drift across HTTP/gRPC/GraphQL/SDK/CLI surfaces. |
 | [`pii-and-compliance`](skills/pii-and-compliance/SKILL.md) | Catch PII and auth material leaking into logs, error traces, analytics events, URLs, or third-party SDKs. Apply to logging calls, telemetry, error handlers, debug statements, and committed test fixtures. |
 | [`test-discipline`](skills/test-discipline/SKILL.md) | Flag the test-edit patterns that hollow out a suite over time: deleted assertions without replacement, mocks that hide the thing being tested, snapshot churn, `.skip`/`.only` left in the diff, time-dependent assertions without frozen time, assertions on internal state instead of observable behavior. |
+| [`skillforge`](skills/skillforge/SKILL.md) ✨ | Create or update a reusable agent skill. Use when you notice a repeated pattern, when a workflow should be persisted for future sessions, or when asked to forge/create/scaffold a new skill. **Vendored from [zakelfassi/skills-driven-development](https://github.com/zakelfassi/skills-driven-development) with attribution** — the canonical SkDD meta-skill (the skill that creates skills). MIT, Zak El Fassi. |
 
 ## Install
 
@@ -61,6 +62,15 @@ Whichever pattern applies, prefer the **collection layout** (`skills/<name>/SKIL
 1. Create `skills/<name>/SKILL.md` with frontmatter (`name`, `description`).
 2. Add a row to the table above.
 3. Open a PR.
+
+## Vendored skills (✨ in the table above)
+
+Skills marked with ✨ are **vendored verbatim from upstream authors** — kept here so they install alongside the thrillmade catalog and stay reachable from the same `npx skills add` command, but with original author + spec metadata preserved in the SKILL.md frontmatter.
+
+Current vendored skills:
+- `skillforge` — from Zak El Fassi's [skills-driven-development](https://github.com/zakelfassi/skills-driven-development) repo. The canonical SkDD meta-skill (the skill that creates skills). MIT licensed. Vendored at v2.0; we'll sync on his releases.
+
+**Why vendor:** the upstream skill is canonical for its methodology; reimplementing would fragment. Vendoring with attribution keeps users on the canonical artifact + makes it installable through the same channel as the rest of our catalog. Both source-of-truth (upstream) and local-copy (here) stay in sync via periodic refresh PRs.
 
 ## License
 

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -36,6 +36,7 @@ agent-skills
 │   ├── respect-existing-conventions
 │   ├── semver-design-tokens
 │   ├── skill-frontmatter-quality
+│   ├── skillforge
 │   ├── spacing-system
 │   ├── test-discipline
 │   ├── token-frugal-tooling

--- a/skills/skillforge/SKILL.md
+++ b/skills/skillforge/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: skillforge
+description: Create or update a reusable agent skill. Use when you notice a repeated pattern, when a workflow should be persisted for future sessions, or when asked to forge/create/scaffold a new skill.
+metadata:
+  author: zakelfassi
+  version: "2.0"
+  spec: agentskills.io
+---
+
+# SkillForge
+
+Create well-formed, spec-compliant skills from observed patterns.
+
+## When to Forge
+
+✅ **Forge when:**
+- You've done the same sequence 2-3 times in a session
+- A project convention isn't documented anywhere
+- You solved a hard problem with a reusable solution
+- Someone asks you to create a skill
+
+❌ **Don't forge when:**
+- It's a one-time task
+- An existing skill already covers it (update instead)
+- The "skill" is just a single command (use a script alias)
+
+## Steps
+
+### 1. Name the pattern
+- What problem does this skill solve?
+- What triggers it? (be specific — the `description` field is the discovery surface)
+- What are the inputs and outputs?
+
+### 2. Choose a name
+- `kebab-case`, 1-64 characters
+- Verb-led when possible: `deploy-preview`, `scaffold-component`, `triage-bug`
+- One responsibility per skill
+
+### 3. Create the skill directory
+
+```bash
+mkdir -p .skills/<skill-name>
+```
+
+### 4. Write SKILL.md
+
+Use this skeleton:
+
+```markdown
+---
+name: <skill-name>
+description: <what it does>. Use when <triggers>.
+metadata:
+  forged-by: <agent-id>
+  forged-from: <session-or-context>
+  forged-reason: "<why this was created>"
+---
+
+# <Skill Name>
+
+## Inputs
+- ...
+
+## Steps
+1. ...
+2. ...
+
+## Conventions
+- Project-specific patterns that apply
+
+## Edge Cases
+- Known gotchas or special handling
+```
+
+### 5. Add scripts (optional)
+If the skill involves file generation or automation:
+
+```
+.skills/<skill-name>/
+├── SKILL.md
+├── scripts/
+│   └── run.sh         # Executable automation
+└── references/
+    └── conventions.md # Detailed reference (keeps SKILL.md lean)
+```
+
+### 6. Register the skill
+Update `.skills-registry.md` at the **project root** (same level as `.skills/`). Create it if it doesn't exist:
+
+```markdown
+| <skill-name> | local | <today> | 1 | <description> |
+```
+
+If the project uses the machine-readable registry (`.skills-registry.json`), update it too — `skdd forge` handles both formats automatically.
+
+## Updating an Existing Skill
+
+When you use a skill and encounter something it doesn't cover:
+
+1. Add the new edge case or step to the existing SKILL.md
+2. If the skill is getting too long (>200 lines), split it
+3. Update `last-used` and increment `usage-count` in the registry
+
+## Quality Checklist
+
+Before committing a new skill:
+
+- [ ] `name` is kebab-case, ≤64 chars
+- [ ] `description` includes what it does AND when to use it
+- [ ] Steps are numbered and actionable
+- [ ] No hardcoded paths, secrets, or environment-specific values
+- [ ] SKILL.md is under 200 lines (move details to `references/`)
+- [ ] Registered in `.skills-registry.md`


### PR DESCRIPTION
Stream 5 implementation. Bundles the canonical SkDD meta-skill from upstream with attribution.

## Why

Per the explore agent's strategic analysis (2026-05-30): `skillforge` v2.0 is the load-bearing meta-skill of Zak Elfassi's [Skills-Driven Development](https://zakelfassi.com/skdd-skills-driven-development) methodology. The agent recommended **USE** (not INSPO or HYBRID) — bundling preserves the canonical artifact and avoids fragmenting the ecosystem with a competing fork.

## What ships

- `skills/skillforge/SKILL.md` — verbatim copy from [zakelfassi/skills-driven-development @ skillforge/SKILL.md](https://github.com/zakelfassi/skills-driven-development/tree/main/skillforge). 113 lines, MIT, Zak El Fassi.
- Frontmatter `metadata.author: zakelfassi`, `version: "2.0"`, `spec: agentskills.io` preserved verbatim — discovery + spec compliance unchanged.
- README updates:
  - New row in skills table marked with ✨ (vendored indicator) + attribution
  - New "Vendored skills" section explaining the pattern + why we don't reimplement upstream skills

## Pattern this establishes

Vendoring with attribution. When an upstream author ships a canonical skill, bundle it (don't fork; don't reimplement) so:
- Users install through our same `npx skills add` channel
- Source-of-truth stays upstream; we sync periodically
- Original author metadata preserved (discovery + credit intact)

Future vendored skills follow this same pattern + ✨ flag.

## Test plan

- [x] Frontmatter parses (YAML valid)
- [x] File present at correct path
- [ ] CI: skill validation gate (if any) passes
- [ ] Sync workflow consideration: how often do we re-sync from upstream? Captured for follow-up — for v1 it's a manual sync on upstream release

🤖 Generated with [Claude Code](https://claude.com/claude-code)