### PR TITLE
logmind v0.6.10 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.10.md
+++ b/.skill-update-todo/v0.6.10.md
@@ -1,0 +1,67 @@
+# logmind v0.6.10 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.10/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.10
+
+## Claude's reasoning
+
+v0.6.10 introduces user-visible behavior changes: (1) hooks now embed a version marker, (2) `logmind doctor` now detects hook version drift (stale/markerless) and exits non-zero on it, and (3) `logmind log` auto-refreshes stale hooks on upgrade. These are agent-facing behaviors that affect how agents should understand `logmind doctor` output and the self-healing behavior of `logmind log` after a binary upgrade.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.10] - 2026-06-01
+
+### Added — Hook-version drift detection (tokenomics 2026-06-01 bug report)
+
+The tokenomics agent flagged a recurrence of the post-merge hook
+checkout-blocking bug AFTER v0.6.9 propagation. Root cause (correctly
+diagnosed by the reporter): the local CLI binary was still v0.3.4, so
+every `logmind log` overwrote `.git/hooks/post-merge` with v0.3.4's
+body (which stages). The workflow-pin upgrade alone does NOT refresh
+local hooks; that requires a binary upgrade on the user's box.
+
+v0.6.10 makes this drift LOUDLY visible:
+
+1. **Hook bodies now embed a version marker** — every installed
+   post-merge + post-rewrite hook contains a
+   `# logmind-hook-version: <X.Y.Z>` line written by the binary that
+   created it.
+
+2. **`logmind doctor` extracts the marker** and compares to the
+   currently-running binary's `__version__`. Drift surfaces as
+   `stale` (marker version differs) or `markerless` (pre-v0.6.10
+   hook). Both are aggregated into the overall-drift signal so
+   doctor exits non-zero.
+
+3. **`install_post_merge_hook` always rewrites when the body
+   differs** — so when a user upgrades binary (v0.3.4 → v0.6.10),
+   the next `logmind log` automatically refreshes the local hook
+   to v0.6.10's body. Self-healing on first upgrade.
+
+### What this fixes vs doesn't fix
+
+- **Fixes**: future drift is loud. After upgrading to v0.6.10+,
+  `logmind doctor` always tells the user when their on-disk hook
+  is stale relative to the binary running. One-command fix:
+  `pip install --upgrade logmind && logmind log` self-heals.
+- **Doesn't fix on its own**: a user stuck at v0.3.4 today can't
+  benefit until they upgrade. The reporter's immediate remediation:
+  `PYENV_VERSION=3.11.8 pip install --upgrade logmind` then
+  `logmind log` once.
+
+### Code
+
+- `src/logmind/core/gitattributes.py` — `HOOK_VERSION_PREFIX` constant,
+  `_build_post_merge_hook_body()` + `_build_post_rewrite_hook_body()`
+  builders that inject `__version__`, new helpers
+  `installed_post_merge_hook_version` / `installed_post_rewrite_hook_version`.
+- `src/logmind/core/doctor.py` — probes now extract the marker,
+  compare versions, return `drift="stale" | "markerless" | "current"`.
+- `tests/test_merge_driver.py` — 5 new tests pinning marker shape,
+  extractor, doctor drift detection, and auto-refresh path.
+
+### Deferred to v0.6.11
+
+The full root-cause fix (skip regen when current branch is orphaned
+post-merge-away) is captured in the plan as a v0.6.11 candidate. Ships
+after v0.6.10 propagates if the doctor warning isn't enough to close
+the loop in practice.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -12,6 +12,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.6.10.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -78,6 +78,11 @@ command, and you do NOT need to run `logmind timeline --write` separately:
 7. **`git commit`** with message `logmind: <decision>`.
 8. **`git push`** to remote (configurable via `auto_push` in
    `.logmind/config.yml`).
+9. **(v0.6.10+) Auto-refreshes stale hooks** — if the on-disk
+   `.git/hooks/post-merge` or `post-rewrite` body differs from what the
+   current binary would write, `logmind log` rewrites the hook in place.
+   Self-healing: upgrading the binary then running `logmind log` once is
+   sufficient to refresh local hooks.
 
 ## `logmind log` IS the commit primitive (no manual git after it)
 
@@ -235,6 +240,22 @@ auto-healed by `logmind init` itself in v0.2.5+, even when no template
 body changed. **If `doctor` reports an `AGENTS.md` stale row, your repo's
 embedded logmind instructions are older than what the installed logmind
 would write — re-run `logmind init` to refresh in place.**
+
+### Hook-version drift detection (v0.6.10+)
+
+Starting in v0.6.10, installed hooks embed a `# logmind-hook-version: <X.Y.Z>`
+marker. `logmind doctor` extracts this marker and compares it to the running
+binary's version:
+
+- **`current`** — hook matches binary; no action needed.
+- **`stale`** — hook version differs from binary (e.g. local binary was
+  upgraded but hook was written by an older version, or vice versa).
+- **`markerless`** — hook predates v0.6.10 and has no marker.
+
+Both `stale` and `markerless` are aggregated into the overall drift signal —
+`logmind doctor` exits non-zero when either is present. **Self-healing**: the
+next `logmind log` after a binary upgrade automatically rewrites the hook if
+the body differs. One-command fix: `pip install --upgrade logmind && logmind log`.
 
 ### Derived-doc freshness check (v0.5.13+ / v0.6.9+)
 
@@ -401,6 +422,9 @@ Common deltas you'll see if you're upgrading across a stretch:
   `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
   fires when the gap between your branch and `origin/<default>` is
   exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+- **v0.6.10**: Hooks embed a version marker; `logmind doctor` detects
+  hook-version drift (`stale` / `markerless`) and exits non-zero.
+  `logmind log` self-heals stale hooks on first run after binary upgrade.
 
 ## Setup (one-time, per project)
 
@@ -453,6 +477,10 @@ The flag name describes the BUNDLE TARGET (the SkDD toolchain), not a specific t
   If the gap between branches includes code files, `docs/file-structure.md`,
   or any file other than `docs/timeline.md`, auto-rebase will refuse and
   emit a heads-up — handle the rebase manually.
+- **Don't ignore `logmind doctor` hook-version drift warnings (v0.6.10+).**
+  A `stale` or `markerless` hook row means the on-disk hook was written by
+  a different binary version. Self-heal with
+  `pip install --upgrade logmind && logmind log` (runs once, rewrites hook).
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.10 shipped.

**CHANGELOG**: [`v0.6.10` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.10/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.10

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

v0.6.10 introduces user-visible behavior changes: (1) hooks now embed a version marker, (2) `logmind doctor` now detects hook version drift (stale/markerless) and exits non-zero on it, and (3) `logmind log` auto-refreshes stale hooks on upgrade. These are agent-facing behaviors that affect how agents should understand `logmind doctor` output and the self-healing behavior of `logmind log` after a binary upgrade.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] Verify the SKILL.md diff accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.