### PR TITLE
logmind v0.6.0 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.0.md
+++ b/.skill-update-todo/v0.6.0.md
@@ -1,0 +1,99 @@
+# logmind v0.6.0 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.0/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.0
+
+## Claude's reasoning
+
+The v0.6.0 release introduces two new user-visible CLI subcommands (`logmind skill new <name>` and `logmind skill test <name>`) with specific behaviors (skdd delegation, --no-log flag, size cap, frontmatter checks, non-zero exit on failure) that agents using logmind should know about. These are new CLI surface area that directly affects how agents work with skills in a logmind project.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.0] - 2026-05-30
+
+### Added — `logmind skill` subgroup (Stream 6 v0.6.0)
+
+First step of the **end-to-end agentic auto-dev loop** the user
+coined (2026-05-30): _"development with skills, logging with
+logmind to document the changes, then using logmind runnerbot to
+forge and update skills, and then cludbug reviews with those
+skills and against them, rinse repeat."_
+
+Two CLI subcommands ship in v0.6.0; bench + log subcommands queued
+for v0.6.1+.
+
+#### `logmind skill new <name>`
+
+Scaffolds a new SKILL.md against the
+[agentskills.io/v1](https://agentskills.io) spec. Composes with
+Zak Elfassi's [`@zakelfassi/skdd`](https://zakelfassi.com/skdd-skills-driven-development):
+
+- If `skdd` is on PATH → delegates to `skdd forge <name>` (canonical
+  SkDD authoring path)
+- Otherwise → scaffolds a basic SKILL.md with required frontmatter
+  fields + a TODO trigger description (the discovery surface)
+
+Auto-decision-logs the skill creation via `logmind log` (audit
+trail of every skill iteration). Pass `--no-log` to skip.
+
+```bash
+logmind skill new my-team-conventions \
+    --description "Apply our team's review checklist on every PR"
+```
+
+#### `logmind skill test <name>`
+
+Validates a SKILL.md against the spec + logmind layered checks.
+
+- If `skdd` is on PATH → delegates to `skdd validate`
+- Layers logmind-specific checks: frontmatter required fields
+  (`name` + `description`), soft size cap (8KB — guards against
+  skills that bloat every agent load)
+- Exits non-zero on any check failure so CI can gate on it
+
+```bash
+logmind skill test my-team-conventions
+# ✓ skdd validate passed
+# ✓ frontmatter required fields: ok
+# ✓ size cap: 2934 bytes (cap: 8000)
+```
+
+### Architecture (per explore-agent strategic analysis, 2026-05-30)
+
+- **Don't reimplement Zak's `forge` / `validate`** when `skdd` is on
+  PATH. Wire to it instead — the canonical SkDD methodology lives
+  upstream.
+- **Layer logmind-specific value** AFTER his CLI does its work:
+  decision-log on creation; size cap + frontmatter checks on test.
+- **Scope discipline**: v0.6.0 ships `new` + `test` only.
+  - v0.6.1: `bench` (per-call token-cost measurement per skill)
+  - v0.6.2: `log` (decision-log a skill iteration, automatable from
+    a parallel bot per Stream 9)
+
+### Tests
+
+20 new tests in `tests/test_skill_cli.py`:
+- 3 cover `scaffold_basic_skill` (creates valid SKILL.md, refuses
+  clobber, TODO when no description)
+- 7 cover validation helpers (`check_frontmatter_required_fields`,
+  `check_size_cap` — passing + failing cases)
+- 8 cover the CLI commands (basic-scaffold path, --no-log, missing
+  skill, broken frontmatter, oversized skill)
+- 2 cover the skdd delegate path via subprocess mocking
+
+Full suite: 693 passed, 1 skipped (was 673 at v0.5.13).
+
+### Upstream collaboration context
+
+Zak Elfassi's `@zakelfassi/skdd` (npm) is the canonical SkDD CLI.
+This release positions logmind as the **complementor**: when his
+CLI is available, we wire to it; when it's not, we degrade
+gracefully to a basic scaffold. The vendored `skillforge` skill
+also lands in agent-skills in parallel (PR #73 there), preserving
+his attribution.
+
+### v0.6.0 vs v0.5.x
+
+Minor version bump because `logmind skill` is a new CLI subgroup —
+new user-visible surface. No breaking changes; all v0.5.x APIs
+unchanged. Consumers upgrading from v0.5.13 → v0.6.0 see the new
+subcommand + zero regressions.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -11,6 +11,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.6.0.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -166,6 +166,48 @@ regardless of `--quiet` (JSON is primary output, not progress). The
 `click.secho` so red/yellow error/warning output still prints under
 `LOGMIND_QUIET=1` — only progress chatter (cyan/green) is suppressed.
 
+## Managing skills: `logmind skill` subgroup (v0.6.0+)
+
+`logmind skill` is the CLI subgroup for creating and validating SKILL.md
+files. It composes with Zak Elfassi's
+[`@zakelfassi/skdd`](https://zakelfassi.com/skdd-skills-driven-development)
+when `skdd` is on PATH; otherwise it degrades gracefully.
+
+### `logmind skill new <name>`
+
+Scaffolds a new SKILL.md against the [agentskills.io/v1](https://agentskills.io)
+spec.
+
+- If `skdd` is on PATH → delegates to `skdd forge <name>` (canonical SkDD
+  authoring path).
+- Otherwise → scaffolds a basic SKILL.md with required frontmatter fields +
+  a TODO trigger description.
+- Auto-decision-logs the skill creation via `logmind log` (audit trail).
+  Pass `--no-log` to skip the auto-log.
+
+```bash
+logmind skill new my-team-conventions \
+    --description "Apply our team's review checklist on every PR"
+```
+
+### `logmind skill test <name>`
+
+Validates a SKILL.md against the spec + logmind layered checks.
+
+- If `skdd` is on PATH → delegates to `skdd validate` first.
+- Layers logmind-specific checks: required frontmatter fields (`name` +
+  `description`), and a **soft size cap of 8 KB** (guards against skills
+  that bloat every agent load).
+- **Exits non-zero on any check failure** — use in CI to gate on skill
+  health.
+
+```bash
+logmind skill test my-team-conventions
+# ✓ skdd validate passed
+# ✓ frontmatter required fields: ok
+# ✓ size cap: 2934 bytes (cap: 8000)
+```
+
 ## Verifying install health
 
 `logmind doctor` (v0.2.4+) reports installed-vs-latest versions for logmind
@@ -254,6 +296,9 @@ Common deltas you'll see if you're upgrading across a stretch:
 - **v0.3.0**: `logmind init` registers a git merge driver for
   `timeline.md` / `file-structure.md` so parallel-PR merges no longer
   conflict on the derived files. Doctor gains three rows tracking it.
+- **v0.6.0**: `logmind skill new` / `logmind skill test` ship. When
+  `skdd` is on PATH, both delegate to it; otherwise logmind scaffolds /
+  validates standalone.
 
 ## Setup (one-time, per project)
 
@@ -282,6 +327,13 @@ logmind doctor             # confirm clean install
   log`** — it's already regenerated and staged. The standalone command is
   an escape hatch for unusual situations (a corrupted timeline, a tree
   someone touched outside logmind), not part of the normal flow.
+- **Don't reimplement `skdd forge` or `skdd validate` logic when `skdd`
+  is on PATH.** Use `logmind skill new` / `logmind skill test` — they
+  delegate to `skdd` automatically and layer logmind-specific checks on
+  top.
+- **Don't create SKILL.md files larger than 8 KB.** `logmind skill test`
+  enforces a soft 8 KB cap; oversized skills bloat every agent load and
+  will fail CI gates.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.0 shipped.

**CHANGELOG**: [`v0.6.0` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.0/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.0

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The v0.6.0 release introduces two new user-visible CLI subcommands (`logmind skill new <name>` and `logmind skill test <name>`) with specific behaviors (skdd delegation, --no-log flag, size cap, frontmatter checks, non-zero exit on failure) that agents using logmind should know about. These are new CLI surface area that directly affects how agents work with skills in a logmind project.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
- [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit `skills/logmind/SKILL.md` on this branch and add it before merging.

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.