### PR TITLE
chore: propagate clud-bug v0.6.29 (skill-usage workflow integration)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -26,7 +26,7 @@
   "excludedBaselines": [
     "clud-bug-collaboration"
   ],
-  "lastUpdateVersion": "0.6.27",
-  "lastUpdate": "2026-05-30T05:18:17.201Z",
+  "lastUpdateVersion": "0.6.29",
+  "lastUpdate": "2026-05-31T18:19:43.017Z",
   "strictMode": true
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -19,5 +19,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.27._
+_Installed at clud-bug v0.6.29._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -841,11 +841,49 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.27 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.29 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
           $CALIBRATION"
+
+      # v0.6.29 / Component 4: pipe structured_output through
+      # `clud-bug update-skill-usage` to compute the per-skill loads +
+      # citations delta from this one review. Writes to the ephemeral
+      # workspace .clud-bug.json AND uploads as a workflow artifact
+      # (90-day retention). v0.6.30 will add aggregation logic so
+      # `clud-bug usage --health` reads + merges artifacts across runs.
+      #
+      # Why artifact instead of committing back to main: committing
+      # would require `contents: write` permission (private-repo
+      # trigger-firing regression risk per v0.6.23 hotfix) + race
+      # handling. Artifacts are GitHub-native persistence with zero
+      # permission expansion + zero commit noise.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true  # don't fail the whole review if usage update flakes
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          # If a .clud-bug.json already exists in the workspace (PR's
+          # snapshot), keep it. Otherwise initialize an empty shell so
+          # update-skill-usage has something to merge into.
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.29 update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          retention-days: 90
 
       # Fallback comment when the model couldn't produce schema-valid
       # output after max retries (structured_output is empty). Keeps a
@@ -942,7 +980,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.27
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,16 +7,16 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v6-pointer -->
+<!-- logmind-block-version: v7-pointer -->
 ## Decision logging — `logmind log` is the commit primitive
 
-This project uses [logmind](https://logmind.dev). **`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
+**`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
 
 ```bash
 logmind log "summary" -r "why" -a "alternative" -i "implication"
 ```
 
-What counts as a decision, branch routing, `--stage scoped` for unrelated WIP, `logmind doctor`, and the required-reading list ([`docs/timeline.md`](docs/timeline.md), [`docs/decisions.md`](docs/decisions.md), [`docs/file-structure.md`](docs/file-structure.md), `docs/decisions-branches/<branch>.md`) all live in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind.
+This project uses [logmind](https://logmind.dev). What counts as a decision, branch routing, `--stage scoped` for unrelated WIP, `logmind doctor`, and the required-reading list ([`docs/timeline.md`](docs/timeline.md), [`docs/decisions.md`](docs/decisions.md), [`docs/file-structure.md`](docs/file-structure.md), `docs/decisions-branches/<branch>.md`) all live in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind.
 <!-- logmind-end -->
 
 ## Project Overview
@@ -44,5 +44,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.27._
+_Installed at clud-bug v0.6.29._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/chore__clud-bug-v0.6.29.md
+++ b/docs/decisions-branches/chore__clud-bug-v0.6.29.md
@@ -1,0 +1,8 @@
+## 2026-05-31 14:20 - chore: propagate clud-bug v0.6.29 (skill-usage workflow integration)
+
+**Reasoning:** v0.6.29 adds workflow post-step that pipes structured_output through update-skill-usage CLI + uploads .clud-bug.json as 90-day artifact
+
+**Implications:**
+- agent-skills is the publisher of clud-bug-collaboration skill; this propagation keeps the workflow template current with v0.6.29 pin
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (38 decisions)
+## 2026-05 (39 decisions)
 
-- **2026-05-30** — Upgrade agent-skills to clud-bug v0.6.27 (Smart Budget Phase 3 — L3 mid-review check-in) *(chore/clud-bug-v0.6.26-v2)* — [decisions-branches/chore__clud-bug-v0.6.26-v2.md](decisions-branches/chore__clud-bug-v0.6.26-v2.md)
-- *... 36 more decisions ...*
+- **2026-05-31** — chore: propagate clud-bug v0.6.29 (skill-usage workflow integration) *(chore/clud-bug-v0.6.29)* — [decisions-branches/chore__clud-bug-v0.6.29.md](decisions-branches/chore__clud-bug-v0.6.29.md)
+- *... 37 more decisions ...*
 - **2026-05-26** — Initialize logmind decision tracking *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)


### PR DESCRIPTION
Picks up clud-bug v0.6.29 — adds workflow post-step that pipes structured_output through `update-skill-usage --stdin` + uploads `.clud-bug.json` as 90-day artifact.