### PR TITLE
logmind v0.6.13 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.13.md
+++ b/.skill-update-todo/v0.6.13.md
@@ -1,0 +1,49 @@
+# logmind v0.6.13 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.13/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.13
+
+## Claude's reasoning
+
+The changelog introduces two user-visible behavioral changes relevant to agents: (1) `logmind log` no longer silently mutates template files — it now only detects drift and emits a warning pointing to the new `logmind self-update` command; and (2) a new `logmind self-update` command is introduced. These are directly agent-facing: agents use `logmind log` as their primary primitive, and the new behavior (no piggyback commits, drift warning, new command) changes what agents should know and do.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.13] - 2026-06-01
+
+Four consumer-product UX fixes accumulated from the 2026-06-01 propagation cycle. All four ship together.
+
+### Fixed — Post-merge hook skips regen on orphan branches (issue #112)
+
+The post-merge hook body now detects "this branch's upstream remote-tracking ref no longer exists" (typical after `gh pr merge --delete-branch` + `git fetch --prune`) and skips regen entirely. Skipping > regen-then-leave-unstaged > stage-and-block-checkout. Closes the chronic "post-merge hook blocks `gh pr merge --delete-branch`'s follow-up `git checkout main`" symptom that recurred on tokenomics across all version upgrades from v0.5.6 → v0.6.12, including for users whose local CLI binary is stale (v0.6.10's doctor warning was invisible to them inline). The orphan-branch detection lives in the hook BODY, so it works even when the locally-installed hook was written by an older binary, as long as the next refresh installs v0.6.13's body.
+
+Files: `src/logmind/core/gitattributes.py` `_build_post_merge_hook_body`.
+
+### Fixed — `logmind log` no longer piggy-backs self-update commits (issue #113)
+
+Previously, `logmind log` called `sync_agent_files_from_config()` which silently rewrote `AGENTS.md` and per-agent stub files when their templates were stale. The rewrites got folded into the user's decision commit, producing piggy-back commits on their feature branch that raced with concurrent self-update PRs. When the self-update PR landed first, the user's branch went CONFLICTING.
+
+v0.6.13:
+- `logmind log` now calls a NEW read-only `detect_template_drift()` function. Drift is **observed** and surfaced as a one-line warning that directs the user to `logmind self-update`. No files mutated.
+- NEW `logmind self-update` command applies the refresh explicitly (calls the existing `sync_agent_files_from_config` + refreshes local hooks). Users run it when they're ready.
+
+Other refresh-touching commands (`init`, `rebase`, `search`, `agents update`) still call `sync_agent_files_from_config` since those are explicitly maintenance operations. Only `log` was conflating decision-logging with template-refresh.
+
+Files: `src/logmind/core/inserter.py` (new `detect_template_drift`), `src/logmind/cli.py` (`log_cmd` swap + new `self_update_cmd`).
+
+### Fixed — `logmind-self-update.yml` v6: smart workflow-skip + PAT for `gh pr create`
+
+Two related self-update template fixes, both surfaced by today's v0.6.12 propagation cycle:
+
+**(c) Smart workflow-skip**: when a release would touch any `.github/workflows/*.yml` file AND no `LOGMIND_AUTO_REGEN_PAT` is configured, the workflow now emits a `::notice::` and exits cleanly instead of failing with a 403. Pin-bump-only releases (no workflow body changes) propagate normally via GITHUB_TOKEN. External consumers get clean pin-bump auto-propagation without the PAT setup; template-touching releases politely defer until they configure it.
+
+**(d) `gh pr create` uses PAT too**: 2 of 5 thrillmade consumer repos (agent-skills, clud-bug) failed during the v0.6.12 self-heal validation at `gh pr create` with `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)`. The push step used the PAT and worked; the `gh pr create` step used GITHUB_TOKEN and hit a per-repo setting. v6 now uses the PAT (with GITHUB_TOKEN fallback) for `gh pr create` too, eliminating the second per-repo setup checkbox.
+
+Files: `src/logmind/templates/github/logmind-self-update.yml.template` (bumped to v6); `tests/test_v0_2_1_audit_fixes.py` (marker bumped to v6).
+
+### Validation gate end-to-end
+
+After v0.6.13 lands, re-running the v0.6.12-style consumer propagation cycle should:
+- 5/5 consumer self-update workflows succeed first attempt (no manual bridging)
+- Pin-bump-only releases propagate to non-PAT-configured external consumers normally
+- `logmind log` on a repo with stale templates produces a decision commit with NO piggy-back self-update content; user sees the drift warning + remediation pointer
+- Issue #112 post-merge hook bug no longer recurs on tokenomics regardless of their local binary version (the hook body's orphan-detection short-circuits before regen)

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -12,6 +12,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.6.13.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -79,6 +79,12 @@ command, and you do NOT need to run `logmind timeline --write` separately:
 8. **`git push`** to remote (configurable via `auto_push` in
    `.logmind/config.yml`).
 
+**v0.6.13+: `logmind log` is READ-ONLY with respect to template files.**
+It no longer rewrites `AGENTS.md` or per-agent stub files when templates
+are stale. Instead it emits a one-line warning and directs you to
+`logmind self-update`. This prevents piggyback template-refresh commits
+from appearing on your feature branch.
+
 ## `logmind log` IS the commit primitive (no manual git after it)
 
 `logmind log` defaults to `--stage all` (since v0.2.7): every change in
@@ -234,7 +240,8 @@ templates / pins / instructions might have drifted. Stale-pin drift is
 auto-healed by `logmind init` itself in v0.2.5+, even when no template
 body changed. **If `doctor` reports an `AGENTS.md` stale row, your repo's
 embedded logmind instructions are older than what the installed logmind
-would write — re-run `logmind init` to refresh in place.**
+would write — run `logmind self-update` (v0.6.13+) or re-run
+`logmind init` to refresh in place.**
 
 ### Derived-doc freshness check (v0.5.13+ / v0.6.9+)
 
@@ -276,7 +283,10 @@ Two PRs that both run `logmind log` no longer textually conflict on
   the full post-merge working tree. Belt + suspenders: the driver runs
   per-file mid-merge before the other branch's `docs/decisions-branches/`
   files are checked out, so its output can miss decisions; the hook
-  sweeps any incomplete regen at end-of-merge.
+  sweeps any incomplete regen at end-of-merge. **(v0.6.13+) The hook
+  detects orphan branches** (e.g. after `gh pr merge --delete-branch` +
+  `git fetch --prune`) and skips regen entirely rather than blocking the
+  follow-up `git checkout main`.
 
 `logmind doctor` reports three new rows for these (v0.3.0+):
 `.gitattributes (merge driver)`, `git config (merge driver)`, and
@@ -289,6 +299,28 @@ The merge driver invokes `logmind file-structure --write <path>`
 command, you should not run it by hand in the normal flow — it exists
 for the merge driver and as an escape hatch (corrupted file, externally
 modified tree).
+
+## Template-refresh: `logmind self-update` (v0.6.13+)
+
+When `logmind log` detects that `AGENTS.md` or per-agent stub files are
+stale relative to the installed templates, it emits a one-line warning:
+
+```
+⚠ Template drift detected — run `logmind self-update` to refresh.
+```
+
+**No files are mutated by `logmind log`.** Apply the refresh explicitly
+when you're ready:
+
+```bash
+logmind self-update    # rewrites AGENTS.md + per-agent stubs to current templates
+                       # + refreshes local hooks
+```
+
+Other maintenance commands (`init`, `rebase`, `search`, `agents update`)
+still apply template refresh as part of their normal operation. Only
+`logmind log` is strictly read-only with respect to templates — preventing
+piggyback template commits from landing on your feature branch.
 
 ## Authoring skills locally (v0.6.0+ — `logmind skill …`)
 
@@ -401,6 +433,9 @@ Common deltas you'll see if you're upgrading across a stretch:
   `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
   fires when the gap between your branch and `origin/<default>` is
   exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+- **v0.6.13**: `logmind log` no longer mutates template files — drift is
+  surfaced as a warning; run `logmind self-update` to apply refresh
+  explicitly. New `logmind self-update` command added.
 
 ## Setup (one-time, per project)
 
@@ -453,6 +488,10 @@ The flag name describes the BUNDLE TARGET (the SkDD toolchain), not a specific t
   If the gap between branches includes code files, `docs/file-structure.md`,
   or any file other than `docs/timeline.md`, auto-rebase will refuse and
   emit a heads-up — handle the rebase manually.
+- **Don't expect `logmind log` to refresh templates (v0.6.13+).** If you
+  see a "Template drift detected" warning after `logmind log`, run
+  `logmind self-update` separately — never as part of the same decision
+  commit flow.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.13 shipped.

**CHANGELOG**: [`v0.6.13` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.13/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.13

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

The changelog introduces two user-visible behavioral changes relevant to agents: (1) `logmind log` no longer silently mutates template files — it now only detects drift and emits a warning pointing to the new `logmind self-update` command; and (2) a new `logmind self-update` command is introduced. These are directly agent-facing: agents use `logmind log` as their primary primitive, and the new behavior (no piggyback commits, drift warning, new command) changes what agents should know and do.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] Verify the SKILL.md diff accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.