### PR TITLE
logmind v0.6.16 shipped — proposed SKILL.md update

### DIFF
--- a/.skill-update-todo/v0.6.16.md
+++ b/.skill-update-todo/v0.6.16.md
@@ -1,0 +1,57 @@
+# logmind v0.6.16 — skill update context
+
+**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/v0.6.16/CHANGELOG.md
+**Release URL**: https://github.com/thrillmade/logmind/releases/tag/v0.6.16
+
+## Claude's reasoning
+
+v0.6.16 introduces three user-visible behavioral changes: (1) a new `commit-msg` hook installed by `logmind init` that warns (or blocks in strict mode) raw `git commit` on substantive code changes, (2) `logmind doctor` now probes PATH resolution and exits non-zero on version drift between the running binary and the shell-resolved binary, and (3) AGENTS.md templates are bumped to v6/v8 with strengthened "DO NOT run raw git" framing. The commit-msg hook and doctor PATH probe are directly agent-facing behaviors that should be reflected in the SKILL.md (the Don'ts section and the doctor section). The AGENTS.md template bump is also relevant since agents run `logmind init`.
+## CHANGELOG section (verbatim, used as Claude's input)
+
+## [0.6.16] - 2026-06-02
+
+Tokenomics-agent verification-report follow-up (Concerns 2/3 + dogfood enforcement + multi-branch self-heal regression). Three changes, one release — all bridge directly into the v1.0 Go rewrite parity matrix.
+
+### Fixed — multi-branch self-heal contract restored
+
+The v0.6.15 blanket default-branch skip in the post-merge hook fixed the `gh pr merge --squash --delete-branch` unstaged-docs case, but broke local-merge regen on main. Concrete failure mode: when agent A merges `feat/agent-a` locally and agent B merges `feat/agent-b` against the same main, the merge driver fires for `docs/timeline.md` with a partial working tree (B's `decisions-branches/feat__agent-b.md` not yet checked out), producing a timeline missing B's content. The post-merge hook was supposed to sweep — but the v0.6.15 skip made it a no-op on main, freezing the partial output.
+
+v0.6.16 tightens the skip: instead of "skip whenever current branch == default," the hook skips only when `HEAD` already matches `origin/<default>` (the actual fast-forward / pull-up case where `regen-timeline.yml` server-side is authoritative). Local merges that introduce new commits not yet on origin run regen normally, so the working tree reflects the merged-in decision content.
+
+Surfaced by three new regression tests in `tests/test_merge_driver.py` (two-branch, three-branch, squash-then-merge variants). All exercise real `git` + `logmind` subprocess calls — no mocks. The whole dogfood loop assumes this contract holds; without it, every concurrent-PR cycle would silently lose decisions on local merges.
+
+### Added — `logmind doctor` PATH-resolution probe (Concern 3)
+
+Tokenomics-agent's 2026-06-01 recurrence had a non-obvious root cause: `logmind doctor` reported `current` for the post-merge hook, but `logmind init` (invoked from the user's shell, via PATH) was writing a v0.3.4 hook body. The discrepancy: doctor was running via `python -m logmind` (PYENV_VERSION=3.11.8 → v0.6.13), while `logmind` typed at the shell prompt resolved through the pyenv shim to an older active pyenv → v0.3.4.
+
+v0.6.16 adds `_probe_path_resolution()` in `core/doctor.py`. The probe runs `shutil.which("logmind")` + `<path> --version` and compares the resolved binary's version against the currently-running version. Drift surfaces as `stale` with a marker showing both versions + the conflicting path, so doctor exits non-zero on PATH-conflict (`Stack status: DRIFT`).
+
+### Added — commit-msg hook (dogfood enforcement)
+
+Tokenomics-session feedback "why git add instead of logmind" revealed that even with AGENTS.md guidance, agents fall back to raw `git commit` on substantive code changes. v0.6.16 adds a `commit-msg` hook installed by `logmind init` (alongside post-merge + post-rewrite) that warns when:
+
+1. Commit message's first line does NOT start with one of the exempt prefixes (`logmind:`, `Revert `, `Merge `, `Bump version`, `chore(release):`, `fixup!`, `squash!`)
+2. Staged diff exceeds 20 lines across code-bearing extensions (`.py .go .ts .tsx .js .jsx .sh .yaml .yml .toml .rs .rb`)
+
+WARN by default. STRICT mode (exits 1, rejecting the commit) when `.logmind/config.yml` contains `commit_msg_hook: strict: true`. Bypass via `git commit --no-verify` for intentional overrides. The hook reads strict mode at runtime so users flip without re-installing.
+
+### Changed — AGENTS.md template bumps + strengthened framing
+
+- `AGENTS.md.template`: v5 → v6 — heading reframed to "REQUIRED for substantive commits" + new blockquote with "DO NOT run raw `git add` / `git commit` / `git push`" warning that references the commit-msg hook
+- `AGENTS.md.slim.template`: v7-pointer → v8-pointer — same strengthening with the contract sentence preserved verbatim ("`logmind log` replaces `git add` + `git commit` + `git push`")
+
+The contract sentence stays load-bearing for `tests/test_agents_consolidation.py` discovery; new `v0.6.16` framing is additive on top.
+
+### Validation gate
+
+- `pytest -q` green: **846 passed, 1 skipped** (+17 over v0.6.15 — 3 self-heal + 9 commit-msg-hook + 5 PATH-probe).
+- After propagation: tokenomics agent's next `logmind doctor` should surface PATH-conflict if their pyenv shim still resolves to v0.3.4. Their next substantive `git commit` (without `logmind log`) will fire the warning. Multi-branch self-heal test guards regression for the v1.0 Go rewrite parity gate.
+
+### Go v1.0 parity carry-forward
+
+Every v0.6.16 change is a parity item for the Go rewrite waves:
+- B2 (hooks): port `_build_commit_msg_hook_body()` to `internal/hooks/commit_msg_body.go` with byte-identical hook body
+- B3 (timeline): port the multi-branch self-heal tests to `internal/timeline/merge_driver_test.go`
+- B4 (templates): bump embedded `AGENTS.md.template` + slim variant in `embed.FS`
+- B6 (doctor): port `_probe_path_resolution()` to `internal/doctor/probe_path.go`
+- Phase 2 convergence: cross-binary parity test (Python v0.6.16 vs Go v1.0 timeline.md byte-identical) is a release gate

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -12,6 +12,8 @@ agent-skills
 │   └── dependabot.yml
 ├── .logmind
 │   └── config.yml
+├── .skill-update-todo
+│   └── v0.6.16.md
 ├── docs
 │   ├── decisions-branches
 │   ├── decisions-archive.md

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -236,6 +236,17 @@ body changed. **If `doctor` reports an `AGENTS.md` stale row, your repo's
 embedded logmind instructions are older than what the installed logmind
 would write — re-run `logmind init` to refresh in place.**
 
+### PATH-resolution probe (v0.6.16+)
+
+`logmind doctor` now also checks for version drift between the currently-
+running logmind process and the `logmind` binary resolved via your shell's
+`PATH`. If they differ (e.g. a pyenv shim resolves to an older version),
+doctor surfaces the conflict as `stale` showing both versions + the
+conflicting path, and exits non-zero (`Stack status: DRIFT`). This guards
+against silent hook-body mismatch where `logmind doctor` reports `current`
+but `logmind init` is actually writing stale hook bodies from an older
+install.
+
 ### Derived-doc freshness check (v0.5.13+ / v0.6.9+)
 
 Both derived docs now have CI-friendly fail-fast modes — exit non-zero
@@ -289,6 +300,33 @@ The merge driver invokes `logmind file-structure --write <path>`
 command, you should not run it by hand in the normal flow — it exists
 for the merge driver and as an escape hatch (corrupted file, externally
 modified tree).
+
+## commit-msg hook: enforcement for substantive commits (v0.6.16+)
+
+`logmind init` now installs a `commit-msg` hook (alongside `post-merge`
+and `post-rewrite`) that fires whenever you run `git commit` directly.
+It warns when **both** of the following are true:
+
+1. The commit message's first line does NOT start with an exempt prefix
+   (`logmind:`, `Revert `, `Merge `, `Bump version`, `chore(release):`,
+   `fixup!`, `squash!`).
+2. The staged diff exceeds 20 lines across code-bearing extensions
+   (`.py .go .ts .tsx .js .jsx .sh .yaml .yml .toml .rs .rb`).
+
+**Default: WARN** (prints a warning but allows the commit). **STRICT
+mode** (exits 1, rejecting the commit) is enabled via `.logmind/config.yml`:
+
+```yaml
+commit_msg_hook:
+  strict: true
+```
+
+The hook reads this setting at runtime — flip without re-installing.
+Bypass for intentional overrides: `git commit --no-verify`.
+
+**For agents: use `logmind log` for all substantive commits.** The hook
+is a safety net, not a substitute — `logmind log` bundles reasoning +
+code + push in one step, which the hook cannot replicate.
 
 ## Authoring skills locally (v0.6.0+ — `logmind skill …`)
 
@@ -401,6 +439,12 @@ Common deltas you'll see if you're upgrading across a stretch:
   `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
   fires when the gap between your branch and `origin/<default>` is
   exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+- **v0.6.16**: `logmind init` installs a `commit-msg` hook that warns
+  (or blocks in strict mode) raw `git commit` on substantive code
+  changes. `logmind doctor` gains a PATH-resolution probe that exits
+  non-zero when the shell-resolved binary version differs from the
+  running version. AGENTS.md templates bumped to v6/v8 with
+  strengthened "DO NOT run raw git" framing.
 
 ## Setup (one-time, per project)
 
@@ -408,7 +452,7 @@ If the project doesn't yet have logmind:
 
 ```bash
 pip install logmind
-logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block, merge drivers + post-merge hook (v0.3.0+)
+logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block, merge drivers + post-merge hook (v0.3.0+), commit-msg hook (v0.6.16+)
 logmind doctor             # confirm clean install
 ```
 
@@ -436,6 +480,8 @@ The flag name describes the BUNDLE TARGET (the SkDD toolchain), not a specific t
   all three in one step. Running them manually either bypasses the
   logging entirely or splits the work across separate commits, both of
   which lose the value of having the reasoning attached to the code.
+  The `commit-msg` hook (v0.6.16+) will warn (or reject in strict mode)
+  substantive raw `git commit` calls as an additional guard.
 - **Don't run `git add` BEFORE `logmind log` either.** Default
   `--stage all` already sweeps the working tree; pre-staging is
   redundant. (Exception: if you're using `--stage scoped` and have
@@ -453,6 +499,11 @@ The flag name describes the BUNDLE TARGET (the SkDD toolchain), not a specific t
   If the gap between branches includes code files, `docs/file-structure.md`,
   or any file other than `docs/timeline.md`, auto-rebase will refuse and
   emit a heads-up — handle the rebase manually.
+- **Don't ignore `logmind doctor` PATH-conflict warnings (v0.6.16+).** If
+  doctor exits non-zero with `Stack status: DRIFT` due to a PATH-resolution
+  mismatch, the shell-resolved `logmind` binary is a different version than
+  the running process — hooks written by one version may not match what the
+  other expects. Fix the PATH / pyenv config before continuing.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
Automated notification from `thrillmade/logmind` — v0.6.16 shipped.

**CHANGELOG**: [`v0.6.16` on logmind](https://github.com/thrillmade/logmind/blob/v0.6.16/CHANGELOG.md)
**Release**: https://github.com/thrillmade/logmind/releases/tag/v0.6.16

## Shape of this PR

proposed SKILL.md edit + TODO context file

## Claude's reasoning

v0.6.16 introduces three user-visible behavioral changes: (1) a new `commit-msg` hook installed by `logmind init` that warns (or blocks in strict mode) raw `git commit` on substantive code changes, (2) `logmind doctor` now probes PATH resolution and exits non-zero on version drift between the running binary and the shell-resolved binary, and (3) AGENTS.md templates are bumped to v6/v8 with strengthened "DO NOT run raw git" framing. The commit-msg hook and doctor PATH probe are directly agent-facing behaviors that should be reflected in the SKILL.md (the Don'ts section and the doctor section). The AGENTS.md template bump is also relevant since agents run `logmind init`.

## Reviewer checklist

- [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
- [ ] Verify the SKILL.md diff accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
- [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).

## How this was generated

`logmind/.github/workflows/notify-agent-skills.yml` (v0.4.0+) on tag push. Calls Anthropic API via `.github/scripts/propose_skill_update.py` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.