### PR TITLE
chore: refresh logmind v0.6.9 → v0.6.11

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -30,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.9"
+        run: pip install "logmind==0.6.11"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -65,7 +65,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.9"
+        run: pip install "logmind==0.6.11"
 
       - name: Regenerate derived docs
         run: |

--- a/docs/decisions-branches/chore__logmind-v0.6.11.md
+++ b/docs/decisions-branches/chore__logmind-v0.6.11.md
@@ -1,0 +1,8 @@
+## 2026-06-01 19:21 - chore: refresh logmind v0.6.9 → v0.6.11
+
+**Reasoning:** Manual propagation: pin bump + AGENTS.md refresh.
+
+**Implications:**
+- Workflow templates pick up v5 self-update body for future cleaner auto-propagation
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (5 decisions)
+## 2026-06 (6 decisions)
 
-- **2026-06-01** — chore: consolidate notify-skills v0.6.3 → v0.6.9 into SKILL.md *(chore/consolidate-notify-skills-v0.6.3-v0.6.9)* — [decisions-branches/chore__consolidate-notify-skills-v0.6.3-v0.6.9.md](decisions-branches/chore__consolidate-notify-skills-v0.6.3-v0.6.9.md)
-- *... 3 more decisions ...*
+- **2026-06-01** — chore: refresh logmind v0.6.9 → v0.6.11 *(chore/logmind-v0.6.11)* — [decisions-branches/chore__logmind-v0.6.11.md](decisions-branches/chore__logmind-v0.6.11.md)
+- *... 4 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (39 decisions)


### PR DESCRIPTION
Workflow pins v0.6.9 → v0.6.11. Manually propagated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)