### PR TITLE
[skip-logmind] chore: re-pin dependabot-auto-merge to §8.6 SHA b208d22

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    # Pinned to thrillmade/.github commit e4dfd7e for supply-chain immutability (per clud-bug-review on PR #112). Bump via dependabot or manual edit.
-    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@e4dfd7ea66a4917ea85b7880c0e700628ced409f
-    secrets: inherit
+    # Pinned to thrillmade/.github commit b208d22 for supply-chain immutability (per clud-bug-review on PR #112). Bump via dependabot or manual edit.
+    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@b208d22652d2585efb106e99e543113a113b101f
+    secrets:
+      orchestrator-app-id: ${{ secrets.THRILLMADE_ORCHESTRATOR_APP_ID }}
+      orchestrator-private-key: ${{ secrets.THRILLMADE_ORCHESTRATOR_PRIVATE_KEY }}


### PR DESCRIPTION
Re-pins the dependabot auto-merge caller workflow to the new `thrillmade/.github` reusable-workflow SHA (`b208d22`) introduced by [thrillmade/.github#2](https://github.com/thrillmade/.github/pull/2).

## What changed

- SHA bump: `e4dfd7e` → `b208d22`
- `secrets: inherit` → named secrets block (`orchestrator-app-id` + `orchestrator-private-key`)

## Why

GitHub policy blocks the default `GITHUB_TOKEN` from approving PRs. The new reusable workflow swaps to a 1-hour installation token from `thrillmade-orchestrator[bot]` (Apps CAN approve PRs) + adds an author_association safety gate so fork PRs from outside contributors still need a human reviewer.

Refs plan §8.6.
