### PR TITLE
chore: refresh logmind v0.5.6 → v0.6.9

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -30,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.5.6"
+        run: pip install "logmind==0.6.9"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -65,7 +65,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.5.6"
+        run: pip install "logmind==0.6.9"
 
       - name: Regenerate derived docs
         run: |

--- a/docs/decisions-branches/chore__logmind-v0.6.9.md
+++ b/docs/decisions-branches/chore__logmind-v0.6.9.md
@@ -1,0 +1,10 @@
+## 2026-06-01 17:16 - chore: refresh logmind v0.5.6 → v0.6.9
+
+**Reasoning:** Workflow pins from v0.5.6 → v0.6.9. Picks up v0.6.7 post-merge unstaged fix + v0.6.9 file-structure --check + v0.6.8 --with-skdd. AGENTS.md was already current.
+
+**Alternatives considered:** Wait for scheduled self-update (blocked by GITHUB_TOKEN workflow-permission gap)
+
+**Implications:**
+- Manual propagation via local logmind 0.6.9 + PAT push (workaround for the auto-propagation failure)
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (3 decisions)
+## 2026-06 (4 decisions)
 
-- **2026-06-01** — chore: propagate clud-bug v0.6.32 *(chore/clud-bug-v0.6.32)* — [decisions-branches/chore__clud-bug-v0.6.32.md](decisions-branches/chore__clud-bug-v0.6.32.md)
-- *... 1 more decision ...*
+- **2026-06-01** — chore: refresh logmind v0.5.6 → v0.6.9 *(chore/logmind-v0.6.9)* — [decisions-branches/chore__logmind-v0.6.9.md](decisions-branches/chore__logmind-v0.6.9.md)
+- *... 2 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (39 decisions)


### PR DESCRIPTION
Workflow pins from v0.5.6 → v0.6.9. Picks up v0.6.7 post-merge unstaged fix + v0.6.9 `file-structure --check` + v0.6.8 `--with-skdd`. AGENTS.md was already current.

The org self-update workflow ran first but failed at the push step (GITHUB_TOKEN lacks `workflows: write` permission for updating `check-doc-links.yml`). Manually propagated via local logmind v0.6.9 + my PAT. Captured as a v0.6.10 candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)