### PR TITLE
logmind v0.6.5 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.5.md
+++ b/.skill-update-todo/v0.6.5.md
@@ -1,0 +1,59 @@
+# logmind v0.6.5 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.5/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.5
+
+## Claude's reasoning
+
+The changelog introduces a new CLI command `logmind skill suggest` with multiple flags (`--since`, `--min-decisions`, `--top`, `--write-drafts`, `--json`), explicit "never auto-PR, never auto-create a skill" guidance, and new behavior around human-gated skill lifecycle. This is a user-visible CLI surface change that agents need to know about, including the critical "never auto-PR/auto-create" constraint which belongs in the Don'ts section.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.5] - 2026-06-01
+
+### Added — `logmind skill suggest` (Stream 6 follow-on, killed-Stream-9 replacement)
+
+Human-initiated pattern detection that scans recent decision-log
+entries for tokens appearing across many distinct decisions — a
+heuristic signal that "we keep talking about X, maybe X should have
+its own skill." Output is a pre-filled GH-issue draft matching
+agent-skills's `new-skill.yml` template. The human reads, decides,
+opens (or discards).
+
+**Never auto-PR. Never auto-create a skill.** The whole point of the
+pragmatic SkDD pivot (2026-05-30) is that humans gate skill lifecycle.
+
+#### Detection heuristics
+
+- Tokenize decision entries into kebab-case / PascalCase / acronym /
+  snake_case identifiers (regex: `_INTERESTING_TOKEN_RE`).
+- Filter stop words + generic structural terms (`_SUGGEST_STOPWORDS`).
+- Count distinct-decision occurrences (a token mentioned 5x in one
+  decision = 1 entry, not 5).
+- Drop tokens that match an existing skill name (already covered).
+- Rank by # distinct decisions; cap at `--top` results.
+
+#### CLI surface
+
+- `logmind skill suggest` — scan last 30 days, ≥3 decisions, top 5.
+- `logmind skill suggest --since 7d --top 10`
+- `logmind skill suggest --min-decisions 5` — tighter signal
+- `logmind skill suggest --write-drafts /tmp/proposals/` — write each
+  suggestion's pre-filled GH-issue body to a `.md` file
+- `logmind skill suggest --json` — machine-readable output
+
+#### Implementation
+
+- `src/logmind/core/skill_cli.py`:
+  - `suggest_skills_from_decisions(repo_root, since_days, min_decisions, top_n)`
+    — returns ranked suggestions
+  - `format_suggest_issue_draft(suggestion)` — renders one suggestion
+    as the pre-filled GH-issue markdown body
+  - `_gather_recent_decisions`, `_excerpt_around`, `_kebab_slug` —
+    internal helpers
+- `src/logmind/cli.py`: `@skill.command("suggest")` with `--since`,
+  `--min-decisions`, `--top`, `--write-drafts`, `--json`.
+- `tests/test_skill_cli.py`: 14 new tests (kebab-case detection,
+  stopword filter, existing-skill exclusion, threshold semantics,
+  intra-entry dedup, main + branch file aggregation, slug
+  normalization, draft formatting, CLI rendering, JSON output,
+  --write-drafts, bad --since validation).

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -13,7 +13,8 @@ agent-skills
 ├── .logmind
 │   └── config.yml
 ├── .skill-update-todo
-│   └── v0.6.1.md
+│   ├── v0.6.1.md
+│   └── v0.6.5.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -269,6 +269,32 @@ command, you should not run it by hand in the normal flow — it exists
 for the merge driver and as an escape hatch (corrupted file, externally
 modified tree).
 
+## Skill suggestion: `logmind skill suggest` (v0.6.5+)
+
+`logmind skill suggest` scans recent decision-log entries for tokens that
+appear across many distinct decisions — a heuristic signal that "we keep
+talking about X, maybe X should have its own skill." Output is a pre-filled
+GitHub-issue draft matching the `new-skill.yml` template.
+
+**This command is human-initiated and produces a draft only. It never
+opens a PR, never creates a skill, and never takes any automated action.**
+Skill lifecycle is always human-gated.
+
+```bash
+logmind skill suggest                        # scan last 30 days, ≥3 decisions, top 5 suggestions
+logmind skill suggest --since 7d --top 10   # narrow window, more results
+logmind skill suggest --min-decisions 5     # tighter signal threshold
+logmind skill suggest --write-drafts /tmp/proposals/  # write each draft to a .md file
+logmind skill suggest --json                # machine-readable output
+```
+
+Detection heuristics:
+- Tokenizes entries into kebab-case / PascalCase / acronym / snake_case identifiers.
+- Filters stop words and generic structural terms.
+- Counts distinct-decision occurrences (a token mentioned 5× in one decision = 1, not 5).
+- Drops tokens that already match an existing skill name.
+- Ranks by number of distinct decisions; caps at `--top` results.
+
 ## Upgrading: `logmind init` prints the changelog
 
 When you run `pip install --upgrade logmind && logmind init` in an
@@ -307,6 +333,9 @@ Common deltas you'll see if you're upgrading across a stretch:
   `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
   fires when the gap between your branch and `origin/<default>` is
   exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+- **v0.6.5**: `logmind skill suggest` added — human-initiated pattern
+  detection that proposes candidate skill topics as GH-issue drafts.
+  Never auto-creates or auto-PRs a skill.
 
 ## Setup (one-time, per project)
 
@@ -342,6 +371,11 @@ logmind doctor             # confirm clean install
   If the gap between branches includes code files, `docs/file-structure.md`,
   or any file other than `docs/timeline.md`, auto-rebase will refuse and
   emit a heads-up — handle the rebase manually.
+- **Don't auto-PR or auto-create a skill based on `logmind skill suggest`
+  output.** `logmind skill suggest` produces a draft GH-issue body for
+  human review only. Skill lifecycle is always human-gated: a human reads
+  the draft, decides, and opens (or discards) the issue. Never automate
+  this step.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.5 shipped.

**CHANGELOG**: [`v0.6.5` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.5/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.5

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The changelog introduces a new CLI command `logmind skill suggest` with multiple flags (`--since`, `--min-decisions`, `--top`, `--write-drafts`, `--json`), explicit "never auto-PR, never auto-create a skill" guidance, and new behavior around human-gated skill lifecycle. This is a user-visible CLI surface change that agents need to know about, including the critical "never auto-PR/auto-create" constraint which belongs in the Don'ts section.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] Verify the SKILL.md diff accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.