### PR TITLE
logmind self-update: 0.6.11 → 0.6.12

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -30,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.11"
+        run: pip install "logmind==0.6.12"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -65,7 +65,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.11"
+        run: pip install "logmind==0.6.12"
 
       - name: Regenerate derived docs
         run: |


### PR DESCRIPTION
Automated upgrade from logmind 0.6.11 → 0.6.12.

PR-creation step in the self-update workflow failed because GitHub Actions is not permitted to create PRs in this repo. Branch was already pushed via the PAT; this PR is manually created for it. Adding the PAT to the gh pr create step is queued as a v0.6.13 candidate in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)