### PR TITLE
[skip-logmind] logmind self-update: 0.6.14 → 0.6.15

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -30,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.14"
+        run: pip install "logmind==0.6.15"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -65,7 +65,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.14"
+        run: pip install "logmind==0.6.15"
 
       - name: Regenerate derived docs
         run: |


### PR DESCRIPTION
Automated upgrade from logmind 0.6.14 → 0.6.15.

Refresh mode (v0.2.1+) only touched workflow templates whose `# logmind-template-version:` marker is stale; `docs/`, `.logmind/config.yml`, and agent files were left alone.

Review the diff. To stop self-updates after this, add `pinVersion: "0.6.15"` to `.logmind/config.yml` before merging.