### PR TITLE
chore: propagate clud-bug v0.6.30 (cross-review aggregation)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -26,7 +26,7 @@
   "excludedBaselines": [
     "clud-bug-collaboration"
   ],
-  "lastUpdateVersion": "0.6.29",
-  "lastUpdate": "2026-05-31T18:19:43.017Z",
+  "lastUpdateVersion": "0.6.30",
+  "lastUpdate": "2026-06-01T04:04:48.506Z",
   "strictMode": true
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -19,5 +19,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.29._
+_Installed at clud-bug v0.6.30._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -841,7 +841,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.29 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.30 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -873,7 +873,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.29 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.30 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -980,7 +980,7 @@ jobs:
       # Letting the action's own failure fail the check is louder and right.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: the summary is now posted by the workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,5 +44,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.29._
+_Installed at clud-bug v0.6.30._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/chore__clud-bug-v0.6.30.md
+++ b/docs/decisions-branches/chore__clud-bug-v0.6.30.md
@@ -1,0 +1,8 @@
+## 2026-06-01 00:04 - chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts)
+
+**Reasoning:** v0.6.30 closes the v0.6.29 loop — usage --health dashboard now walks per-PR artifacts + aggregates into one org-level snapshot
+
+**Implications:**
+- Composite-action pin bump only; 0.0.W² auto-skip expected
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,6 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
+## 2026-06
+
+- **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
+
 ## 2026-05 (39 decisions)
 
 - **2026-05-31** — chore: propagate clud-bug v0.6.29 (skill-usage workflow integration) *(chore/clud-bug-v0.6.29)* — [decisions-branches/chore__clud-bug-v0.6.29.md](decisions-branches/chore__clud-bug-v0.6.29.md)


### PR DESCRIPTION
Picks up clud-bug v0.6.30 — `usage --health` now reads workflow artifacts. Composite-action pin bump 0.6.29 → 0.6.30.