### PR TITLE
logmind v0.6.3 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.3.md
+++ b/.skill-update-todo/v0.6.3.md
@@ -1,0 +1,52 @@
+# logmind v0.6.3 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.3/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.3
+
+## Claude's reasoning
+
+The v0.6.3 release adds a new CLI command `logmind skill bench <name>` with user-visible behavior: it reports skill file size in bytes, estimated tokens, status buckets (tight/typical/verbose/over-budget), per-section breakdown, and trim suggestions. It also introduces a `--json` flag and defined thresholds. This is a new CLI surface that agents should know about to manage skill file size, so it warrants a SKILL.md update.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.3] - 2026-06-01
+
+### Added — `logmind skill bench <name>` (Stream 6 follow-on)
+
+Closes the "measure" arrow of the SkDD loop. Every time an agent loads
+a SKILL.md, the whole file enters the context window. `bench` reports
+exactly what that costs in bytes + estimated tokens + a status bucket
+(`tight` / `typical` / `verbose` / `over-budget`) + per-section
+breakdown + trim suggestions when over budget.
+
+Pair with clud-bug's `usage --health` (v0.6.28+) for the complete
+picture: bench tells you what each skill COSTS, usage tells you whether
+it EARNS that cost in citations.
+
+#### Thresholds
+
+- **tight**: ≤ 2000 bytes (~500 tokens) — focused, well-trimmed
+- **typical**: ≤ 6000 bytes (~1500 tokens) — most skills land here
+- **verbose**: ≤ 8000 bytes (~2000 tokens) — past budget, suggestions emitted
+- **over-budget**: > 8000 bytes — past hard cap, split recommended
+
+#### Suggestions emitted when verbose+
+
+- Dominant section (>30% of total): "Section 'Examples' is N bytes
+  (35% of total) — consider linking out OR moving to its own skill."
+- Large HTML comment volume: agents load them too; move authoring
+  notes to a sibling NOTES.md.
+- Past the 8KB hard cap: "split into multiple focused skills."
+
+#### CLI surface
+
+- `logmind skill bench <name>` — human-readable table with section
+  breakdown + suggestions.
+- `logmind skill bench <name> --json` — machine-readable for automation.
+
+#### Implementation
+
+- `src/logmind/core/skill_cli.py`: new `bench_skill(content, target?, budget?)`
+  pure function returning `{bytes, est_tokens, status, sections, suggestions}`.
+- `src/logmind/cli.py`: new `@skill.command("bench")` wiring.
+- `tests/test_skill_cli.py`: 11 new tests covering all status buckets,
+  section parsing, suggestion heuristics, CLI integration.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -13,7 +13,8 @@ agent-skills
 ├── .logmind
 │   └── config.yml
 ├── .skill-update-todo
-│   └── v0.6.1.md
+│   ├── v0.6.1.md
+│   └── v0.6.3.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -269,6 +269,38 @@ command, you should not run it by hand in the normal flow — it exists
 for the merge driver and as an escape hatch (corrupted file, externally
 modified tree).
 
+## Skill size budgeting: `logmind skill bench` (v0.6.3+)
+
+Every SKILL.md loaded by an agent occupies context-window space. Use
+`logmind skill bench <name>` to measure what a skill costs and whether
+it needs trimming.
+
+```bash
+logmind skill bench logmind          # human-readable table: bytes, est. tokens, status, per-section breakdown
+logmind skill bench logmind --json   # machine-readable for automation
+```
+
+### Status buckets
+
+| Status | Threshold | Meaning |
+|---|---|---|
+| `tight` | ≤ 2 000 bytes (~500 tokens) | Focused, well-trimmed |
+| `typical` | ≤ 6 000 bytes (~1 500 tokens) | Most skills land here |
+| `verbose` | ≤ 8 000 bytes (~2 000 tokens) | Past budget — suggestions emitted |
+| `over-budget` | > 8 000 bytes | Past hard cap — split recommended |
+
+### Suggestions emitted at `verbose` and above
+
+- **Dominant section** (> 30 % of total bytes): "Section 'X' is N bytes
+  (Y% of total) — consider linking out OR moving to its own skill."
+- **Large HTML comment volume**: agents load comments too; move authoring
+  notes to a sibling `NOTES.md`.
+- **Past the 8 KB hard cap**: "split into multiple focused skills."
+
+Pair with `clud-bug usage --health` (v0.6.28+) for the complete picture:
+`bench` tells you what each skill *costs*; `usage` tells you whether it
+*earns* that cost in citations.
+
 ## Upgrading: `logmind init` prints the changelog
 
 When you run `pip install --upgrade logmind && logmind init` in an
@@ -307,6 +339,10 @@ Common deltas you'll see if you're upgrading across a stretch:
   `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
   fires when the gap between your branch and `origin/<default>` is
   exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+- **v0.6.3**: `logmind skill bench <name>` reports skill file size in
+  bytes + estimated tokens + status bucket + per-section breakdown +
+  trim suggestions. Use to keep skills within the 6 KB typical / 8 KB
+  hard-cap budget.
 
 ## Setup (one-time, per project)
 
@@ -342,6 +378,9 @@ logmind doctor             # confirm clean install
   If the gap between branches includes code files, `docs/file-structure.md`,
   or any file other than `docs/timeline.md`, auto-rebase will refuse and
   emit a heads-up — handle the rebase manually.
+- **Don't let a skill grow past 8 KB without running `logmind skill bench`.**
+  Skills in the `verbose` or `over-budget` bucket waste agent context on
+  every load; trim dominant sections or split into focused sub-skills.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.3 shipped.

**CHANGELOG**: [`v0.6.3` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.3/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.3

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The v0.6.3 release adds a new CLI command `logmind skill bench <name>` with user-visible behavior: it reports skill file size in bytes, estimated tokens, status buckets (tight/typical/verbose/over-budget), per-section breakdown, and trim suggestions. It also introduces a `--json` flag and defined thresholds. This is a new CLI surface that agents should know about to manage skill file size, so it warrants a SKILL.md update.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] Verify the SKILL.md diff accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.