### PR TITLE
[skip-logmind] logmind self-update: 0.6.14 → 0.6.16

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -30,7 +30,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.14"
+        run: pip install "logmind==0.6.16"
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -65,7 +65,7 @@ jobs:
         # Version pinned to the logmind that originally ran `logmind init`
         # in this repo, so CI behavior matches what the maintainer tested
         # locally. Bump after running `logmind init` against a new release.
-        run: pip install "logmind==0.6.14"
+        run: pip install "logmind==0.6.16"
 
       - name: Regenerate derived docs
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,15 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v7-pointer -->
-## Decision logging — `logmind log` is the commit primitive
+<!-- logmind-block-version: v8-pointer -->
+## Decision logging — `logmind log` is REQUIRED for substantive commits
 
 **`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
+
+> **DO NOT run raw `git add` / `git commit` / `git push` for substantive code changes.**
+> The commit-msg hook installed by `logmind init` warns when raw git is used on
+> a substantive commit; the intent is to prevent the warning, not bypass it via
+> `--no-verify`. Typo / whitespace / dep-bump-only commits MAY use raw git.
 
 ```bash
 logmind log "summary" -r "why" -a "alternative" -i "implication"


### PR DESCRIPTION
Automated upgrade from logmind 0.6.14 → 0.6.16.

Refresh mode (v0.2.1+) only touched workflow templates whose `# logmind-template-version:` marker is stale; `docs/`, `.logmind/config.yml`, and agent files were left alone.

Review the diff. To stop self-updates after this, add `pinVersion: "0.6.16"` to `.logmind/config.yml` before merging.