### PR TITLE
Skill engine W1: drift detection, placement map, §1.10.1 validator, taxonomy

### DIFF
--- a/.github/scripts/census_counters.py
+++ b/.github/scripts/census_counters.py
@@ -8,10 +8,13 @@ locally-authored skills have converged across repos (the strongest promotion
 signal). The *judgment* half — gap/placement/promotion verdicts — is Mode B
 (`census_panel.py`), which reads this script's `census.json`.
 
-Stdlib ONLY (urllib, json, os, sys, datetime). No pip, so the counters step
-runs on a bare runner before the panel step installs the Anthropic SDK. If
-the panel step is skipped (no ANTHROPIC_API_KEY), this file's `digest.md`
-still ships as the cycle's deliverable.
+Stdlib ONLY (base64, hashlib, json, os, re, subprocess, sys, urllib, datetime).
+No pip, so the counters step runs on a bare runner before the panel step
+installs the Anthropic SDK. If the panel step is skipped (no
+ANTHROPIC_API_KEY), this file's `digest.md` still ships as the cycle's
+deliverable. `subprocess` is used narrowly (git plumbing only — `log`/`show`
+against the local checkout, see `_algo_proven_for_lineage`), never to shell
+out to anything network- or input-derived.
 
 Inputs (env):
   STEWARD_TOKEN   required — GitHub App installation token with read access
@@ -36,8 +39,11 @@ Failure posture:
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
+import re
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -61,12 +67,17 @@ CONSUMER_REPOS = (
 ORG = "thrillmade"
 CATALOG_REPO = "agent-skills"
 CATALOG_DIR = "skills"  # read locally from the checkout cwd
+CATALOG_SOURCE = f"{ORG}/{CATALOG_REPO}"  # lock `source` value for catalog subs
 
 # Contents API paths probed per consumer repo.
 LOCK_PATH = "skills-lock.json"
 MANIFEST_PATH = ".claude/skills/.clud-bug.json"
 LOCAL_SKILLS_DIR = ".claude/skills"
 MANIFEST_FILENAME = ".clud-bug.json"  # excluded from local-dir accounting
+
+# Placement map (authored by the placement agent; may not exist yet). Read
+# locally from the checkout cwd. Cross-checked against live subscriptions.
+PLACEMENT_MAP_PATH = "docs/placement-map.json"
 
 # Grace: catalog skills that are EXPECTED to have zero subscribers, so a
 # zero-subscription count for them is not a coverage gap. Two families:
@@ -107,6 +118,160 @@ STRUCTURAL_L0 = frozenset(
 
 STALE_DAYS = 14  # docket issues untouched longer than this are "stale"
 API_TIMEOUT = 30  # seconds per request
+
+# --- Catalog content hashing (subscription-drift detection) ----------------
+#
+# skills-lock.json stores a `computedHash` per subscribed skill — a content
+# hash of the catalog SKILL.md at the ref the lock pinned. A refresh that
+# fetches a ref whose recomputed content hash differs MUST surface the change
+# (SPEC: refresh drift). Surfacing is the census's job; it NEVER auto-fixes.
+#
+# The hash is produced by the EXTERNAL skills.sh CLI's own content
+# normalization. We determined the algorithm empirically: every historical
+# version of skills/{brand-voice-review,logmind}/SKILL.md (via `git log` +
+# `git show <sha>:<path>`) was hashed with ~40 candidate algorithms — raw
+# sha256, trailing-newline-stripped, per-line rstrip, CRLF->LF, git blob
+# sha1/sha256, body-only (frontmatter stripped), frontmatter-only, and
+# path/source/dir-concat/git-tree composites. NONE reproduced either stored
+# computedHash (0488e9…brand-voice-review / 6f20f4…logmind). Conclusion: the
+# normalization lives inside the skills.sh CLI and is not reproducible from
+# stdlib here.
+#
+# DUAL MODE. The compute-and-compare path below is real and complete; it is
+# gated on CATALOG_HASH_ALGO naming a registered algorithm. Because no local
+# algorithm reproduces the stored hashes, CATALOG_HASH_ALGO is None today and
+# every catalog subscription is reported 'indeterminate' (once per lock, with
+# a reason) — we NEVER report drift we cannot prove. CATALOG_HASH_ALGO stays
+# None until someone actually mirrors the skills.sh CLI's normalization into
+# _HASH_ALGOS — flipping it to a wrong-but-plausible algorithm is exactly the
+# failure mode this module is written to survive.
+#
+# PER-SKILL DRIFT PROOF (guards the day CATALOG_HASH_ALGO IS set). Even once
+# an algorithm is registered, `compute_subscription_drift` never asserts
+# 'drift' for a skill on the strength of the algorithm alone — see
+# `_algo_proven_for_lineage`. Before calling a mismatch 'drift', it replays
+# the algorithm against up to 30 historical versions of that skill's catalog
+# SKILL.md (`git log` + `git show <sha>:<path>`) and requires the algorithm to
+# reproduce the subscription's stored `computedHash` for at least one of
+# them. If none reproduce it, the algorithm is unproven for *this skill's*
+# specific pin lineage and the verdict downgrades to 'indeterminate' instead
+# of 'drift' — so a single global algorithm flip can never mass-mis-flag
+# subscriptions whose lineage it was never actually verified against.
+
+
+def _strip_frontmatter(raw: bytes) -> bytes:
+    """Return the markdown body with a leading YAML frontmatter block removed."""
+    text = raw.decode("utf-8", "replace")
+    m = re.match(r"^---\r?\n.*?\r?\n---\r?\n", text, re.DOTALL)
+    return text[m.end():].encode("utf-8") if m else raw
+
+
+def _git_blob_sha1(raw: bytes) -> str:
+    h = hashlib.sha1()
+    h.update(b"blob %d\x00" % len(raw))
+    h.update(raw)
+    return h.hexdigest()
+
+
+# Registered candidate normalizations. Keys are stable names; a future
+# determination sets CATALOG_HASH_ALGO to one of these (or adds a new one that
+# mirrors the skills.sh CLI). Each maps raw file bytes -> hex digest.
+_HASH_ALGOS = {
+    "sha256_raw": lambda raw: hashlib.sha256(raw).hexdigest(),
+    "sha256_rstrip_nl": lambda raw: hashlib.sha256(
+        raw.decode("utf-8", "replace").rstrip("\n").encode("utf-8")
+    ).hexdigest(),
+    "sha256_lf": lambda raw: hashlib.sha256(
+        raw.decode("utf-8", "replace").replace("\r\n", "\n").encode("utf-8")
+    ).hexdigest(),
+    "sha256_body": lambda raw: hashlib.sha256(_strip_frontmatter(raw)).hexdigest(),
+    "git_blob_sha1": _git_blob_sha1,
+}
+
+# None => algorithm undetermined => drift is 'indeterminate' (never asserted).
+# Set to a key of _HASH_ALGOS once the skills.sh normalization is reproduced.
+CATALOG_HASH_ALGO: str | None = None
+
+
+def compute_catalog_hash(skill_path: str, algo: str | None = None) -> str | None:
+    """Recompute the content hash of a CURRENT catalog SKILL.md, read locally
+    from the checkout cwd. Returns the hex digest, or None when the algorithm
+    is undetermined (default), the algo name is unknown, the path is outside
+    the catalog, or the file is unreadable. None => the caller must treat the
+    subscription as 'indeterminate' (never 'drift').
+    """
+    name = algo if algo is not None else CATALOG_HASH_ALGO
+    if name is None:
+        return None
+    fn = _HASH_ALGOS.get(name)
+    if fn is None:
+        return None
+    # Scope to the catalog tree and refuse traversal outside it.
+    norm = os.path.normpath(skill_path)
+    if norm.startswith("..") or os.path.isabs(norm):
+        return None
+    if not (norm == CATALOG_DIR or norm.startswith(CATALOG_DIR + os.sep)):
+        return None
+    try:
+        with open(os.path.join(os.getcwd(), norm), "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return None
+    return fn(raw)
+
+
+_LINEAGE_HISTORY_CAP = 30  # max historical versions walked per skill
+
+
+def _algo_proven_for_lineage(skill_path: str, stored_hash: str, algo: str) -> bool:
+    """Return True iff `algo` (a key of _HASH_ALGOS) reproduces `stored_hash`
+    for AT LEAST ONE historical version of `skill_path`, walking at most
+    `_LINEAGE_HISTORY_CAP` versions via `git log` + `git show <sha>:<path>`
+    against the local checkout (cwd).
+
+    This is the guard that lets `compute_subscription_drift` assert 'drift'
+    for a skill: a hash mismatch against the *current* file only means
+    "drift OR the algorithm is wrong for this file" until we've shown the
+    algorithm has actually reproduced a real stored hash somewhere in this
+    specific skill's history. Best-effort and defensive — any git/hash
+    failure is treated as "not proven" (never raises, never asserts drift on
+    an exception).
+    """
+    fn = _HASH_ALGOS.get(algo)
+    if fn is None:
+        return False
+    try:
+        log = subprocess.run(
+            ["git", "-C", ".", "log", f"-n{_LINEAGE_HISTORY_CAP}", "--format=%H", "--", skill_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if log.returncode != 0:
+        return False
+    shas = [s for s in log.stdout.splitlines() if s.strip()][:_LINEAGE_HISTORY_CAP]
+    for sha in shas:
+        try:
+            show = subprocess.run(
+                ["git", "show", f"{sha}:{skill_path}"],
+                capture_output=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if show.returncode != 0:
+            continue
+        try:
+            if fn(show.stdout) == stored_hash:
+                return True
+        except Exception:  # noqa: BLE001 — a bad historical blob must not crash the census
+            continue
+    return False
+
 
 # --- HTTP ------------------------------------------------------------------
 
@@ -240,6 +405,140 @@ def parse_manifest(manifest: object) -> list[str]:
     return _dedupe(slugs)
 
 
+def parse_lock_hashes(lock: object) -> tuple[list[dict], list[str]]:
+    """Extract catalog subscriptions carrying a `computedHash` from a
+    skills-lock.json payload, tolerant of the same shape variations as
+    `parse_lock`. Returns `(checkable, unscoped)`:
+
+        checkable: list of {"slug", "source", "skillPath", "computedHash"}
+                   dicts — drift-CHECKABLE catalog subscriptions.
+        unscoped:  list of skill-name strings — catalog-scoped subscriptions
+                   (valid computedHash + skillPath under the catalog dir)
+                   whose lock entry has a missing/falsy `source`.
+
+    A subscription is drift-*checkable* iff, in addition to carrying a
+    non-empty `computedHash` and a `skillPath` under the catalog dir, its
+    `source` equals `CATALOG_SOURCE` (`thrillmade/agent-skills`) — i.e. the
+    lock itself attributes the pin to this catalog. Three-way scoping:
+
+      - `source == CATALOG_SOURCE`  -> checkable (appended to `checkable`).
+      - missing/None/falsy `source` -> NOT checkable, but still catalog-
+        scoped (has a real computedHash + in-catalog skillPath) — surfaced
+        distinctly via `unscoped` rather than silently dropped or miscounted
+        as drift-checkable.
+      - any other non-matching `source` (a foreign lock source) -> excluded
+        entirely; it is not an agent-skills subscription at all, so it never
+        enters catalog-subscription counting in either bucket.
+
+    Entries without a stored hash, or whose skillPath isn't under the catalog
+    dir, are skipped outright (not raised) — a malformed lock degrades to "no
+    drift-checkable subscriptions here", never a repo-level error.
+    """
+    out: list[dict] = []
+    unscoped: list[str] = []
+
+    def _add(slug: object, meta: object) -> None:
+        if not isinstance(meta, dict):
+            return
+        computed = meta.get("computedHash")
+        skill_path = meta.get("skillPath")
+        name = slug if isinstance(slug, str) and slug else meta.get("slug") or meta.get("name")
+        if not (isinstance(computed, str) and computed):
+            return
+        if not (isinstance(skill_path, str) and skill_path):
+            return
+        norm = os.path.normpath(skill_path)
+        if not (norm == CATALOG_DIR or norm.startswith(CATALOG_DIR + os.sep)):
+            return  # not a catalog file — out of drift scope entirely
+        resolved_name = name if isinstance(name, str) and name else norm
+        src = meta.get("source")
+        if not src:
+            # Missing/None (or empty) source: catalog-scoped but NOT
+            # drift-checkable — bucketed separately, never dropped silently.
+            unscoped.append(resolved_name)
+            return
+        if not (isinstance(src, str) and src == CATALOG_SOURCE):
+            # Foreign source — not an agent-skills subscription; excluded
+            # entirely from catalog-subscription counting (neither bucket).
+            return
+        out.append(
+            {
+                "slug": resolved_name,
+                "source": src,
+                "skillPath": skill_path,
+                "computedHash": computed,
+            }
+        )
+
+    if isinstance(lock, dict):
+        container = lock.get("skills") or lock.get("installed")
+        if isinstance(container, dict):
+            for key, meta in container.items():
+                _add(key, meta)
+        elif isinstance(container, list):
+            for entry in container:
+                if isinstance(entry, dict):
+                    _add(entry.get("slug") or entry.get("name"), entry)
+        else:
+            # Bare name -> metadata mapping (no `skills`/`installed` wrapper).
+            for key, meta in lock.items():
+                if key in ("version", "lastUpdate", "lastUpdateVersion"):
+                    continue
+                _add(key, meta)
+    elif isinstance(lock, list):
+        for entry in lock:
+            if isinstance(entry, dict):
+                _add(entry.get("slug") or entry.get("name"), entry)
+
+    return out, unscoped
+
+
+# Usage keys are consumer-controlled input (a repo's own .clud-bug.json) that
+# ends up interpolated straight into digest.md markdown (table cells,
+# headers) — validate the shape before trusting a key as a skill slug.
+USAGE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
+
+
+def parse_usage(manifest: object) -> tuple[dict, list[str]]:
+    """Extract the top-level `usage` object from a .clud-bug.json payload
+    (clud-bug skill-usage schema v2: `usage[<slug>] = {loads, citations,
+    last_cited}`). Returns `(usage, rejected)`:
+
+        usage:    {slug: {loads, citations, last_cited}} for keys matching
+                  USAGE_SLUG_RE (the catalog's skill-name slug shape).
+        rejected: raw key strings that did NOT match USAGE_SLUG_RE — counted
+                  and surfaced (never silently dropped, never raised on, and
+                  never trusted as a slug for interpolation).
+
+    Tolerant: absent/malformed usage => ({}, []) (never raises). Numeric
+    fields default to 0; `last_cited` is passed through as a string or None.
+    """
+    if not isinstance(manifest, dict):
+        return {}, []
+    usage = manifest.get("usage")
+    if not isinstance(usage, dict):
+        return {}, []
+    out: dict = {}
+    rejected: list[str] = []
+    for slug, stats in usage.items():
+        if not isinstance(slug, str):
+            continue
+        if not USAGE_SLUG_RE.match(slug):
+            rejected.append(slug)
+            continue
+        if not isinstance(stats, dict):
+            continue
+        loads = stats.get("loads")
+        citations = stats.get("citations")
+        last_cited = stats.get("last_cited")
+        out[slug] = {
+            "loads": loads if isinstance(loads, int) and not isinstance(loads, bool) else 0,
+            "citations": citations if isinstance(citations, int) and not isinstance(citations, bool) else 0,
+            "last_cited": last_cited if isinstance(last_cited, str) else None,
+        }
+    return out, rejected
+
+
 def _dedupe(items: list[str]) -> list[str]:
     """Order-preserving de-duplication."""
     seen: set[str] = set()
@@ -261,9 +560,13 @@ def survey_repo(repo: str, token: str) -> dict:
     try:
         lock = _get_file_json(repo, LOCK_PATH, token)
         lock_names, _lock_sources = parse_lock(lock) if lock is not None else ([], [])
+        lock_subscriptions, unscoped_subscriptions = (
+            parse_lock_hashes(lock) if lock is not None else ([], [])
+        )
 
         manifest = _get_file_json(repo, MANIFEST_PATH, token)
         manifest_slugs = parse_manifest(manifest) if manifest is not None else []
+        usage, usage_rejected = parse_usage(manifest) if manifest is not None else ({}, [])
 
         subscribed = _dedupe(lock_names + manifest_slugs)
         subscribed_set = set(subscribed)
@@ -291,12 +594,20 @@ def survey_repo(repo: str, token: str) -> dict:
             "subscribed": sorted(subscribed),
             "untracked": list(local_dirs),
             "local": list(local_dirs),
+            "lock_subscriptions": lock_subscriptions,
+            "unscoped_subscriptions": unscoped_subscriptions,
+            "usage": usage,
+            "usage_rejected": usage_rejected,
         }
     except Exception as exc:  # noqa: BLE001 — collect, never die on one repo.
         return {
             "subscribed": [],
             "untracked": [],
             "local": [],
+            "lock_subscriptions": [],
+            "unscoped_subscriptions": [],
+            "usage": {},
+            "usage_rejected": [],
             "error": str(exc),
         }
 
@@ -373,6 +684,261 @@ def compute_signals(catalog: list[str], repos: dict[str, dict]) -> dict:
     }
 
 
+_USE_DEFAULT_ALGO = object()  # sentinel: "fall back to CATALOG_HASH_ALGO"
+
+
+def compute_subscription_drift(
+    repos: dict[str, dict], algo: object = _USE_DEFAULT_ALGO
+) -> list[dict]:
+    """For every repo whose skills-lock.json subscribes catalog skills,
+    recompute each subscription's catalog SKILL.md hash (current, local) and
+    compare to the stored computedHash. Emits one record per verdict:
+
+        {"repo", "skill", "status": ok|drift|indeterminate|unscoped,
+         "stored", "recomputed", "note"}
+
+    DUAL MODE (see CATALOG_HASH_ALGO):
+      - algorithm KNOWN  -> per-subscription 'ok' (hashes equal) or 'drift'
+        (hashes differ AND the algorithm is PROVEN for this skill's pin
+        lineage — see `_algo_proven_for_lineage`; otherwise 'indeterminate'
+        with note "algo unproven for this skill's pin lineage", never
+        'drift' on an unproven algorithm). The census SURFACES real drift and
+        never auto-fixes.
+      - algorithm UNDETERMINED -> a SINGLE 'indeterminate' record per lock
+        (one reason line, no per-skill noise). We never report drift we
+        cannot prove.
+
+    Additionally, per repo, any subscriptions `parse_lock_hashes` bucketed as
+    `unscoped_subscriptions` (catalog-scoped but missing/None `source`, so not
+    drift-checkable at all) get their OWN 'unscoped' record — reported
+    alongside 'indeterminate', never merged into it, so the two "we didn't
+    check this" reasons (algorithm undetermined vs. source not attributable
+    to this catalog) stay distinguishable.
+
+    `algo` overrides CATALOG_HASH_ALGO (used by the self-test to exercise the
+    compute path); by default it uses the module-level setting.
+    """
+    algo = CATALOG_HASH_ALGO if algo is _USE_DEFAULT_ALGO else algo
+    records: list[dict] = []
+    for repo in sorted(repos):
+        subs = repos[repo].get("lock_subscriptions") or []
+        unscoped = repos[repo].get("unscoped_subscriptions") or []
+
+        if unscoped:
+            records.append(
+                {
+                    "repo": repo,
+                    "skill": None,
+                    "status": "unscoped",
+                    "count": len(unscoped),
+                    "skills": sorted(unscoped),
+                    "note": (
+                        f"{len(unscoped)} subscription(s) with missing/None "
+                        "`source` in skills-lock.json — not attributable to "
+                        f"this catalog ({CATALOG_SOURCE}), so not "
+                        "drift-checkable; excluded from catalog-subscription "
+                        "drift counting entirely (distinct from 'indeterminate')"
+                    ),
+                }
+            )
+
+        if not subs:
+            continue
+        if algo is None:
+            slugs = sorted(s["slug"] for s in subs)
+            records.append(
+                {
+                    "repo": repo,
+                    "skill": None,
+                    "status": "indeterminate",
+                    "count": len(subs),
+                    "skills": slugs,
+                    "note": (
+                        f"hash algorithm undetermined (external skills.sh "
+                        f"normalization not reproduced); {len(subs)} catalog "
+                        f"subscription(s) not verifiable — not reported as drift"
+                    ),
+                }
+            )
+            continue
+        for sub in sorted(subs, key=lambda s: s["slug"]):
+            stored = sub["computedHash"]
+            recomputed = compute_catalog_hash(sub["skillPath"], algo)
+            if recomputed is None:
+                records.append(
+                    {
+                        "repo": repo,
+                        "skill": sub["slug"],
+                        "status": "indeterminate",
+                        "stored": stored,
+                        "recomputed": None,
+                        "note": f"catalog file {sub['skillPath']} unreadable/out of scope",
+                    }
+                )
+            elif recomputed == stored:
+                records.append(
+                    {
+                        "repo": repo,
+                        "skill": sub["slug"],
+                        "status": "ok",
+                        "stored": stored,
+                        "recomputed": recomputed,
+                        "note": "",
+                    }
+                )
+            elif not _algo_proven_for_lineage(sub["skillPath"], stored, algo):
+                # A mismatch alone doesn't prove drift — it's equally
+                # consistent with the algorithm being wrong for this file.
+                # Never assert 'drift' unless the algorithm has reproduced a
+                # real stored hash somewhere in THIS skill's history.
+                records.append(
+                    {
+                        "repo": repo,
+                        "skill": sub["slug"],
+                        "status": "indeterminate",
+                        "stored": stored,
+                        "recomputed": recomputed,
+                        "note": "algo unproven for this skill's pin lineage",
+                    }
+                )
+            else:
+                records.append(
+                    {
+                        "repo": repo,
+                        "skill": sub["slug"],
+                        "status": "drift",
+                        "stored": stored,
+                        "recomputed": recomputed,
+                        "note": (
+                            f"catalog {sub['skillPath']} moved since lock "
+                            f"({stored[:12]}… → {recomputed[:12]}…) — refresh to reconcile"
+                        ),
+                    }
+                )
+    return records
+
+
+def aggregate_usage(repos: dict[str, dict]) -> dict:
+    """Aggregate per-skill usage (clud-bug schema v2 `usage[<slug>]`) across
+    repos. Sums `loads` + `citations`; keeps the most-recent `last_cited`;
+    records which repos reported each skill. Returns:
+
+        {"present": bool, "total_citations": int, "total_loads": int,
+         "skills": {slug: {loads, citations, last_cited, repos: [...]}},
+         "rejected": {repo: [raw_key, ...]}, "rejected_count": int}
+
+    `present` is False when no surveyed repo emitted a usage block (the
+    expected state until clud-bug consumers start writing schema v2).
+    `rejected`/`rejected_count` roll up `parse_usage`'s per-repo
+    `usage_rejected` (keys that failed USAGE_SLUG_RE) — counted and named by
+    repo, never silently dropped.
+    """
+    skills: dict[str, dict] = {}
+    rejected: dict[str, list[str]] = {}
+    for repo in sorted(repos):
+        usage = repos[repo].get("usage") or {}
+        for slug, stats in usage.items():
+            agg = skills.setdefault(
+                slug, {"loads": 0, "citations": 0, "last_cited": None, "repos": []}
+            )
+            agg["loads"] += stats.get("loads", 0)
+            agg["citations"] += stats.get("citations", 0)
+            last = stats.get("last_cited")
+            if isinstance(last, str) and (agg["last_cited"] is None or last > agg["last_cited"]):
+                agg["last_cited"] = last
+            if repo not in agg["repos"]:
+                agg["repos"].append(repo)
+        repo_rejected = repos[repo].get("usage_rejected") or []
+        if repo_rejected:
+            rejected[repo] = list(repo_rejected)
+    for agg in skills.values():
+        agg["repos"].sort()
+    total_citations = sum(a["citations"] for a in skills.values())
+    total_loads = sum(a["loads"] for a in skills.values())
+    return {
+        "present": bool(skills),
+        "total_citations": total_citations,
+        "total_loads": total_loads,
+        "skills": skills,
+        "rejected": rejected,
+        "rejected_count": sum(len(v) for v in rejected.values()),
+    }
+
+
+def read_placement_map() -> dict | None:
+    """Read docs/placement-map.json locally from the checkout cwd. Returns the
+    parsed object, or None if the file is absent (authored by a parallel
+    agent — its absence is tolerated) or unparseable.
+    """
+    path = os.path.join(os.getcwd(), PLACEMENT_MAP_PATH)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def compute_placement_divergence(
+    placement_map: dict | None, repos: dict[str, dict]
+) -> dict:
+    """Cross-check the placement map's declared `subscribers[]` against LIVE
+    observed subscriptions (each repo's `subscribed` set). Returns:
+
+        {"available": bool, "note": str, "divergences": [
+            {"skill", "declared": [...], "observed": [...],
+             "missing": [...], "extra": [...]}
+        ]}
+
+    `missing` = declared subscriber not observed live; `extra` = observed
+    subscriber the map omits. These feed placement verdicts (Mode B).
+    """
+    if not isinstance(placement_map, dict):
+        return {
+            "available": False,
+            "note": f"{PLACEMENT_MAP_PATH} absent — placement cross-check skipped",
+            "divergences": [],
+        }
+    skills = placement_map.get("skills")
+    if not isinstance(skills, dict):
+        return {
+            "available": False,
+            "note": f"{PLACEMENT_MAP_PATH} present but has no `skills` object — cross-check skipped",
+            "divergences": [],
+        }
+
+    # Observed subscribers per skill: repo names whose live `subscribed` carries it.
+    observed: dict[str, set[str]] = {}
+    for repo, record in repos.items():
+        for skill in record.get("subscribed", []):
+            observed.setdefault(skill, set()).add(repo)
+
+    divergences: list[dict] = []
+    for slug, meta in sorted(skills.items()):
+        declared_raw = meta.get("subscribers") if isinstance(meta, dict) else None
+        declared = {r for r in declared_raw if isinstance(r, str)} if isinstance(declared_raw, list) else set()
+        observed_set = observed.get(slug, set())
+        missing = declared - observed_set
+        extra = observed_set - declared
+        if missing or extra:
+            divergences.append(
+                {
+                    "skill": slug,
+                    "declared": sorted(declared),
+                    "observed": sorted(observed_set),
+                    "missing": sorted(missing),
+                    "extra": sorted(extra),
+                }
+            )
+    return {
+        "available": True,
+        "note": "",
+        "divergences": divergences,
+    }
+
+
 def _parse_ts(value: str) -> datetime | None:
     """Parse a GitHub ISO-8601 timestamp (trailing 'Z') to an aware datetime."""
     try:
@@ -428,6 +994,17 @@ def survey_docket(token: str, now: datetime) -> dict:
 
 
 # --- Rendering -------------------------------------------------------------
+
+
+def _md_safe(value: str) -> str:
+    """Strip characters that could break a markdown table cell or inject
+    formatting when interpolating repo-controlled data (e.g. a usage slug)
+    into the digest: '|' (breaks table columns), backtick (breaks code-span
+    nesting), and newlines (breaks a single-line cell). Defense in depth on
+    top of the upstream shape validation (USAGE_SLUG_RE already restricts
+    usage keys to `[a-z0-9-]`) — belt and suspenders, not the only guard.
+    """
+    return value.replace("|", "").replace("`", "").replace("\n", " ").replace("\r", " ")
 
 
 def _cycle_tag(now: datetime) -> str:
@@ -512,6 +1089,126 @@ def render_digest(census: dict) -> str:
             lines.append(f"- `{name}`: {err}")
         lines.append("")
 
+    # Subscription drift — recomputed catalog hash vs. each lock's computedHash.
+    lines.append("## Subscription drift")
+    lines.append("")
+    drift = signals.get("subscription_drift", [])
+    if not drift:
+        lines.append("_No repo subscribes catalog skills with a stored `computedHash` — nothing to check._")
+        lines.append("")
+    else:
+        drifted = [r for r in drift if r["status"] == "drift"]
+        indeterminate = [r for r in drift if r["status"] == "indeterminate"]
+        unscoped = [r for r in drift if r["status"] == "unscoped"]
+        if CATALOG_HASH_ALGO is None:
+            lines.append(
+                "> Hash algorithm **undetermined** — the `computedHash` is produced by the "
+                "external skills.sh CLI's normalization, which no local candidate reproduces "
+                "(verified against every historical version of the catalog files). Drift is "
+                "reported `indeterminate` per lock; the census never asserts drift it cannot "
+                "prove. Set `CATALOG_HASH_ALGO` once the normalization is mirrored to unlock "
+                "`ok`/`drift` verdicts (each still guarded per-skill against its own pin "
+                "lineage — see the module docstring)."
+            )
+            lines.append("")
+        lines.append("| Repo | Skill | Status | Note |")
+        lines.append("|---|---|---|---|")
+        for r in drift:
+            if r.get("skill") is None:
+                skill_cell = f"{r.get('count', 0)} sub(s): " + ", ".join(
+                    f"`{_md_safe(s)}`" for s in r.get("skills", [])
+                )
+            else:
+                skill_cell = f"`{_md_safe(r['skill'])}`"
+            badge = {
+                "ok": "✅ ok",
+                "drift": "⚠️ drift",
+                "indeterminate": "❔ indeterminate",
+                "unscoped": "🚫 unscoped",
+            }.get(r["status"], r["status"])
+            note = r.get("note", "") or ""
+            lines.append(f"| `{r['repo']}` | {skill_cell} | {badge} | {note} |")
+        lines.append("")
+        summary_parts = []
+        if drifted:
+            summary_parts.append(
+                f"**{len(drifted)} drifted subscription(s)** — the catalog moved since the "
+                "lock was written. Surfaced only; refresh in the consumer repo to reconcile "
+                "(the census never auto-fixes)."
+            )
+        if indeterminate:
+            summary_parts.append(
+                f"**{len(indeterminate)} lock(s)/subscription(s) indeterminate** — no drift "
+                "asserted (algorithm undetermined, or unproven for that skill's pin lineage)."
+            )
+        if unscoped:
+            summary_parts.append(
+                f"**{len(unscoped)} lock(s) with unscoped subscription(s)** — missing/None "
+                "`source` in skills-lock.json, not attributable to this catalog, so not "
+                "drift-checkable (distinct from 'indeterminate')."
+            )
+        for part in summary_parts:
+            lines.append(part)
+        lines.append("")
+
+    # Usage citations — clud-bug skill-usage schema v2 aggregation.
+    lines.append("## Usage citations")
+    lines.append("")
+    usage = signals.get("usage", {"present": False, "skills": {}})
+    if usage.get("present"):
+        lines.append(
+            f"Aggregated across surveyed repos: {usage['total_citations']} citation(s), "
+            f"{usage['total_loads']} load(s)."
+        )
+        lines.append("")
+        lines.append("| Skill | Loads | Citations | Last cited | Repos |")
+        lines.append("|---|---:|---:|---|---|")
+        for slug in sorted(usage["skills"]):
+            s = usage["skills"][slug]
+            reps = ", ".join(f"`{r}`" for r in s.get("repos", []))
+            lines.append(
+                f"| `{_md_safe(slug)}` | {s['loads']} | {s['citations']} | "
+                f"{s.get('last_cited') or '—'} | {reps} |"
+            )
+        lines.append("")
+    else:
+        lines.append(
+            "_No usage data — `usage[]` not yet emitted by consumers "
+            "(clud-bug schema v2 pending). Never failed on absence._"
+        )
+        lines.append("")
+    rejected_count = usage.get("rejected_count", 0)
+    if rejected_count:
+        rejected_repos = usage.get("rejected", {})
+        lines.append(
+            f"> {rejected_count} usage key(s) across {len(rejected_repos)} repo(s) rejected "
+            "(did not match the skill-slug shape `^[a-z0-9][a-z0-9-]{0,62}$`) — not "
+            "aggregated above; see `signals.usage.rejected` in census.json for the raw keys."
+        )
+        lines.append("")
+
+    # Placement-map cross-check — declared subscribers vs. live observation.
+    lines.append("## Placement divergence")
+    lines.append("")
+    placement = signals.get("placement_divergence", {"available": False, "divergences": []})
+    if not placement.get("available"):
+        lines.append(f"_{placement.get('note', 'placement cross-check unavailable')}._")
+        lines.append("")
+    else:
+        divs = placement.get("divergences", [])
+        if not divs:
+            lines.append("_Placement map agrees with live subscriptions — no divergence._")
+            lines.append("")
+        else:
+            for d in divs:
+                parts = []
+                if d["missing"]:
+                    parts.append("declared-but-not-observed: " + ", ".join(f"`{r}`" for r in d["missing"]))
+                if d["extra"]:
+                    parts.append("observed-but-not-declared: " + ", ".join(f"`{r}`" for r in d["extra"]))
+                lines.append(f"- `{d['skill']}` — " + "; ".join(parts))
+            lines.append("")
+
     # Stale docket
     docket = census["stale_docket"]
     lines.append("## Docket staleness")
@@ -546,13 +1243,33 @@ def render_digest(census: dict) -> str:
         "subscription coverage. It does **not** measure:"
     )
     lines.append("")
-    lines.append("- **Usage / firing frequency** — how often each skill actually loads in agent sessions.")
-    lines.append("- **Citation data** — which skills get referenced in PRs, reviews, or decision logs.")
+    usage_present = signals.get("usage", {}).get("present")
+    if usage_present:
+        lines.append(
+            "- **Usage / firing frequency** — now partially wired: see **Usage "
+            "citations** above (aggregated from consumers' `usage[]` blocks)."
+        )
+        lines.append(
+            "- **Citation data** — partially wired via `usage[<slug>].citations` "
+            "(clud-bug schema v2); coverage is limited to repos already emitting it."
+        )
+    else:
+        lines.append("- **Usage / firing frequency** — how often each skill actually loads in agent sessions.")
+        lines.append(
+            "- **Citation data** — `usage[]` not yet emitted by consumers "
+            "(clud-bug schema v2 pending); no skill carries citation counts this cycle."
+        )
     lines.append("")
-    lines.append(
-        "Those signals are not yet wired. Promotion/demotion judgments this "
-        "cycle rest on structural convergence (see Signals), not observed use."
-    )
+    if usage_present:
+        lines.append(
+            "Structural convergence (see Signals) remains the primary promotion "
+            "evidence; observed-use data is still sparse."
+        )
+    else:
+        lines.append(
+            "Those signals are not yet wired. Promotion/demotion judgments this "
+            "cycle rest on structural convergence (see Signals), not observed use."
+        )
     lines.append("")
 
     return "\n".join(lines) + "\n"
@@ -581,6 +1298,12 @@ def main() -> int:
         repos[repo] = survey_repo(repo, token)
 
     signals = compute_signals(catalog, repos)
+    # Additive signals (never mutate compute_signals' existing contract).
+    signals["subscription_drift"] = compute_subscription_drift(repos)
+    signals["usage"] = aggregate_usage(repos)
+    signals["placement_divergence"] = compute_placement_divergence(
+        read_placement_map(), repos
+    )
     stale_docket = survey_docket(token, now)
 
     census = {
@@ -602,6 +1325,11 @@ def main() -> int:
 
     # One-line ok summary to stdout (matches the org's `ok <k=v>` house style).
     error_repos = len(signals["per_repo_errors"])
+    drift_recs = signals["subscription_drift"]
+    drift_count = sum(1 for r in drift_recs if r["status"] == "drift")
+    indeterminate_count = sum(1 for r in drift_recs if r["status"] == "indeterminate")
+    unscoped_count = sum(1 for r in drift_recs if r["status"] == "unscoped")
+    usage_rejected_count = signals["usage"].get("rejected_count", 0)
     print(
         "ok "
         f"cycle={census['cycle']} "
@@ -611,11 +1339,141 @@ def main() -> int:
         f"convergent={len(signals['convergent_local'])} "
         f"unsubscribed={len(signals['unsubscribed_catalog_skills'])} "
         f"untracked_total={signals['untracked_total']} "
+        f"drift={drift_count} "
+        f"drift_indeterminate={indeterminate_count} "
+        f"drift_unscoped={unscoped_count} "
+        f"usage_citations={signals['usage']['total_citations']} "
+        f"usage_rejected={usage_rejected_count} "
+        f"placement_divergences={len(signals['placement_divergence']['divergences'])} "
         f"stale_docket={stale_docket.get('stale_count', 0)} "
         f"out={out_dir}"
     )
     return 0
 
 
+def local_selftest(argv: list[str]) -> int:
+    """Network-free self-test (STEWARD_TOKEN not required). Exercises hash
+    determination + drift classification + placement-map read against the
+    LOCAL checkout only, printing results. Optional `--lock <path>` points at a
+    real skills-lock.json to run the empirical hash determination against
+    (defaults to ./skills-lock.json if present).
+
+    Never fetches anything. Returns 0 always (a diagnostic, not a gate).
+    """
+    lock_path = None
+    if "--lock" in argv:
+        i = argv.index("--lock")
+        if i + 1 < len(argv):
+            lock_path = argv[i + 1]
+    if lock_path is None and os.path.isfile(os.path.join(os.getcwd(), LOCK_PATH)):
+        lock_path = os.path.join(os.getcwd(), LOCK_PATH)
+
+    print("== census_counters --local-selftest ==")
+    print(f"cwd={os.getcwd()}")
+    print(f"CATALOG_HASH_ALGO={CATALOG_HASH_ALGO!r} "
+          f"(None => drift is 'indeterminate'; algorithm undetermined)")
+    print(f"registered algorithms: {sorted(_HASH_ALGOS)}")
+
+    catalog = read_catalog()
+    print(f"\n-- catalog ({len(catalog)} skills) --")
+    print(", ".join(catalog) if catalog else "(none)")
+
+    # 1) Hash determination against a real lock (if available).
+    print("\n-- hash determination (recompute each catalog file, all algos) --")
+    subs: list[dict] = []
+    unscoped: list[str] = []
+    if lock_path and os.path.isfile(lock_path):
+        try:
+            with open(lock_path, "r", encoding="utf-8") as fh:
+                lock = json.load(fh)
+        except (OSError, ValueError) as exc:
+            print(f"  could not read lock {lock_path}: {exc}")
+            lock = None
+        subs, unscoped = parse_lock_hashes(lock) if lock is not None else ([], [])
+        print(f"  lock={lock_path} — {len(subs)} catalog subscription(s), "
+              f"{len(unscoped)} unscoped (missing/None source): {unscoped}")
+        for sub in subs:
+            print(f"  * {sub['slug']} (skillPath={sub['skillPath']})")
+            print(f"      stored     : {sub['computedHash']}")
+            any_match = False
+            for name in sorted(_HASH_ALGOS):
+                got = compute_catalog_hash(sub["skillPath"], name)
+                mark = "  <== MATCH" if got == sub["computedHash"] else ""
+                if got == sub["computedHash"]:
+                    any_match = True
+                print(f"      {name:<16}: {got}{mark}")
+            if not any_match:
+                print("      => NO local algorithm reproduces the stored hash "
+                      "(external skills.sh normalization).")
+    else:
+        print("  no lock provided/found — skipping empirical determination "
+              "(pass --lock <path> to run it).")
+
+    # 2) Drift classification — dual mode demonstration, plus the per-skill
+    # lineage-proof guard (a mismatch alone is never enough to assert 'drift').
+    print("\n-- drift classification (dual mode + per-skill lineage proof) --")
+    if subs or unscoped:
+        pseudo = {
+            "selftest-lock": {
+                "subscribed": [],
+                "lock_subscriptions": subs,
+                "unscoped_subscriptions": unscoped,
+            }
+        }
+        default_recs = compute_subscription_drift(pseudo)
+        print(f"  CATALOG_HASH_ALGO={CATALOG_HASH_ALGO!r}: "
+              f"{[r['status'] for r in default_recs]}")
+        for r in default_recs:
+            print(f"    {r['status']:<13} skill={r.get('skill')} note={r.get('note')}")
+        # Demonstrate the compute path with an algorithm forced on (no global
+        # mutation — the override is a parameter). sha256_raw is known NOT to
+        # be the real skills.sh normalization, so the per-skill lineage-proof
+        # guard (_algo_proven_for_lineage) should downgrade every mismatch to
+        # 'indeterminate' rather than assert 'drift' — this is the guard
+        # working as designed, not a regression.
+        forced = compute_subscription_drift(pseudo, algo="sha256_raw")
+        print(f"  algo='sha256_raw' (illustrative, deliberately wrong): "
+              f"{[r['status'] for r in forced]}")
+        for r in forced:
+            if r.get("skill") is None:
+                print(f"    {r['status']:<13} skill=None note={r.get('note')}")
+            else:
+                print(f"    {r['status']:<13} skill={r.get('skill')} note={r.get('note')} "
+                      f"stored={str(r.get('stored'))[:12]}… recomputed={str(r.get('recomputed'))[:12]}…")
+        if any(r["status"] == "drift" for r in forced):
+            print("  NOTE: a forced-wrong algorithm still produced 'drift' — this would mean "
+                  "_algo_proven_for_lineage matched a historical version by coincidence.")
+        else:
+            print("  (forced-algo verdicts are 'indeterminate', not 'drift' — the per-skill "
+                  "lineage-proof guard correctly refused to assert drift for an algorithm "
+                  "unproven against this skill's history.)")
+    else:
+        print("  no lock — skipping drift demonstration.")
+
+    # 3) Placement-map read + cross-check.
+    print("\n-- placement-map cross-check --")
+    pm = read_placement_map()
+    if pm is None:
+        print(f"  {PLACEMENT_MAP_PATH}: ABSENT/unreadable (tolerated).")
+    else:
+        skills = pm.get("skills") if isinstance(pm, dict) else None
+        n = len(skills) if isinstance(skills, dict) else 0
+        print(f"  {PLACEMENT_MAP_PATH}: present, version={pm.get('version')}, "
+              f"updated={pm.get('updated')}, skills={n}")
+    print("  NOTE: offline self-test observes NO live subscriptions, so every "
+          "declared subscriber below reads as 'missing' — this only exercises "
+          "the code path; real divergences need a networked run.")
+    result = compute_placement_divergence(pm, {})
+    print(f"  cross-check available={result['available']} "
+          f"note={result['note']!r} divergences={len(result['divergences'])}")
+    for d in result["divergences"]:
+        print(f"    - {d['skill']}: missing={d['missing']} extra={d['extra']}")
+
+    print("\nok selftest done")
+    return 0
+
+
 if __name__ == "__main__":
+    if "--local-selftest" in sys.argv:
+        sys.exit(local_selftest(sys.argv[1:]))
     sys.exit(main())

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -5,16 +5,23 @@ name: validate-skills
 # name mismatch with directory) before it ships to skills.sh, where
 # downstream consumers (clud-bug, agent runtimes via skills CLI)
 # would silently get broken skills.
+#
+# Also gates docs/placement-map.json (when present): valid JSON/shape, and
+# its `skills` keys reconciled 1:1 against skills/ directory names. This is
+# what makes the placement-map guide's claim ("the map is kept in sync")
+# actually true instead of aspirational.
 
 on:
   pull_request:
     paths:
       - "skills/**/SKILL.md"
+      - "docs/placement-map.json"
       - ".github/workflows/validate-skills.yml"
   push:
     branches: [main]
     paths:
       - "skills/**/SKILL.md"
+      - "docs/placement-map.json"
       - ".github/workflows/validate-skills.yml"
 
 permissions:
@@ -38,6 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           python <<'PY'
+          import json
           import re
           import sys
           from pathlib import Path
@@ -46,6 +54,37 @@ jobs:
 
           ROOT = Path("skills")
           FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+
+          # protocol SPEC.md §1.10.1 "Frontmatter (NORMATIVE)" -- enums and
+          # shapes enforced below. Every key here is OPTIONAL in the
+          # frontmatter; unknown keys (and the RESERVED, definition-deferred
+          # `layer` / `status` / `superseded_by` keys) are always tolerated
+          # and never validated -- only the fields below are checked, and
+          # only when present.
+          NAME_SLUG_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
+          # SPEC §1.10.1: `source: manual | logmind-derived | skills-sh | clud-bug-baseline`
+          SOURCE_VALUES = {"manual", "logmind-derived", "skills-sh", "clud-bug-baseline"}
+          # SPEC §1.10.1: `kind: rule | voice | design`
+          KIND_VALUES = {"rule", "voice", "design"}
+          # SPEC §1.10.1: `voice_scope: personal | team | org | community`
+          VOICE_SCOPE_VALUES = {"personal", "team", "org", "community"}
+          # SPEC §1.10.1: `review_mode: shared | dedicated`
+          REVIEW_MODE_VALUES = {"shared", "dedicated"}
+
+          def _valid_extension_entry(e: object) -> bool:
+              """An `applies_to.extensions` entry is a suffix-matched string —
+              clud-bug does suffix matching, not strict dotfile-extension
+              matching, so both '.tsx' and '_test.py' (skills/test-discipline
+              ships the latter) are legitimate. Require: non-empty string, no
+              whitespace, at least one '.', and not the bare string '.'.
+              """
+              return (
+                  isinstance(e, str)
+                  and e != ""
+                  and not re.search(r"\s", e)
+                  and "." in e
+                  and e != "."
+              )
 
           errors: list[str] = []
 
@@ -95,11 +134,18 @@ jobs:
                   errors.append(
                       f"::error file={prefix}::frontmatter is missing a non-empty `name:` field"
                   )
-              elif name.strip() != dir_name:
-                  errors.append(
-                      f"::error file={prefix}::frontmatter name='{name.strip()}' "
-                      f"does not match directory name '{dir_name}'"
-                  )
+              else:
+                  name = name.strip()
+                  if name != dir_name:
+                      errors.append(
+                          f"::error file={prefix}::frontmatter name='{name}' "
+                          f"does not match directory name '{dir_name}'"
+                      )
+                  if not NAME_SLUG_RE.match(name):
+                      errors.append(
+                          f"::error file={prefix}::frontmatter name='{name}' does not match "
+                          r"the SPEC §1.10.1 slug regex ^[a-z][a-z0-9-]{0,62}$"
+                      )
 
               description = meta.get("description")
               if not description or not isinstance(description, str) or not description.strip():
@@ -113,6 +159,197 @@ jobs:
                   errors.append(
                       f"::error file={prefix}::body has no top-level `# Title` heading"
                   )
+
+              # --- SPEC §1.10.1 OPTIONAL-field validation ---
+
+              kind = meta.get("kind")
+              if kind is not None and kind not in KIND_VALUES:
+                  errors.append(
+                      f"::error file={prefix}::`kind: {kind!r}` is not one of "
+                      f"{sorted(KIND_VALUES)} (SPEC §1.10.1)"
+                  )
+
+              voice_scope = meta.get("voice_scope")
+              if kind == "voice":
+                  if voice_scope is None or voice_scope not in VOICE_SCOPE_VALUES:
+                      errors.append(
+                          f"::error file={prefix}::`kind: voice` requires `voice_scope` "
+                          f"to be one of {sorted(VOICE_SCOPE_VALUES)} (SPEC §1.10.1)"
+                      )
+              elif voice_scope is not None:
+                  errors.append(
+                      f"::error file={prefix}::`voice_scope` is set but `kind` is not "
+                      "`voice` (SPEC §1.10.1: voice_scope is required by, and only "
+                      "valid alongside, kind: voice)"
+                  )
+
+              review_mode = meta.get("review_mode")
+              if review_mode is not None and review_mode not in REVIEW_MODE_VALUES:
+                  errors.append(
+                      f"::error file={prefix}::`review_mode: {review_mode!r}` is not one "
+                      f"of {sorted(REVIEW_MODE_VALUES)} (SPEC §1.10.1)"
+                  )
+
+              source = meta.get("source")
+              if source is not None and source not in SOURCE_VALUES:
+                  errors.append(
+                      f"::error file={prefix}::`source: {source!r}` is not one of "
+                      f"{sorted(SOURCE_VALUES)} (SPEC §1.10.1)"
+                  )
+
+              applies_to = meta.get("applies_to")
+              if applies_to is not None:
+                  if not isinstance(applies_to, dict):
+                      errors.append(
+                          f"::error file={prefix}::`applies_to` must be a YAML mapping"
+                      )
+                  else:
+                      paths = applies_to.get("paths")
+                      if paths is not None and (
+                          not isinstance(paths, list)
+                          or not all(isinstance(p, str) and p.strip() for p in paths)
+                      ):
+                          errors.append(
+                              f"::error file={prefix}::`applies_to.paths` must be a list "
+                              "of non-empty glob strings (SPEC §1.10.1)"
+                          )
+
+                      extensions = applies_to.get("extensions")
+                      if extensions is not None and (
+                          not isinstance(extensions, list)
+                          or not all(_valid_extension_entry(e) for e in extensions)
+                      ):
+                          errors.append(
+                              f"::error file={prefix}::`applies_to.extensions` must be a "
+                              "list of extension/suffix strings (e.g. '.tsx', "
+                              "'_test.py') (SPEC §1.10.1)"
+                          )
+
+                      author = applies_to.get("author")
+                      if author is not None:
+                          if not isinstance(author, str) or not author.strip():
+                              errors.append(
+                                  f"::error file={prefix}::`applies_to.author` must be a "
+                                  "single non-empty GitHub handle string, not a list "
+                                  "(SPEC §1.10.1)"
+                              )
+                          elif author.strip().startswith("@"):
+                              errors.append(
+                                  f"::error file={prefix}::`applies_to.author` must not "
+                                  "include a leading '@' (SPEC §1.10.1)"
+                              )
+
+          # --- docs/placement-map.json gate --------------------------------
+          #
+          # The steward's placement map (docs/integrating-with-agent-skills.md
+          # "The placement map") claims it is the per-skill ground truth kept
+          # in sync with skills/. Make that claim real: validate shape + enums
+          # when the file is present, and reconcile its `skills` keys 1:1
+          # against the skills/ directory names (report missing/extra by
+          # name). Absence is tolerated (it may not exist yet / may be
+          # authored by a parallel agent) -- only presence-with-defects fails.
+
+          PLACEMENT_MAP_PATH = Path("docs/placement-map.json")
+          AUTHORING_HOME_RE = re.compile(r"^(catalog|undecided|repo-mirrored:[a-z0-9-]+)$")
+          DISTRIBUTION_VALUES = {"default-on", "opt-in", "catalog-only"}
+
+          if PLACEMENT_MAP_PATH.exists():
+              pm_prefix = str(PLACEMENT_MAP_PATH)
+
+              try:
+                  pm_text = PLACEMENT_MAP_PATH.read_text(encoding="utf-8")
+              except OSError as e:
+                  errors.append(
+                      f"::error file={pm_prefix}::could not read {PLACEMENT_MAP_PATH}: {e}"
+                  )
+                  pm_text = None
+
+              pm = None
+              if pm_text is not None:
+                  try:
+                      pm = json.loads(pm_text)
+                  except json.JSONDecodeError as e:
+                      errors.append(
+                          f"::error file={pm_prefix}::{PLACEMENT_MAP_PATH} is not valid JSON: {e}"
+                      )
+
+              if pm is not None:
+                  if not isinstance(pm, dict):
+                      errors.append(
+                          f"::error file={pm_prefix}::top level of {PLACEMENT_MAP_PATH} "
+                          "must be a JSON object with `version`, `updated`, `skills`"
+                      )
+                  else:
+                      version = pm.get("version")
+                      if not isinstance(version, int) or isinstance(version, bool):
+                          errors.append(
+                              f"::error file={pm_prefix}::`version` must be an int"
+                          )
+
+                      updated = pm.get("updated")
+                      if not isinstance(updated, str) or not updated.strip():
+                          errors.append(
+                              f"::error file={pm_prefix}::`updated` must be a non-empty string"
+                          )
+
+                      skills_map = pm.get("skills")
+                      if not isinstance(skills_map, dict):
+                          errors.append(
+                              f"::error file={pm_prefix}::`skills` must be an object "
+                              "mapping skill name -> metadata"
+                          )
+                      else:
+                          for slug, meta in skills_map.items():
+                              if not isinstance(meta, dict):
+                                  errors.append(
+                                      f"::error file={pm_prefix}::skills.{slug} must be "
+                                      "an object (unknown per-skill keys are tolerated; "
+                                      "the value itself must still be a mapping)"
+                                  )
+                                  continue
+
+                              authoring_home = meta.get("authoring_home")
+                              if not isinstance(authoring_home, str) or not AUTHORING_HOME_RE.match(
+                                  authoring_home
+                              ):
+                                  errors.append(
+                                      f"::error file={pm_prefix}::skills.{slug}.authoring_home="
+                                      f"{authoring_home!r} must match "
+                                      r"^(catalog|undecided|repo-mirrored:[a-z0-9-]+)$"
+                                  )
+
+                              distribution = meta.get("distribution")
+                              if distribution not in DISTRIBUTION_VALUES:
+                                  errors.append(
+                                      f"::error file={pm_prefix}::skills.{slug}.distribution="
+                                      f"{distribution!r} is not one of "
+                                      f"{sorted(DISTRIBUTION_VALUES)}"
+                                  )
+
+                              subscribers = meta.get("subscribers")
+                              if not isinstance(subscribers, list) or not all(
+                                  isinstance(s, str) for s in subscribers
+                              ):
+                                  errors.append(
+                                      f"::error file={pm_prefix}::skills.{slug}.subscribers "
+                                      "must be a list of strings"
+                                  )
+
+                          # Map keys must EXACTLY equal the skills/ directory names.
+                          map_names = set(skills_map.keys())
+                          dir_names = {d.name for d in skill_dirs}
+                          missing_from_map = sorted(dir_names - map_names)
+                          extra_in_map = sorted(map_names - dir_names)
+                          if missing_from_map:
+                              errors.append(
+                                  f"::error file={pm_prefix}::{PLACEMENT_MAP_PATH} is missing "
+                                  f"an entry for: {', '.join(missing_from_map)}"
+                              )
+                          if extra_in_map:
+                              errors.append(
+                                  f"::error file={pm_prefix}::{PLACEMENT_MAP_PATH} has an entry "
+                                  f"for non-existent skills/ dir(s): {', '.join(extra_in_map)}"
+                              )
 
           if errors:
               for e in errors:

--- a/docs/decisions-branches/feat__skill-engine-w1-foundations.md
+++ b/docs/decisions-branches/feat__skill-engine-w1-foundations.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-17 20:15 - skill engine W1: drift detection, placement-map ground truth, §1.10.1 validator, six-kind taxonomy
+
+**Reasoning:** The engine detected-and-filed but had no live-connection verify, an under-enforcing validator, no committed placement ground truth, and a rubric whose verdict-kinds block contradicted its own panel. W1 lands: subscription drift detection in census_counters (source-scoped to this catalog, per-skill lineage proof required before any drift assertion — the lock hash algorithm proved EXTERNAL after ~40 candidates x full git history matched nothing, so status stays honestly indeterminate until skills.sh's normalization is mirrored); docs/placement-map.json (46 skills, authoring-home/distribution/subscribers) with a real CI gate; validate-skills enforcing the §1.10.1 enums + shapes with unknown-key tolerance; usage[] read wired (no consumer emits it yet); six-kind taxonomy reconciled with the label mapping stated.
+
+**Alternatives considered:** Assert drift on plain sha256 mismatch (rejected: proven false-drift on EOL/foreign-catalog/unproven-algo cases — never report drift you cannot prove). '.'-prefix requirement on applies_to.extensions (rejected: my own brief error — clud-bug suffix-matches; test-discipline's _test.py entries are deliberate).
+
+**Implications:**
+- Flipping CATALOG_HASH_ALGO alone can no longer mis-flag (lineage-proof gate). The placement map is signal-1 ground truth the census cross-checks; divergence files placement verdicts. W2 (process-verdict actuator + notify-subscribers fan-out) builds on these seams. census_panel should read the three new signal keys — noted for W2.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -22,6 +22,7 @@ agent-skills
 │   ├── decisions.md
 │   ├── file-structure.md
 │   ├── integrating-with-agent-skills.md
+│   ├── placement-map.json
 │   └── timeline.md
 ├── skills
 │   ├── apca-contrast

--- a/docs/integrating-with-agent-skills.md
+++ b/docs/integrating-with-agent-skills.md
@@ -73,6 +73,14 @@ For a repo that predates this system (all current thrillmade repos):
 5. **Subscribe deliberately.** Check the open `placement:` issues on this repo — the census may already have recommendations for you.
 6. **Protect your seams:** never hand-edit subscribed copies (updaters overwrite them); publishers must never let refresh automation write their shipped source (e.g. clud-bug's `templates/skills/**` — that's an npm release, not a cron); preserve symlink topology (`.claude/skills/` → `.agents/skills/`); automation commits use `[skip-logmind]` or file a decision entry (protocol SPEC §15).
 
+### The placement map
+
+[`docs/placement-map.json`](placement-map.json) is the per-skill ground truth the census reads as **signal 1**. For every skill in `skills/`, it records `authoring_home` (`catalog` / `repo-mirrored:<repo>` / `undecided`), `distribution` (`default-on` / `opt-in` / `catalog-only`), and `subscribers` (the repos that actually pull it) — the verdicts a prior editorial round already reached, so each new census cycle starts from a baseline instead of re-litigating placement from zero.
+
+Divergence from live state — a repo's `skills-lock.json` or `.clud-bug.json` subscribing to something the map marks `catalog-only`, or authoring a copy of something the map homes at `catalog` — isn't silently reconciled. It *files* a placement verdict: the census raises it as a `placement:` issue for a human to resolve, either by correcting the repo or by updating the map.
+
+Editing the map is a normal PR through the same gate as any other catalog change — `validate-skills.yml`, strict-mode clud-bug review, human approval. There's no separate authority for it.
+
 ## Publishing a skill (nomination flow)
 
 1. Incubate in your repo's `.claude/skills/<slug>/SKILL.md` until it's stable.

--- a/docs/placement-map.json
+++ b/docs/placement-map.json
@@ -1,0 +1,277 @@
+{
+  "version": 1,
+  "updated": "2026-07-17",
+  "skills": {
+    "critical-issues-only": {
+      "authoring_home": "catalog",
+      "distribution": "default-on",
+      "subscribers": ["clud-bug", "clud-bug-app", "logmind", "tokenomics", "protocol", "reporulez", "rezgen"]
+    },
+    "evidence-based-review": {
+      "authoring_home": "catalog",
+      "distribution": "default-on",
+      "subscribers": ["clud-bug", "clud-bug-app", "logmind", "tokenomics", "protocol", "reporulez", "rezgen"]
+    },
+    "respect-existing-conventions": {
+      "authoring_home": "catalog",
+      "distribution": "default-on",
+      "subscribers": ["clud-bug", "clud-bug-app", "logmind", "tokenomics", "protocol", "reporulez", "rezgen"]
+    },
+    "clud-bug-collaboration": {
+      "authoring_home": "catalog",
+      "distribution": "default-on",
+      "subscribers": ["clud-bug", "clud-bug-app", "logmind", "tokenomics", "protocol", "reporulez", "rezgen"]
+    },
+    "logmind": {
+      "authoring_home": "repo-mirrored:logmind",
+      "distribution": "opt-in",
+      "subscribers": ["tokenomics"],
+      "notes": "release-sync: logmind's release workflow PRs its skill update here"
+    },
+    "brand-voice-review": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": ["tokenomics"]
+    },
+    "designing-elite-ui": {
+      "authoring_home": "undecided",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "authoring-home ruling pending clud-bug#235; currently authored in clud-bug/templates/skills/design/, promotion in flight"
+    },
+    "design-system-consistency": {
+      "authoring_home": "undecided",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "authoring-home ruling pending clud-bug#235; currently authored in clud-bug/templates/skills/design/, promotion in flight"
+    },
+    "frontend-a11y": {
+      "authoring_home": "undecided",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "authoring-home ruling pending clud-bug#235; currently authored in clud-bug/templates/skills/design/, promotion in flight"
+    },
+    "visual-polish": {
+      "authoring_home": "undecided",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "authoring-home ruling pending clud-bug#235; currently authored in clud-bug/templates/skills/design/, promotion in flight"
+    },
+    "orchestrating-elite-agent-qa": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "tokenomics flip from authored-here to subscribed is pending (nomination in flight); tokenomics census says it would subscribe once accepted"
+    },
+    "udts-component-sizing-ladders": {
+      "authoring_home": "repo-mirrored:tokenomics",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "incubating — deliberately unwritten; tokenomics is holding K2 incubation until the Phase R tier-model rewrite (feat/udts-color-polarity) lands so it doesn't encode the old model"
+    },
+    "udts-dtcg-extensions": {
+      "authoring_home": "repo-mirrored:tokenomics",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "incubating — deliberately unwritten; tokenomics is holding K2 incubation until the Phase R tier-model rewrite (feat/udts-color-polarity) lands so it doesn't encode the old model"
+    },
+    "udts-linter-rules": {
+      "authoring_home": "repo-mirrored:tokenomics",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "incubating — deliberately unwritten; tokenomics is holding K2 incubation until the Phase R tier-model rewrite (feat/udts-color-polarity) lands so it doesn't encode the old model"
+    },
+    "udts-naming-convention": {
+      "authoring_home": "repo-mirrored:tokenomics",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "incubating — deliberately unwritten; tokenomics is holding K2 incubation until the Phase R tier-model rewrite (feat/udts-color-polarity) lands so it doesn't encode the old model"
+    },
+    "udts-review": {
+      "authoring_home": "repo-mirrored:tokenomics",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "incubating — deliberately unwritten; tokenomics census names this a gap (clud-bug lens for UDTS R7-R10 rules), but holding K2 incubation until the Phase R tier-model rewrite lands"
+    },
+    "udts-semver-defaults": {
+      "authoring_home": "repo-mirrored:tokenomics",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "incubating — deliberately unwritten; tokenomics is holding K2 incubation until the Phase R tier-model rewrite (feat/udts-color-polarity) lands so it doesn't encode the old model"
+    },
+    "udts-spacing-defaults": {
+      "authoring_home": "repo-mirrored:tokenomics",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "incubating — deliberately unwritten; tokenomics is holding K2 incubation until the Phase R tier-model rewrite (feat/udts-color-polarity) lands so it doesn't encode the old model"
+    },
+    "udts-token-model": {
+      "authoring_home": "repo-mirrored:tokenomics",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "incubating — deliberately unwritten; tokenomics is holding K2 incubation until the Phase R tier-model rewrite (feat/udts-color-polarity) lands so it doesn't encode the old model"
+    },
+    "design-token-naming": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "deprecated — migration window; SUPERSEDED by token-naming-conventions (L0) + udts-naming-convention (L2, incubating); kept unchanged until downstream migrations land"
+    },
+    "component-sizing": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "deprecated — migration window; SUPERSEDED by component-sizing-principles (L0) + udts-component-sizing-ladders (L2, incubating); kept unchanged until downstream migrations land"
+    },
+    "consuming-a-design-system": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "L1 dispatcher — entry point that routes to the L0 primitives; a repo consumes what it routes to, not the dispatcher itself as a standing subscription"
+    },
+    "designing-a-design-system": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "L1 dispatcher — entry point that routes to the L0 primitives; a repo consumes what it routes to, not the dispatcher itself as a standing subscription"
+    },
+    "reviewing-design-work": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "L1 dispatcher — entry point that routes to review lenses; a repo consumes what it routes to, not the dispatcher itself as a standing subscription"
+    },
+    "curating-a-skill-catalog": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "catalog-steward tooling for running/judging the census cycle itself, not a downstream repo's review discipline"
+    },
+    "skill-frontmatter-quality": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "nomination-time gate scoped to skills/*/SKILL.md edits in this repo; not applicable to a downstream repo's product code"
+    },
+    "skillforge": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "skill-authoring tool (vendored, author: zakelfassi); catalog-side utility rather than a per-repo subscription"
+    },
+    "spacing-system": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
+    },
+    "test-discipline": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "review-discipline skill (review_mode: dedicated, applies_to test paths) a repo might subscribe to"
+    },
+    "token-frugal-tooling": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "quick-reference for repos running both logmind and clud-bug; a repo with both installed might subscribe"
+    },
+    "token-naming-conventions": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; successor to deprecated design-token-naming; a repo building or extending its own token system might subscribe directly"
+    },
+    "type-scale": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
+    },
+    "wcag-contrast": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
+    },
+    "web-interface-guidelines-review": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "review-discipline skill (review_mode: dedicated) for UI code a repo might subscribe to"
+    },
+    "apca-contrast": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; tokenomics census names this as a would-subscribe (build-agent grounding), not yet subscribed"
+    },
+    "api-contract-enforcement": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "review-discipline skill (review_mode: dedicated, applies_to api paths) a repo might subscribe to"
+    },
+    "chroma-harmonization": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
+    },
+    "component-sizing-principles": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; successor to deprecated component-sizing; a repo building or extending its own token system might subscribe directly"
+    },
+    "conventions-template": {
+      "authoring_home": "catalog",
+      "distribution": "catalog-only",
+      "subscribers": [],
+      "notes": "template — copy + customize per maintainer's applies_to.author, not a live subscription"
+    },
+    "dtcg-format": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
+    },
+    "line-height-grid": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
+    },
+    "oklch-color-space": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; tokenomics census names this as a would-subscribe (build-agent grounding), not yet subscribed"
+    },
+    "orchestrating-agent-delegation": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "agent-orchestration discipline a repo doing multi-agent build/review work might subscribe to"
+    },
+    "palette-relationships": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
+    },
+    "pii-and-compliance": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "review-discipline skill (review_mode: dedicated) a repo might subscribe to"
+    },
+    "semver-design-tokens": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
+    }
+  }
+}

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (6 decisions)
+## 2026-07 (7 decisions)
 
-- **2026-07-17** — census panel: disable thinking for the JSON-only judgment call (cycle-W29 root cause) *(fix/census-panel-thinking-budget)* — [decisions-branches/fix__census-panel-thinking-budget.md](decisions-branches/fix__census-panel-thinking-budget.md)
-- *... 4 more decisions ...*
+- **2026-07-17** — skill engine W1: drift detection, placement-map ground truth, §1.10.1 validator, six-kind taxonomy *(feat/skill-engine-w1-foundations)* — [decisions-branches/feat__skill-engine-w1-foundations.md](decisions-branches/feat__skill-engine-w1-foundations.md)
+- *... 5 more decisions ...*
 - **2026-07-16** — skill unification: three-layer design catalog — K0 splits/stubs/promotions, K1 dispatchers, K3 abstraction *(feat/skill-unification-k0-k1-k3)* — [decisions-branches/feat__skill-unification-k0-k1-k3.md](decisions-branches/feat__skill-unification-k0-k1-k3.md)
 
 ## 2026-06 (10 decisions)

--- a/skills/curating-a-skill-catalog/SKILL.md
+++ b/skills/curating-a-skill-catalog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: curating-a-skill-catalog
 description: |
-  Use when judging whether a skill earns its place — running or reviewing a skill census cycle, triaging gap:/placement:/revise:/promotion-candidate:/demotion-candidate: issues, deciding to deprecate or promote a skill, or auditing a skill catalog's health. Names the lifecycle state machine (incubating → active → needs-revision → deprecated → retired), the five verdict kinds with their evidence standards (Keep is silent — no issue; Demote needs zero citations across cycles AND no structural role, with L0-primitive grace; Revise needs a fought-usage or stale-source quote; Promote needs convergent evolution or a named consumer; Gap needs the concrete recurring case), the prosecutor/defender judgment frame, the top-5-plus-digest noise budget, and the human-editor gate (the census proposes; it never merges or demotes by itself). Cite when a census run files more than ~6 issues, when a demotion is proposed without usage evidence, or when a verdict issue lacks quoted grounds.
+  Use when judging whether a skill earns its place — running or reviewing a skill census cycle, triaging gap:/placement:/revise:/promotion-candidate:/demotion-candidate: issues, deciding to deprecate or promote a skill, or auditing a skill catalog's health. Names the lifecycle state machine (incubating → active → needs-revision → deprecated → retired), the six verdict kinds with their evidence standards (Keep is silent — no issue; Revise needs a fought-usage or stale-source quote; Demote needs zero citations across cycles AND no structural role, with L0-primitive grace; Promotion-candidate needs convergent evolution or a named consumer; Placement needs an applies_to profile or placement-map row naming the repo; Gap needs the concrete recurring case), the prosecutor/defender judgment frame, the top-5-plus-digest noise budget, and the human-editor gate (the census proposes; it never merges or demotes by itself). Cite when a census run files more than ~6 issues, when a demotion is proposed without usage evidence, or when a verdict issue lacks quoted grounds.
 ---
 
 # Curating a skill catalog
@@ -49,12 +49,17 @@ Demotion follows the catalog's own SemVer deprecation discipline, not an
 ad-hoc cut: **warn in a minor, remove in a major, notify subscribers**. See
 `semver-design-tokens` for the underlying warn/remove cycle this borrows.
 
-## The five verdict kinds
+## The six verdict kinds
 
 **Keep** — the silent default. No issue is filed. Sufficient grounds: none
 required — Keep is what happens when no other verdict clears its bar.
 Insufficient-to-overturn: a reviewer's hunch that "probably nobody uses this"
 with no citation data behind it stays Keep, it does not become Demote.
+
+**Revise** — a fought-usage or stale-source quote. Sufficient: a quoted
+review thread where an agent applied the skill's rule and got pushback, or a
+quoted dead link / superseded API in its Sources section. Insufficient: "this
+reads a bit dated" with nothing quoted.
 
 **Demote** — zero usage citations across multiple census cycles **and** no
 structural role (not named as `REQUIRED BACKGROUND` or a cross-reference
@@ -63,15 +68,15 @@ structurally rather than by usage. Sufficient: "zero citations across three
 consecutive cycles; not referenced by any other skill; not L0." Insufficient:
 "this feels redundant with X" with no citation count quoted.
 
-**Revise** — a fought-usage or stale-source quote. Sufficient: a quoted
-review thread where an agent applied the skill's rule and got pushback, or a
-quoted dead link / superseded API in its Sources section. Insufficient: "this
-reads a bit dated" with nothing quoted.
+**Promotion-candidate** — convergent evolution or a named consumer.
+Sufficient: two independent repos quoted arriving at the same pattern
+unprompted, or a named skill citing this one as `REQUIRED BACKGROUND`.
+Insufficient: "this seems important enough to promote" with no repo or
+consumer named.
 
-**Promote** — convergent evolution or a named consumer. Sufficient: two
-independent repos quoted arriving at the same pattern unprompted, or a named
-skill citing this one as `REQUIRED BACKGROUND`. Insufficient: "this seems
-important enough to promote" with no repo or consumer named.
+**Placement** — a skill belongs in a repo that doesn't subscribe (or vice
+versa). Sufficient: an applies_to profile or placement-map row naming the
+repo. Insufficient: "seems useful there."
 
 **Gap** — the concrete recurring case. Sufficient: three quoted PRs this cycle
 each hand-rolling the same missing pattern. Insufficient: "agents might want
@@ -85,6 +90,10 @@ amendment), not Gap. Only when no existing skill is the right home does it
 stay Gap — and the grounds must say why not. (Precedent: the dual-review gap
 that first had to check overlap with `orchestrating-elite-agent-qa` before
 forging.)
+
+Filed labels are symmetric candidates: a demote verdict files as
+`demotion-candidate`, a promotion verdict as `promotion-candidate`; the other
+kinds file under their own names.
 
 ## Prosecutor/defender judgment frame
 


### PR DESCRIPTION
Wave 1 of the complete-the-engine phase (P2/P3/P4/P5 foundations; P1 processor + fan-out follow in W2).

- **Drift detection** (`census_counters.py`): recomputes subscribed skills' hashes vs `skills-lock.json` pins — **source-scoped** to this catalog (foreign-catalog/sourceless pins bucketed, never compared) and gated behind a **per-skill lineage proof** so no drift can ever be asserted that isn't provable. Load-bearing discovery: the lock's `computedHash` algorithm is **external** (skills.sh CLI normalization — ~40 stdlib candidates × the full git history of two skills matched nothing), so status reports honestly `indeterminate` until that normalization is mirrored; the guard means flipping the algo constant alone can't mis-flag.
- **`docs/placement-map.json`** — committed ground truth (46 skills: authoring-home / distribution / subscribers), with a **real CI gate** in `validate-skills.yml` (schema + enums + exact key↔dir reconciliation) and census cross-checking (divergence → `placement` verdicts).
- **Validator to §17.1**: `validate-skills.yml` now enforces the §1.10.1 name regex + `kind`/`voice_scope`/`review_mode`/`source` enums + `applies_to` shapes, with unknown-key + RESERVED-key tolerance. Whole catalog passes (46/46). Extensions rule accepts suffix patterns (`_test.py`) — clud-bug suffix-matches.
- **Usage signal wired** (`usage[<slug>]` read cross-repo, sanitized, gracefully absent — no consumer emits it yet; clud-bug hand-off covers emission).
- **Six-kind taxonomy** reconciled in `curating-a-skill-catalog` (adds Placement, fixes Promotion-candidate, states the demote→demotion-candidate label mapping). Closes the #162 naming drift.

Build: 3-lane workflow (opus on the drift lane) + opus correctness refute (proved the false-drift attacks) + sonnet conventions pass + one fix batch with negative-control verification. All checks reproduced locally: validator 46/46, py_compile, selftest, placement-gate negative test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)