### PR TITLE
fix(census): disable thinking on the panel call — W29 empty-response root cause

### DIFF
--- a/.github/scripts/census_panel.py
+++ b/.github/scripts/census_panel.py
@@ -485,12 +485,29 @@ def call_claude(system_prompt: str, user_message: str) -> str:
         raise RuntimeError("ANTHROPIC_API_KEY not set")
 
     client = Anthropic(timeout=CLIENT_TIMEOUT)  # SDK default max_retries (no extra retries)
-    msg = client.messages.create(
+    request = dict(
         model=MODEL,
         max_tokens=MAX_TOKENS,
         system=system_prompt,
         messages=[{"role": "user", "content": user_message}],
+        # This is a JSON-only structured task; without this, the model can spend
+        # the entire max_tokens budget inside a default thinking block and hit
+        # max_tokens before emitting any text block (cycle census-2026-W29
+        # failed exactly this way: ~92s generation, zero text blocks).
+        thinking={"type": "disabled"},
     )
+    try:
+        msg = client.messages.create(**request)
+    except TypeError:
+        # Older SDK without the thinking kwarg — retry without it.
+        request.pop("thinking", None)
+        msg = client.messages.create(**request)
+    except Exception as exc:  # noqa: BLE001 - param-rejection fallback only
+        if "thinking" in str(exc).lower():
+            request.pop("thinking", None)
+            msg = client.messages.create(**request)
+        else:
+            raise
 
     parts: list[str] = []
     for block in msg.content:
@@ -498,7 +515,12 @@ def call_claude(system_prompt: str, user_message: str) -> str:
         if text:
             parts.append(text)
     if not parts:
-        raise RuntimeError("empty response from Anthropic API")
+        block_types = [getattr(b, "type", "?") for b in msg.content]
+        raise RuntimeError(
+            "no text blocks in Anthropic API response "
+            f"(stop_reason={getattr(msg, 'stop_reason', '?')}, "
+            f"block_types={block_types or 'none'})"
+        )
     return "".join(parts)
 
 

--- a/.github/workflows/skill-census.yml
+++ b/.github/workflows/skill-census.yml
@@ -130,7 +130,7 @@ jobs:
         if: steps.guard.outputs.panel_enabled == 'true'
         run: pip install anthropic
 
-      - name: Census panel (Mode B judgment)
+      - name: Census panel (judgment)
         id: panel
         if: steps.guard.outputs.panel_enabled == 'true'
         continue-on-error: false
@@ -333,5 +333,6 @@ jobs:
             ${{ runner.temp }}/census/census.json
             ${{ runner.temp }}/census/digest.md
             ${{ runner.temp }}/census/verdicts.json
+            ${{ runner.temp }}/census/panel_failed.marker
           if-no-files-found: ignore
           retention-days: 30

--- a/docs/decisions-branches/fix__census-panel-thinking-budget.md
+++ b/docs/decisions-branches/fix__census-panel-thinking-budget.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-17 13:39 - census panel: disable thinking for the JSON-only judgment call (cycle-W29 root cause)
+
+**Reasoning:** Cycle census-2026-W29's panel returned zero text blocks after a ~92s full-budget generation — claude-sonnet-5's default thinking consumed the entire 8192-token max_tokens before any text was emitted, so run_panel raised 'empty response' and the cycle degraded to Mode B (digest filed, no verdicts — the degradation contract held). Root-caused via systematic-debugging: HTTP 200 + no SDK exception + 92s runtime + zero .text blocks pins it to thinking-block exhaustion, not auth/model/prompt failure.
+
+**Alternatives considered:** Raise max_tokens instead (rejected: unbounded thinking can consume any budget; disabling is deterministic for a schema-constrained JSON task). Keep thinking with a small budget_tokens (rejected for now: adds a second tunable; revisit if verdict quality suffers without reasoning).
+
+**Implications:**
+- Falls back to a thinking-free request shape on SDK/API param rejection (older SDKs). Empty-response error now self-diagnoses (stop_reason + block types). panel_failed.marker joins the artifact upload; step name mislabel fixed. Re-run of cycle one after merge doubles as the idempotency test — the digest must be commented, not duplicated.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (5 decisions)
+## 2026-07 (6 decisions)
 
-- **2026-07-17** — skill-census engine: weekly steward-run editorial cycle (counters + AI panel + verdict issues) *(feat/skill-census-engine)* — [decisions-branches/feat__skill-census-engine.md](decisions-branches/feat__skill-census-engine.md)
-- *... 3 more decisions ...*
+- **2026-07-17** — census panel: disable thinking for the JSON-only judgment call (cycle-W29 root cause) *(fix/census-panel-thinking-budget)* — [decisions-branches/fix__census-panel-thinking-budget.md](decisions-branches/fix__census-panel-thinking-budget.md)
+- *... 4 more decisions ...*
 - **2026-07-16** — skill unification: three-layer design catalog — K0 splits/stubs/promotions, K1 dispatchers, K3 abstraction *(feat/skill-unification-k0-k1-k3)* — [decisions-branches/feat__skill-unification-k0-k1-k3.md](decisions-branches/feat__skill-unification-k0-k1-k3.md)
 
 ## 2026-06 (10 decisions)


### PR DESCRIPTION
Cycle census-2026-W29 ran green end-to-end but filed only the digest: the panel's `claude-sonnet-5` call generated for ~92s and returned **zero text blocks** — the model's default thinking consumed the whole 8192 `max_tokens` before emitting text, tripping the script's empty-response guard and (correctly) degrading to Mode B.

Fix at root: `thinking={"type": "disabled"}` on the one API call (JSON-only structured task; reasoning burn was the failure), with a graceful fallback that strips the param on SDK/API rejection. Plus two diagnosability gaps found en route: the empty-response error now reports `stop_reason` + block types, and `panel_failed.marker` joins the artifact upload (it was written but never uploaded). Step-name mislabel ("Mode B judgment") corrected.

Verification plan post-merge: re-dispatch cycle one — expect verdicts.json + up to 5 verdict issues, and the existing W29 digest to be **commented, not duplicated** (doubles as the idempotency test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)