### PR TITLE
logmind v0.6.8 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.8.md
+++ b/.skill-update-todo/v0.6.8.md
@@ -1,0 +1,64 @@
+# logmind v0.6.8 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.8/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.8
+
+## Claude's reasoning
+
+The changelog introduces a new CLI flag `logmind init --with-skdd` that users/agents should know about when setting up projects. This is a user-visible behavior change to the `logmind init` command (a core setup command) that collapses the multi-step SkDD toolchain bootstrap into one command, with specific behaviors around npx availability and subprocess failure handling. The Setup section and any upgrade notes in SKILL.md should reflect this new flag.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.8] - 2026-06-01
+
+### Added — `logmind init --with-skdd` (unified install, Python entry)
+
+One-command bootstrap for the full SkDD toolchain. Previously the
+install sequence was 3 commands across 2 ecosystems:
+
+```bash
+pip install logmind
+logmind init
+npx clud-bug init
+```
+
+The new `--with-skdd` flag collapses the last two:
+
+```bash
+pip install logmind
+logmind init --with-skdd   # logmind + clud-bug, one command
+```
+
+#### Why the bundle naming
+
+The flag name describes the BUNDLE TARGET (the SkDD toolchain),
+not a specific tool. As the toolchain grows beyond logmind + clud-bug
+(future skills authoring tools, etc.), the same flag stays — no
+flag-explosion API surface. The Node side ships a symmetric mirror
+in clud-bug v0.6.33 (`clud-bug init --with-skdd`).
+
+#### Behavior
+
+- Default (no flag): logmind init unchanged — Python-only install.
+- With `--with-skdd` + `npx` on PATH: subprocesses to
+  `npx --yes clud-bug@latest init` after logmind setup completes.
+  Stream output to user (not silenced).
+- With `--with-skdd` + no `npx`: emits a clear warning with the
+  recovery command (`npx --yes clud-bug@latest init`), exit code 0.
+- Subprocess failure (non-zero exit, OSError): warning surfaced but
+  logmind init still succeeds — clud-bug is an additive layer.
+
+#### Anti-loop guarantee
+
+`logmind init --with-skdd` invokes `npx clud-bug init` (NOT
+`clud-bug init --with-skdd`). v0.6.33's mirror does the same
+in reverse. Each opt-in only goes one level deep; no mutual
+recursion possible.
+
+#### Implementation
+
+- `src/logmind/cli.py`: new `--with-skdd` flag (mirrors the existing
+  `--install-hook` opt-in pattern) + `_install_skdd_via_npx()` helper
+  with `shutil.which` check + graceful subprocess error handling.
+- `tests/test_init_with_skdd.py`: 6 new tests covering flag
+  acceptance / no-flag baseline / npx-invocation / no-npx-warning /
+  non-zero-exit-warning / OSError-warning.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -13,7 +13,8 @@ agent-skills
 ├── .logmind
 │   └── config.yml
 ├── .skill-update-todo
-│   └── v0.6.1.md
+│   ├── v0.6.1.md
+│   └── v0.6.8.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -307,6 +307,9 @@ Common deltas you'll see if you're upgrading across a stretch:
   `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
   fires when the gap between your branch and `origin/<default>` is
   exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+- **v0.6.8**: `logmind init --with-skdd` bootstraps the full SkDD
+  toolchain (logmind + clud-bug) in one command. Without the flag,
+  `logmind init` is unchanged.
 
 ## Setup (one-time, per project)
 
@@ -317,6 +320,34 @@ pip install logmind
 logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block, merge drivers + post-merge hook (v0.3.0+)
 logmind doctor             # confirm clean install
 ```
+
+### Full SkDD toolchain in one command (v0.6.8+)
+
+If your project uses the SkDD toolchain (logmind + clud-bug), use
+`--with-skdd` to bootstrap both tools in a single step:
+
+```bash
+pip install logmind
+logmind init --with-skdd   # runs logmind init, then npx --yes clud-bug@latest init
+logmind doctor             # confirm clean install
+```
+
+Behavior details:
+
+- **No flag**: `logmind init` runs as always — Python-only, no change.
+- **`--with-skdd` + `npx` on PATH**: after logmind setup completes,
+  subprocesses to `npx --yes clud-bug@latest init` and streams its
+  output to you (not silenced).
+- **`--with-skdd` + no `npx`**: emits a clear warning with the manual
+  recovery command (`npx --yes clud-bug@latest init`); exits 0. Logmind
+  init itself still succeeds.
+- **Subprocess failure** (non-zero exit or OSError): warning is surfaced
+  but logmind init still succeeds — clud-bug is an additive layer.
+
+The flag targets the bundle (the SkDD toolchain), not a specific tool,
+so it stays stable as the toolchain grows. There is no mutual recursion:
+`logmind init --with-skdd` calls `npx clud-bug init` (without
+`--with-skdd`), going only one level deep.
 
 ## Don'ts
 


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.8 shipped.

**CHANGELOG**: [`v0.6.8` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.8/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.8

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The changelog introduces a new CLI flag `logmind init --with-skdd` that users/agents should know about when setting up projects. This is a user-visible behavior change to the `logmind init` command (a core setup command) that collapses the multi-step SkDD toolchain bootstrap into one command, with specific behaviors around npx availability and subprocess failure handling. The Setup section and any upgrade notes in SKILL.md should reflect this new flag.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] Verify the SKILL.md diff accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.