### PR TITLE
logmind v0.6.9 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.9.md
+++ b/.skill-update-todo/v0.6.9.md
@@ -1,0 +1,67 @@
+# logmind v0.6.9 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.9/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.9
+
+## Claude's reasoning
+
+The changelog introduces `logmind file-structure --check`, a new CLI flag that enables CI gate symmetry with `logmind timeline --check`. This is a user-visible new flag with specific exit codes (0, 1, 2) and behavior that agents using CI patterns should know about. It also closes the asymmetry between `timeline --check` and `file-structure --check`, which affects how CI workflows should be written.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.9] - 2026-06-01
+
+### Added — `logmind file-structure --check` (symmetric with `timeline --check`)
+
+`logmind timeline --check` has shipped since v0.5.13 — exits non-zero when
+the on-disk `docs/timeline.md` differs from a fresh regen, so CI can fail
+the build before the auto-fix step. The mirror command `logmind
+file-structure` has been missing the same flag; v0.6.9 closes that
+asymmetry.
+
+```bash
+# Used by CI / pre-commit gates: "are derived docs stale?"
+logmind file-structure --write docs/file-structure.md --check
+#   → exit 0 + "✓ up to date"  if current
+#   → exit 1 + "✗ stale — re-run …" if regen would change the file
+#   → exit 2 + "requires --write" if --write is missing
+```
+
+The `regen-timeline.yml` workflow template can now use explicit `--check`
+calls for both derived docs (cleaner than the current
+`--write` + `git diff --quiet` pattern, though that still works fine).
+
+### Context — closes #93 (the v0.5.14 "conflict-tolerant regen merge driver" candidate)
+
+The original framing of "always-fire merge driver to catch silent-success
+3-way merge interleaves on `docs/timeline.md`" turned out to be infeasible
+by git design — merge drivers only invoke on conflict, and
+`pre-merge-commit` hooks don't fire on GitHub's server-side squash-merge
+flow (the dominant case). Practical coverage of the original problem has
+been built up across multiple releases:
+
+- **v0.5.11** post-rewrite hook (rebases + amends regen + stage)
+- **v0.5.12** driver auto-install on fresh clones / CI
+- **v0.5.13** `logmind rebase` convenience + doctor stale-derived warning
+- **v0.6.7** post-merge leaves regen unstaged (next `logmind log` picks
+  up cleanly)
+- `regen-timeline.yml` v3 template with `LOGMIND_AUTO_REGEN_PAT`-driven
+  auto-fix mode (regenerates derived docs + pushes back to the PR branch
+  when the PAT secret is configured; PAT-pushed commits re-trigger
+  downstream checks, unlike GITHUB_TOKEN-pushed ones)
+- `logmind timeline --check` (CI gate) since v0.5.13
+
+v0.6.9's `file-structure --check` completes the CI-gate symmetry. The
+practical problem #93 surfaced is now covered end-to-end:
+
+```text
+local merge → post-merge hook regens → unstaged → next `logmind log` stages
+       OR
+GitHub squash-merge → check-derived-docs workflow on next PR catches stale
+       OR (with PAT)
+GitHub squash-merge → check-derived-docs auto-regens + pushes back
+       OR (in pre-commit / CI)
+`logmind timeline --check` + `logmind file-structure --check` exit non-zero
+```
+
+No new merge-driver mechanism is shipping. Issue #93 closed with this
+context.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -13,7 +13,8 @@ agent-skills
 ├── .logmind
 │   └── config.yml
 ├── .skill-update-todo
-│   └── v0.6.1.md
+│   ├── v0.6.1.md
+│   └── v0.6.9.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -269,6 +269,37 @@ command, you should not run it by hand in the normal flow — it exists
 for the merge driver and as an escape hatch (corrupted file, externally
 modified tree).
 
+## CI gates: `--check` flag for derived docs (v0.5.13+ / v0.6.9+)
+
+Both derived-doc commands support a `--check` flag for use in CI and
+pre-commit gates. `--check` does **not** write anything — it exits
+non-zero when the on-disk file differs from a fresh regeneration, so
+the build fails before any auto-fix step runs.
+
+### `logmind timeline --check` (v0.5.13+)
+
+```bash
+logmind timeline --write docs/timeline.md --check
+#   → exit 0 + "✓ up to date"  if current
+#   → exit 1 + "✗ stale — re-run …" if regen would change the file
+#   → exit 2 + "requires --write" if --write is missing
+```
+
+### `logmind file-structure --check` (v0.6.9+)
+
+```bash
+logmind file-structure --write docs/file-structure.md --check
+#   → exit 0 + "✓ up to date"  if current
+#   → exit 1 + "✗ stale — re-run …" if regen would change the file
+#   → exit 2 + "requires --write" if --write is missing
+```
+
+Both flags are symmetric: require `--write` to specify the target path,
+exit 0/1/2 with the same semantics, and are CI-pluggable (non-zero on
+stale). Use them instead of the older `--write` + `git diff --quiet`
+pattern in `regen-timeline.yml` or similar workflow templates (though
+the old pattern still works).
+
 ## Upgrading: `logmind init` prints the changelog
 
 When you run `pip install --upgrade logmind && logmind init` in an
@@ -307,6 +338,9 @@ Common deltas you'll see if you're upgrading across a stretch:
   `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
   fires when the gap between your branch and `origin/<default>` is
   exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+- **v0.6.9**: `logmind file-structure --check` added (mirrors
+  `logmind timeline --check` from v0.5.13). Both derived-doc commands
+  now support CI-gate `--check` with exit 0/1/2 semantics.
 
 ## Setup (one-time, per project)
 
@@ -342,6 +376,11 @@ logmind doctor             # confirm clean install
   If the gap between branches includes code files, `docs/file-structure.md`,
   or any file other than `docs/timeline.md`, auto-rebase will refuse and
   emit a heads-up — handle the rebase manually.
+- **Don't use `--write` + `git diff --quiet` to check derived-doc staleness
+  in CI when `--check` is available.** Prefer `logmind timeline --check`
+  (v0.5.13+) and `logmind file-structure --check` (v0.6.9+) — they give
+  cleaner exit codes (0/1/2) and explicit stale messages without touching
+  the working tree.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.9 shipped.

**CHANGELOG**: [`v0.6.9` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.9/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.9

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The changelog introduces `logmind file-structure --check`, a new CLI flag that enables CI gate symmetry with `logmind timeline --check`. This is a user-visible new flag with specific exit codes (0, 1, 2) and behavior that agents using CI patterns should know about. It also closes the asymmetry between `timeline --check` and `file-structure --check`, which affects how CI workflows should be written.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] Verify the SKILL.md diff accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.