### PR TITLE
logmind v0.6.4 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.4.md
+++ b/.skill-update-todo/v0.6.4.md
@@ -1,0 +1,53 @@
+# logmind v0.6.4 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.4/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.4
+
+## Claude's reasoning
+
+The changelog introduces `logmind skill audit` — a new CLI command (`logmind skill audit` and `logmind skill audit --json`) with user-visible behavior including status thresholds (active/aging/ghost), output format, and how it pairs with `clud-bug usage --health`. This is a new CLI surface that agents using logmind should know about, particularly for skill lifecycle management.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.4] - 2026-06-01
+
+### Added — `logmind skill audit` (Stream 6 follow-on)
+
+Author's-side staleness read for every SKILL.md in `.claude/skills/`.
+Pairs with clud-bug's `usage --health` (the enforcement read) for a
+complete picture of skill lifecycle:
+
+- **audit**: what's HERE, how big, last-touched, decision-log mention
+  count, and a deterministic status (`active` / `aging` / `ghost`).
+- **usage --health**: which skills earn their context budget (loads
+  vs. citations from real review runs).
+
+#### Status thresholds
+
+- **ghost**: `decision_count == 0` AND `bytes > 2000` — loaded into
+  every context but author never iterates; candidate for usage-side
+  confirmation + archive.
+- **aging**: last-modified > 90 days ago — was useful once, hasn't
+  been touched in a quarter.
+- **active**: otherwise.
+
+#### CLI surface
+
+- `logmind skill audit` — human-readable table sorted by skill name
+  with `name`, `status`, `bytes`, `decisions`, `last touched`. Summary
+  line: `ok skill: audit 7 skills (3 active, 2 aging, 2 ghost)`.
+- `logmind skill audit --json` — machine-readable array per skill,
+  status enriched.
+
+#### Implementation
+
+- `src/logmind/core/skill_cli.py`: `audit_skills(repo_root)` walks
+  `.claude/skills/*/SKILL.md`, counts decision-log mentions across
+  `docs/decisions.md` + `docs/decisions-branches/*.md`, prefers
+  `git log -1 --format=%cs --` for `last_modified` (falls back to
+  file mtime). `classify_audit_row(row, now=)` applies thresholds;
+  injectable `now` for testability.
+- `src/logmind/cli.py`: `@skill.command("audit")` wiring.
+- `tests/test_skill_cli.py`: 13 new tests covering directory walking,
+  decision counting (incl. branch decision files), every status
+  bucket, CLI rendering, JSON output, edge cases (no skills, empty
+  directory, invalid date).

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -13,7 +13,8 @@ agent-skills
 ├── .logmind
 │   └── config.yml
 ├── .skill-update-todo
-│   └── v0.6.1.md
+│   ├── v0.6.1.md
+│   └── v0.6.4.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -215,6 +215,41 @@ regardless of `--quiet` (JSON is primary output, not progress). The
 `click.secho` so red/yellow error/warning output still prints under
 `LOGMIND_QUIET=1` — only progress chatter (cyan/green) is suppressed.
 
+## Skill lifecycle: `logmind skill audit` (v0.6.4+)
+
+Use `logmind skill audit` to get a staleness read on every `SKILL.md` in
+`.claude/skills/`. This is the **author-side** view of skill health; it
+pairs with `clud-bug usage --health` (the enforcement/load-vs-citation
+read) for a complete picture.
+
+```bash
+logmind skill audit          # human-readable table: name, status, bytes, decisions, last touched
+logmind skill audit --json   # machine-readable array per skill, status enriched
+```
+
+Example summary line:
+
+```
+ok skill: audit 7 skills (3 active, 2 aging, 2 ghost)
+```
+
+#### Status thresholds
+
+| Status | Condition | What it means |
+|--------|-----------|---------------|
+| **ghost** | `decision_count == 0` AND `bytes > 2000` | Loaded into every context but the author has never iterated on it; candidate for usage-side confirmation + archive |
+| **aging** | last-modified > 90 days ago | Was useful once, hasn't been touched in a quarter |
+| **active** | otherwise | Healthy |
+
+`last_modified` is resolved via `git log -1 --format=%cs --` (falls back
+to file mtime). `decisions` counts mentions across `docs/decisions.md` +
+`docs/decisions-branches/*.md`.
+
+Use audit output to decide which skills to refresh, archive, or promote.
+Ghost skills in particular should be investigated: a large skill that
+never appears in decision logs is burning context budget without visible
+payback.
+
 ## Verifying install health
 
 `logmind doctor` (v0.2.4+) reports installed-vs-latest versions for logmind
@@ -307,6 +342,9 @@ Common deltas you'll see if you're upgrading across a stretch:
   `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
   fires when the gap between your branch and `origin/<default>` is
   exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+- **v0.6.4**: `logmind skill audit` added — author-side staleness read
+  for every SKILL.md in `.claude/skills/`, with `active`/`aging`/`ghost`
+  status classification and `--json` output.
 
 ## Setup (one-time, per project)
 
@@ -342,6 +380,9 @@ logmind doctor             # confirm clean install
   If the gap between branches includes code files, `docs/file-structure.md`,
   or any file other than `docs/timeline.md`, auto-rebase will refuse and
   emit a heads-up — handle the rebase manually.
+- **Don't ignore `ghost` skills surfaced by `logmind skill audit`.** A skill
+  with zero decision-log mentions and > 2 000 bytes is burning context budget
+  every session without visible payback — investigate, refresh, or archive it.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.4 shipped.

**CHANGELOG**: [`v0.6.4` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.4/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.4

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The changelog introduces `logmind skill audit` — a new CLI command (`logmind skill audit` and `logmind skill audit --json`) with user-visible behavior including status thresholds (active/aging/ghost), output format, and how it pairs with `clud-bug usage --health`. This is a new CLI surface that agents using logmind should know about, particularly for skill lifecycle management.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] Verify the SKILL.md diff accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.