### PR TITLE
F2: docs truth pass — sRGB doctrine, dead catalog→clud-bug sync, census re-filing, four skills reconciled

### DIFF
--- a/.github/scripts/census_panel.py
+++ b/.github/scripts/census_panel.py
@@ -25,7 +25,13 @@ Inputs (env):
 
 Outputs (written to CENSUS_DIR):
   verdicts.json      On success — the sanitized, capped, prefix-enforced
-                     verdicts the workflow's bash step files as issues.
+                     verdicts the workflow's bash step files as issues. Each
+                     non-keep verdict carries a `census_key` field
+                     (`<kind>:<subject-slug>`, deterministic, no cycle tag) so
+                     the workflow can find and comment on the SAME canonical
+                     issue across cycles instead of re-filing an identical
+                     verdict under a new per-cycle title. See RULING 5 below
+                     `validate_and_build`.
   panel_failed.marker  On any API/validation failure — a reason string. The
                      workflow treats the panel as skipped (Mode B) on this.
 
@@ -67,6 +73,14 @@ RUBRIC_PATH = "skills/curating-a-skill-catalog/SKILL.md"  # cwd-relative (RULING
 DOCKET_BODY_LIMIT = 1500  # per-issue body truncation before it reaches the model
 BODY_CAP = 6000           # per-verdict body cap in the written verdicts.json
 MAX_NON_KEEP = 5          # hard cap on filable (non-keep) verdicts
+
+# RULING 5 (DEDUP-BY-KEY): a stable identifier per verdict, independent of the
+# cycle tag, so the same (kind, subject) recurring next week resolves to the
+# SAME key. The workflow's file-issues step searches open issues for this
+# marker before creating one; a match gets a comment, not a new issue. Caps
+# the subject-slug segment so the key stays a sane length for a `gh issue
+# list --search` query string.
+CENSUS_KEY_SUBJECT_MAX = 60
 
 KEEP_KIND = "keep"
 VALID_KINDS = frozenset(
@@ -553,6 +567,29 @@ def _defang(text: str) -> str:
     return text.replace("@", "@ ")
 
 
+def _slugify(text: str) -> str:
+    """Deterministic lowercase-kebab slug for the subject segment of a
+    census_key. No randomness, no cycle/date component: the same input text
+    always yields the same slug, which is the whole point — it's what lets
+    the same verdict recur across cycles under one stable key instead of a
+    fresh one every time. Never raises; an empty/unslugabble input yields
+    "untitled" rather than an empty or malformed key segment."""
+    text = text.strip().lower()
+    text = re.sub(r"[`'\"]", "", text)      # drop quote/backtick noise
+    text = re.sub(r"[^a-z0-9]+", "-", text)  # non-alnum runs -> single hyphen
+    text = text.strip("-")
+    if len(text) > CENSUS_KEY_SUBJECT_MAX:
+        text = text[:CENSUS_KEY_SUBJECT_MAX].rstrip("-")
+    return text or "untitled"
+
+
+def _census_key(kind: str, subject: str) -> str:
+    """`<kind>:<subject-slug>` — the stable cross-cycle identifier for a
+    verdict (RULING 5). `kind` is used verbatim (already one of VALID_KINDS
+    by the time this is called); only the subject is slugged."""
+    return f"{kind}:{_slugify(subject)}"
+
+
 def _sanitize_body(value: object) -> str:
     """Defang @-mentions, then cap at BODY_CAP characters (final length <= cap)."""
     text = value if isinstance(value, str) else ("" if value is None else str(value))
@@ -590,7 +627,15 @@ def validate_and_build(
     `revise` targeting `amend_target` — but only if `amend_target` names a real
     catalog skill; otherwise the verdict is dropped with a printed warning. A
     "new-skill" (or undisposed) gap is left as-is: whether its `grounds` records
-    a comparison is the model's job, not this validator's — we don't over-police."""
+    a comparison is the model's job, not this validator's — we don't over-police.
+
+    RULING 5 (DEDUP-BY-KEY): every non-keep verdict also gets a `census_key`
+    (`<kind>:<subject-slug>`, see `_census_key`/`_slugify`) computed from the
+    FINAL kind/subject — i.e. after the RULING-4 amend rewrite, so an
+    amend-disposed gap keys off its rewritten `revise` + `amend_target`, not
+    its original `gap` + free-text subject. The workflow's file-issues step
+    searches open issues for this marker before filing; a hit gets a comment
+    instead of a new issue, which is the whole point — see skill-census.yml."""
     data = _parse_json(response_text)
     if not isinstance(data, dict):
         raise PanelValidationError("model output is not a JSON object")
@@ -656,6 +701,13 @@ def validate_and_build(
             {
                 "kind": kind,
                 "subject": subject,
+                # RULING 5: computed AFTER the amend-vs-forge rewrite above, so
+                # a `gap` disposed "amend" keys off its rewritten `revise` kind
+                # and the amend_target subject — the same underlying skill
+                # gets the same key regardless of which cycle first proposed
+                # amending it. No cycle tag: same (kind, subject) next week
+                # produces the identical string.
+                "census_key": _census_key(kind, subject),
                 "grounds": grounds,
                 "confidence": confidence,
                 "title": _enforce_title(kind, cycle_slug, verdict.get("title"), subject),

--- a/.github/workflows/notify-clud-bug.yml
+++ b/.github/workflows/notify-clud-bug.yml
@@ -2,8 +2,8 @@ name: sync skill to clud-bug
 
 # Open a PR on thrillmade/clud-bug refreshing one bundled baseline SKILL.md
 # from the current state of this repo, plus the BASELINE_SKILLS_REF pin in
-# lib/skills.js, plus a patch version bump and CHANGELOG entry. Replaces the
-# v0.x workflow that opened an issue with "you should update X" instructions
+# src/cli/skills.ts, plus a patch version bump and CHANGELOG entry. Replaces
+# the v0.x workflow that opened an issue with "you should update X" instructions
 # the maintainer then applied by hand — the PR shape applies them directly.
 #
 # Triggers:
@@ -164,6 +164,25 @@ jobs:
           # Surfaces the scope mismatch loudly before we try to mutate the repo.
           gh api repos/thrillmade/clud-bug --jq '.full_name' > /dev/null
 
+      - name: Verify BASELINE_SKILLS_REF target exists
+        # Fail loud, not silent-no-op: clud-bug's v0.7.0 TS migration moved this
+        # constant from lib/skills.js (deleted) to src/cli/skills.ts. If clud-bug
+        # ever relocates or reshapes the declaration again, `set -euo pipefail`
+        # alone won't catch a sed that silently matches zero lines — this step
+        # names exactly what it looked for before the sync step below relies on it.
+        working-directory: clud-bug
+        run: |
+          set -euo pipefail
+          TARGET="src/cli/skills.ts"
+          if [ ! -f "$TARGET" ]; then
+            echo "::error::${TARGET} not found in thrillmade/clud-bug — BASELINE_SKILLS_REF may have moved again since the v0.7.0 TS migration. Update the target path in notify-clud-bug.yml (search clud-bug's repo for 'BASELINE_SKILLS_REF' to find its new home)."
+            exit 1
+          fi
+          if ! grep -qE "^const BASELINE_SKILLS_REF = '[a-f0-9]{40}';" "$TARGET"; then
+            echo "::error::No line matching \`const BASELINE_SKILLS_REF = '<40-hex-sha>';\` found in ${TARGET} — the constant's declaration shape changed, so the sed in the sync step would silently no-op. Update the regex (or the target path) in notify-clud-bug.yml."
+            exit 1
+          fi
+
       - name: Short-circuit if PR already open for this branch
         id: existing
         working-directory: clud-bug
@@ -208,15 +227,17 @@ jobs:
           # 1. Copy source SKILL.md into bundled location.
           cp "../skills/${SKILL}/SKILL.md" "templates/skills/baseline/${SKILL}.md"
 
-          # 2. Bump BASELINE_SKILLS_REF in lib/skills.js. The constant is
-          #    declared as a single line:
+          # 2. Bump BASELINE_SKILLS_REF in src/cli/skills.ts (moved here from
+          #    the now-deleted lib/skills.js in clud-bug's v0.7.0 TS migration —
+          #    see the "Verify BASELINE_SKILLS_REF target exists" guard above).
+          #    The constant is declared as a single line:
           #      const BASELINE_SKILLS_REF = '<40-hex-sha>';
           #    Verify after sed that the new SHA actually landed — if the
           #    declaration shape ever changes the regex would silently no-op.
-          sed -i.bak -E "s|^(const BASELINE_SKILLS_REF = ')[a-f0-9]{40}(';.*)$|\1${SHA}\2|" lib/skills.js
-          rm lib/skills.js.bak
-          if ! grep -q "BASELINE_SKILLS_REF = '${SHA}'" lib/skills.js; then
-            echo "::error::BASELINE_SKILLS_REF sed did not produce the expected line — check the constant declaration shape in lib/skills.js."
+          sed -i.bak -E "s|^(const BASELINE_SKILLS_REF = ')[a-f0-9]{40}(';.*)$|\1${SHA}\2|" src/cli/skills.ts
+          rm src/cli/skills.ts.bak
+          if ! grep -q "BASELINE_SKILLS_REF = '${SHA}'" src/cli/skills.ts; then
+            echo "::error::BASELINE_SKILLS_REF sed did not produce the expected line — check the constant declaration shape in src/cli/skills.ts."
             exit 1
           fi
 
@@ -237,7 +258,7 @@ jobs:
 
           ### Changed
 
-          - **Bundled \`${SKILL}\` SKILL.md refreshed** from \`thrillmade/agent-skills@${SHORT}\`. \`BASELINE_SKILLS_REF\` in \`lib/skills.js\` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by \`agent-skills/.github/workflows/notify-clud-bug.yml\`.
+          - **Bundled \`${SKILL}\` SKILL.md refreshed** from \`thrillmade/agent-skills@${SHORT}\`. \`BASELINE_SKILLS_REF\` in \`src/cli/skills.ts\` pinned to the same commit so the install-time fetch path and the bundled offline-fallback path resolve to byte-identical content. Auto-synced by \`agent-skills/.github/workflows/notify-clud-bug.yml\`.
 
           EOF
           # awk inserts the entry on the line after the [Unreleased] header.
@@ -291,7 +312,7 @@ jobs:
           ## Changes applied
 
           - \`templates/skills/baseline/${SKILL}.md\` ← byte-for-byte copy of the source above.
-          - \`lib/skills.js\` — \`BASELINE_SKILLS_REF\` bumped to \`${SHA}\` so the install-time fetch from \`thrillmade/agent-skills\` and the bundled offline-fallback both resolve to identical content.
+          - \`src/cli/skills.ts\` — \`BASELINE_SKILLS_REF\` bumped to \`${SHA}\` so the install-time fetch from \`thrillmade/agent-skills\` and the bundled offline-fallback both resolve to identical content.
           - \`package.json\` — patch version bump to \`${new_version}\`.
           - \`CHANGELOG.md\` — entry under [Unreleased] documenting the refresh.
 

--- a/.github/workflows/skill-census.yml
+++ b/.github/workflows/skill-census.yml
@@ -267,8 +267,15 @@ jobs:
             exit 0
           fi
 
-          # Verdict issues: hard-cap at 5 (head -5 semantics), exact-title
-          # idempotency, bodies via --body-file.
+          # Verdict issues: hard-cap at 5 (head -5 semantics), bodies via
+          # --body-file. Dedup is by `census_key` (a stable `<kind>:<subject-
+          # slug>` marker the panel computes deterministically — same subject
+          # next cycle produces the same key, no cycle tag in it) — NOT by
+          # title, which changes every cycle and was re-filing the identical
+          # verdict as a fresh issue three cycles running. A census_key match
+          # gets THIS cycle's reasoning as a comment on the existing canonical
+          # issue; only a miss creates a new one, and the new body embeds the
+          # marker so next cycle's search finds it in turn.
           FILE_N=$VERDICT_COUNT
           if [ "$FILE_N" -gt "$MAX_VERDICTS" ]; then
             FILE_N=$MAX_VERDICTS
@@ -283,8 +290,19 @@ jobs:
               continue
             fi
 
+            V_KEY=$(jq -r ".verdicts[$i].census_key // \"\"" "$VERDICTS_FILE")
+            if [ -z "$V_KEY" ]; then
+              echo "::warning::verdict '${V_TITLE}' has no census_key — falling back to exact-title dedup only, so an identical verdict may re-file next cycle under a new title."
+            fi
+
             V_BODY_FILE="$(mktemp)"
             jq -r ".verdicts[$i].body // \"\"" "$VERDICTS_FILE" > "$V_BODY_FILE"
+            if [ -n "$V_KEY" ]; then
+              {
+                echo ""
+                echo "<!-- census-key: ${V_KEY} -->"
+              } >> "$V_BODY_FILE"
+            fi
 
             # Labels: always census; add each declared label if it is allowed.
             LABEL_ARGS=(--label census)
@@ -298,6 +316,38 @@ jobs:
               esac
             done < <(jq -r ".verdicts[$i].labels // [] | .[]" "$VERDICTS_FILE")
 
+            # Primary lookup: an open issue already carrying this census_key,
+            # anywhere in its body OR its comments. `in:body` alone would miss
+            # the catalog's first four canonical issues, seeded with the
+            # marker as a comment rather than in the body — search both so
+            # dedup works for those as well as for every issue this workflow
+            # creates from here on (which embeds the marker in the body).
+            KEY_MATCH=""
+            if [ -n "$V_KEY" ]; then
+              KEY_MATCH=$(gh issue list --state open \
+                --search "\"<!-- census-key: ${V_KEY} -->\" in:body,comments" \
+                --json number 2>/dev/null | jq -r '.[0].number // empty') || KEY_MATCH=""
+            fi
+
+            if [ -n "$KEY_MATCH" ]; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "=== DRY-RUN: verdict $((i + 1))/${FILE_N} ==="
+                echo "Would COMMENT on existing canonical issue #${KEY_MATCH} (census_key=${V_KEY}) instead of filing a new one:"
+                echo "----- body -----"
+                cat "$V_BODY_FILE"
+                echo "----- end body -----"
+              else
+                gh issue comment "$KEY_MATCH" --body-file "$V_BODY_FILE"
+                echo "::notice::census_key=${V_KEY} already tracked as #${KEY_MATCH} — commented this cycle's reasoning instead of re-filing."
+              fi
+              rm -f "$V_BODY_FILE"
+              i=$((i + 1))
+              continue
+            fi
+
+            # Fallback: no census_key (or no match) — exact-title dedup, same
+            # as before, so a verdict never double-files within one title's
+            # lifetime even without a usable key.
             EXISTS=$(gh issue list --state open --search "${V_TITLE} in:title" \
               --json number,title 2>/dev/null \
               | jq -r --arg t "$V_TITLE" 'map(select(.title == $t)) | .[0].number // empty') || EXISTS=""
@@ -307,7 +357,7 @@ jobs:
               if [ -n "$EXISTS" ]; then
                 echo "Would SKIP (already open as #${EXISTS}): ${V_TITLE}"
               else
-                echo "Would CREATE '${V_TITLE}' (labels: ${LABEL_ARGS[*]}):"
+                echo "Would CREATE '${V_TITLE}' (labels: ${LABEL_ARGS[*]}, census_key=${V_KEY:-<none>}):"
                 echo "----- body -----"
                 cat "$V_BODY_FILE"
                 echo "----- end body -----"

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The short version — every repo holds each skill in one of three postures:
 - **Published** — born in your repo, nominated here by PR. The editor gate (validate-skills CI, `skill-frontmatter-quality`, strict-mode review, human approval) accepts or rejects — nomination ≠ publication.
 - **Local** — repo-specific, never syncs.
 
-New repo: `npx skdd init` (logmind + clud-bug + baselines), subscribe to what you need, **commit your manifests**, apply the reporulez ruleset. Existing repo: run the census checklist in the guide (register untracked skills, commit your lock, classify local vs promotion-worthy). A weekly editorial cycle audits placement, gaps, and staleness org-wide and files its verdicts as issues here; steward-run automation for onboarding and fan-out is the roadmap (protocol#39).
+New repo, today: `brew install thrillmade/tap/logmind && logmind init` + `npx clud-bug init` (baselines), subscribe to what you need, **commit your manifests**, apply the reporulez ruleset. (`npx skdd init` — one command bundling all of this — is the umbrella installer being built; it isn't available yet.) Existing repo: run the census checklist in the guide (register untracked skills, commit your lock, classify local vs promotion-worthy). A weekly editorial cycle already audits placement, gaps, and staleness org-wide and files its verdicts as issues here; steward-run auto-onboarding and catalog fan-out are the roadmap (protocol#39).
 
 ## Install
 

--- a/docs/decisions-branches/feat__f2-docs-truth-pass.md
+++ b/docs/decisions-branches/feat__f2-docs-truth-pass.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-25 15:42 - F2 docs truth pass: correct the sRGB doctrine, repair the dead catalog→clud-bug sync, make the census comment instead of re-filing, and reconcile four skills against current source
+
+**Reasoning:** Three load-bearing docs described behavior that does not exist: notify-clud-bug.yml sed'd lib/skills.js (deleted in clud-bug's v0.7.0 TS migration, so the advertised auto-sync hard-failed on every run), the onboarding guide opened with npx skdd init (skdd has no implementation), and chroma-harmonization + oklch-color-space taught an sRGB-default that agent-skills#170's locked ruling bans from computation. The census had also re-filed identical verdicts for three consecutive cycles because nothing gave a verdict a stable identity.
+
+**Alternatives considered:** Re-pull each skill from its authoring home instead of reconciling. Rejected after verification: the catalog logmind skill's 'retired' surfaces (skill audit, skill suggest, LOGMIND_QUIET, the merge driver) are all live on origin/main — a re-pull would have deleted four working surfaces to remove one dead one (skill bench, which turned out to still be live too). Also rejected: trimming skills/logmind/SKILL.md to a 250-line budget that nothing in CI enforces.
+
+**Implications:**
+- The catalog→clud-bug sync now targets src/cli/skills.ts and fails loudly on a path-miss rather than silently. Census verdicts carry a stable census-key and comment on the live issue instead of duplicating it — the search must be in:body,comments, since the four canonical seeds carry their marker in a comment. Three review rounds were needed: builders introduced two HIGH defects the adversarial pass caught, and the fix round introduced a third (skill push listed under a blanket 'never auto-PR' claim while skill_push.go opens a real PR with no confirmation). Five facts in the original brief were false and the builders refused all five; two came from reading a stale local branch. skills/logmind/SKILL.md is deliberately left at 267 lines against a catalog median of 81 — splitting it is a catalog decision for the census, not a trim.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -7,7 +7,6 @@ agent-skills
 ├── .claude
 │   ├── commands
 │   ├── skills
-│   ├── scheduled_tasks.lock
 │   └── settings.json
 ├── .github
 │   ├── ISSUE_TEMPLATE

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -7,6 +7,7 @@ agent-skills
 ├── .claude
 │   ├── commands
 │   ├── skills
+│   ├── scheduled_tasks.lock
 │   └── settings.json
 ├── .github
 │   ├── ISSUE_TEMPLATE

--- a/docs/integrating-with-agent-skills.md
+++ b/docs/integrating-with-agent-skills.md
@@ -19,13 +19,23 @@ Two rules make the system trustworthy:
 
 ## New repo setup — today
 
-Until the steward automates onboarding (see roadmap below), a new repo wires in with four steps:
+`npx skdd init` — a single command bundling toolchain + rulesets +
+subscriptions into one onboarding step — is the umbrella installer **being
+built** (see [thrillmade/skdd](https://github.com/thrillmade/skdd)); it
+is not available yet, and no repo should be told to run it. Until it
+ships, a new repo wires in with the commands that actually work today:
 
 ```bash
-# 1. Toolchain: logmind (decision logging) + clud-bug (skill-driven review).
-#    Installs the 4 baseline review skills into .claude/skills/ and writes
-#    .claude/skills/.clud-bug.json. Add --with-design for the design-critic lenses.
-npx skdd init
+# 1. logmind (decision logging) — separate install, not yet bundled:
+brew install thrillmade/tap/logmind   # or: curl -fsSL https://logmind.dev/install.sh | bash
+logmind init
+
+#    clud-bug (skill-driven review) — installs the 4 baseline review
+#    skills into .claude/skills/ and writes .claude/skills/.clud-bug.json.
+#    Add --with-design for the design-critic lenses (installs the kit and
+#    flips it to enabled — still needs a browser MCP + allowedTools wired
+#    into your review workflow to actually run).
+npx clud-bug init
 
 # 2. Subscribe to the catalog skills this repo needs (per-skill opt-in):
 npx skills add https://github.com/thrillmade/agent-skills --skill logmind
@@ -35,9 +45,13 @@ npx skills add https://github.com/thrillmade/agent-skills --skill brand-voice-re
 # 3. Commit the manifests (skills-lock.json + .clud-bug.json). Do not gitignore them.
 
 # 4. Org rules: apply the reporulez ruleset so the review gate is enforced.
-#    Use the `skdd` variant when the clud-bug review check has a producer
-#    (hosted App or Action); use the `external` variant when it does not —
+#    Use the `clud-bug` variant when only the clud-bug-review check needs to
+#    gate merges; use the `skdd` variant (the canonical thrillmade-toolchain
+#    ruleset — clud-bug + logmind + protocol checks) for repos running the
+#    full toolchain; use `baseline` when no producer needs gating at all —
 #    per protocol SPEC §7, never require a check nothing produces.
+#    (`external` is a deprecated alias for `baseline` — reporulez's own
+#    README says so; use `baseline`.)
 ```
 
 Then point agents at the system: `AGENTS.md` should name logmind (decision logging is REQUIRED for substantive commits) and clud-bug (see the `clud-bug-collaboration` skill), the same shape as this repo's own `AGENTS.md`.
@@ -54,12 +68,16 @@ Then point agents at the system: `AGENTS.md` should name logmind (decision loggi
 - **Release → catalog sync** — logmind's release workflow PRs its skill update here (the `repo-mirrored` authoring pattern).
 - **The review gate** — strict-mode clud-bug review + `validate-skills.yml` on every PR touching `skills/`.
 
+**Shipped:**
+
+- **The registration manifest** — any org registers its own `skdd-steward` App instance from [skdd/docs/skdd-steward-app.md](https://github.com/thrillmade/skdd/blob/main/docs/skdd-steward-app.md); there is no shared, hosted steward, every adopting org runs its own.
+- **The weekly editorial cycle** (skill census) runs today: [`skill-census.yml`](../.github/workflows/skill-census.yml) mints the steward App's installation token to read every subscribed repo's manifests + clud-bug's skill-usage data cross-org, an adversarial panel judges, and verdicts land as `gap:` / `placement:` / `promotion-candidate:` / `demotion-candidate:` / `revise:` issues here (top ~5 + digest, weekly). Humans decide; the steward merges nothing.
+
 **Steward roadmap** (post-Marketplace-launch, per the locked sequencing in [protocol#8](https://github.com/thrillmade/protocol/issues/8); contracts in [protocol#39](https://github.com/thrillmade/protocol/issues/39)):
 
-- The `thrillmade-orchestrator` App renames to **`skdd-steward`** and publishes a registration manifest so any org can run its own instance.
+- **thrillmade's own App instance finishing its rename**: the manifest above targets the `skdd-steward` identity for new adopters, but this repo's own workflows still mint from the legacy `THRILLMADE_ORCHESTRATOR_APP_ID` / `THRILLMADE_ORCHESTRATOR_PRIVATE_KEY` secrets and post census issues under `github-actions[bot]` rather than the App's own identity (pending the App being granted Issues R/W) — the cutover for thrillmade's own instance isn't complete yet, even though the manifest and the weekly cycle both already work.
 - **Auto-onboarding:** `skdd init` grows the full-magic bundle — toolchain + rulesets + subscriptions + guided App registration + an offer to scaffold an org-local skill reservoir.
-- **Skill fan-out:** a catalog change opens refresh PRs on every subscribed repo under `skdd-steward[bot]`, replacing per-repo crons with one org-wide watcher.
-- **The weekly editorial cycle** (skill census) runs under the steward: counters read every repo's manifests + clud-bug's skill-usage data → an adversarial panel judges → verdicts land as `gap:` / `placement:` / `promotion-candidate:` / `demotion-candidate:` / `revise:` issues here (top ~5 + digest). Humans decide; the steward merges nothing.
+- **Skill fan-out:** a catalog change opens refresh PRs on every subscribed repo under the steward's identity, replacing per-repo crons with one org-wide watcher.
 - **Invokes, never bypasses:** steward changes are always PRs, always clud-bug-reviewed, always gated by reporulez rulesets, always logged per logmind conventions.
 
 ## Existing repo — adjustment checklist
@@ -107,4 +125,4 @@ When the catalog supersedes a skill (e.g. `design-token-naming` → `token-namin
 
 ## Questions this guide will absorb answers to
 
-Authoring-home ruling for the promoted design lenses ([clud-bug#235](https://github.com/thrillmade/clud-bug/issues/235)); the steward service contract and census cadence details (protocol#39); the org-reservoir template for consumer orgs (skdd roadmap). When those land, this section shrinks.
+The authoring-home ruling for the promoted design lenses landed ([clud-bug#243](https://github.com/thrillmade/clud-bug/issues/243) Ruling 2: `catalog`, per [`docs/placement-map.json`](placement-map.json)). Still open: the steward service contract and census cadence details (protocol#39); the org-reservoir template for consumer orgs (skdd roadmap). When those land, this section shrinks further.

--- a/docs/placement-map.json
+++ b/docs/placement-map.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-07-17",
+  "updated": "2026-07-25",
   "skills": {
     "critical-issues-only": {
       "authoring_home": "catalog",
@@ -34,28 +34,28 @@
       "subscribers": ["tokenomics"]
     },
     "designing-elite-ui": {
-      "authoring_home": "undecided",
+      "authoring_home": "catalog",
       "distribution": "opt-in",
       "subscribers": [],
-      "notes": "authoring-home ruling pending clud-bug#235; currently authored in clud-bug/templates/skills/design/, promotion in flight"
+      "notes": "authoring-home decided (clud-bug#243 Ruling 2): catalog is the edit point; clud-bug's templates/skills/design/ is a vendored mirror refreshed only by an explicit release PR, never by automation"
     },
     "design-system-consistency": {
-      "authoring_home": "undecided",
+      "authoring_home": "catalog",
       "distribution": "opt-in",
       "subscribers": [],
-      "notes": "authoring-home ruling pending clud-bug#235; currently authored in clud-bug/templates/skills/design/, promotion in flight"
+      "notes": "authoring-home decided (clud-bug#243 Ruling 2): catalog is the edit point; clud-bug's templates/skills/design/ is a vendored mirror refreshed only by an explicit release PR, never by automation"
     },
     "frontend-a11y": {
-      "authoring_home": "undecided",
+      "authoring_home": "catalog",
       "distribution": "opt-in",
       "subscribers": [],
-      "notes": "authoring-home ruling pending clud-bug#235; currently authored in clud-bug/templates/skills/design/, promotion in flight"
+      "notes": "authoring-home decided (clud-bug#243 Ruling 2): catalog is the edit point; clud-bug's templates/skills/design/ is a vendored mirror refreshed only by an explicit release PR, never by automation"
     },
     "visual-polish": {
-      "authoring_home": "undecided",
+      "authoring_home": "catalog",
       "distribution": "opt-in",
       "subscribers": [],
-      "notes": "authoring-home ruling pending clud-bug#235; currently authored in clud-bug/templates/skills/design/, promotion in flight"
+      "notes": "authoring-home decided (clud-bug#243 Ruling 2): catalog is the edit point; clud-bug's templates/skills/design/ is a vendored mirror refreshed only by an explicit release PR, never by automation"
     },
     "orchestrating-elite-agent-qa": {
       "authoring_home": "catalog",

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (7 decisions)
+## 2026-07 (8 decisions)
 
-- **2026-07-17** — skill engine W1: drift detection, placement-map ground truth, §1.10.1 validator, six-kind taxonomy *(feat/skill-engine-w1-foundations)* — [decisions-branches/feat__skill-engine-w1-foundations.md](decisions-branches/feat__skill-engine-w1-foundations.md)
-- *... 5 more decisions ...*
+- **2026-07-25** — F2 docs truth pass: correct the sRGB doctrine, repair the dead catalog→clud-bug sync, make the census comment instead of re-filing, and reconcile four skills against current source *(feat/f2-docs-truth-pass)* — [decisions-branches/feat__f2-docs-truth-pass.md](decisions-branches/feat__f2-docs-truth-pass.md)
+- *... 6 more decisions ...*
 - **2026-07-16** — skill unification: three-layer design catalog — K0 splits/stubs/promotions, K1 dispatchers, K3 abstraction *(feat/skill-unification-k0-k1-k3)* — [decisions-branches/feat__skill-unification-k0-k1-k3.md](decisions-branches/feat__skill-unification-k0-k1-k3.md)
 
 ## 2026-06 (10 decisions)

--- a/skills/chroma-harmonization/SKILL.md
+++ b/skills/chroma-harmonization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chroma-harmonization
-description: Use when constructing or auditing a multi-hue palette where all hues should appear equally saturated at each contrast stop. Names the per-stop chroma cap rule (take the minimum achievable chroma across hues at the stop), the sRGB-gamut bottleneck pattern (blue at mid-L is usually the limiter), and the relationship to UDTS's default `harmony` palette variant. Generalizes Evil Martians' Harmony algorithm.
+description: Use when constructing or auditing a multi-hue palette where all hues should appear equally saturated at each contrast stop. Names the per-stop chroma cap rule (take the minimum achievable chroma across hues at the stop), the gamut bottleneck pattern (blue at mid-L is the classic limiter in sRGB; Display P3 — UDTS's default compose gamut — reshapes it), and the relationship to UDTS's default `harmony` palette variant. Generalizes Evil Martians' Harmony algorithm.
 ---
 
 # Chroma harmonization
@@ -18,13 +18,13 @@ Multi-hue palettes look unbalanced when one hue is more saturated than the rest 
 
 - Single-hue palettes (no other hues to harmonize against — chroma is unconstrained by the procedure).
 - Brand-spot or accent palettes where one hue *should* dominate. Use the `max` palette variant instead — see `oklch-color-space`.
-- Palettes designed for Display P3 only where the wider gamut changes the bottleneck calculus (the procedure still applies, just with P3 boundaries).
+- Palettes constrained to legacy sRGB-only output, where the narrower gamut shifts the bottleneck calculus back toward the classic blue-at-~220° limiter (the procedure still applies — Display P3 is the default target space; substitute the sRGB boundary deliberately for legacy-only catalogs).
 
 ## The algorithm
 
 For each contrast stop in the palette (each L value):
 
-1. For each hue in the set, find the maximum in-gamut chroma at that (L, H) in the target color space (sRGB by default; figma-p3 for wider gamut).
+1. For each hue in the set, find the maximum in-gamut chroma at that (L, H) in the target color space (**Display P3 by default** — UDTS composes end-to-end in P3 via apcach's `colorSpace: 'p3'`; sRGB only when a catalog is deliberately constrained to legacy-only output).
 2. Take the **minimum** of those per-hue maxima. This is the stop's chroma ceiling.
 3. Emit every hue at the stop using that ceiling.
 
@@ -36,7 +36,7 @@ for each stop L:
     emit oklch(L, c_ceiling, h)
 ```
 
-The bottleneck pattern: at moderate lightness (L ≈ 0.5), **blue (~220°)** is usually the limiter in sRGB — its gamut is narrowest there. At the extremes (L near 0 or 1) the gamut shrinks for all hues, so the ceiling collapses naturally.
+The bottleneck pattern: at moderate lightness (L ≈ 0.5), **blue (~220°)** is the classic limiter in sRGB — its gamut is narrowest there. In Display P3 (the default compose gamut) the boundary is wider and reshaped, so blue is not guaranteed to be the tightest hue — treat the bottleneck as empirical per palette rather than assuming ~220° holds. At the extremes (L near 0 or 1) the gamut shrinks for all hues in either space, so the ceiling collapses naturally.
 
 ## Why the *minimum*, not the average
 
@@ -44,7 +44,7 @@ Average would push half the hues out of gamut at the bottleneck. Maximum would p
 
 ## Headroom rule
 
-Stay ≥ 10% below the computed ceiling. Rounding from OKLCH to hex, downstream conversions (P3 → sRGB at consumption), and display-driver quirks can push a borderline-in-gamut value out of gamut. A headroom margin prevents those failures.
+Stay ≥ 10% below the computed ceiling. This headroom is for the **emission edge**, not the harmonization math itself: rounding when materializing the sRGB hex fallback (the compatibility export for legacy consumers — see `oklch-color-space`) and display-driver quirks can push a borderline-in-gamut P3 value out of gamut once flattened to 8-bit sRGB. A headroom margin prevents those fallback-materialization failures; it does not change the P3-native chroma math above.
 
 ## Relationship to UDTS palette variants
 
@@ -62,7 +62,7 @@ After harmonizing a stop:
 
 1. **Gamut check:** every emitted `oklch(L, c_ceiling, h)` is `displayable()` in the target color space.
 2. **Visual check:** at the same stop, all hues should report identical (or near-identical) saturation in a side-by-side swatch. Use [oklch.com](https://oklch.com) or a culori-based tool.
-3. **Headroom check:** the actual ceiling sits ≥ 10% below the computed sRGB-gamut maximum at every (L, H) in the set.
+3. **Headroom check:** the actual ceiling sits ≥ 10% below the computed **Display P3**-gamut maximum at every (L, H) in the set (verify the sRGB-fallback headroom separately, at emission).
 
 If any hue clips at the ceiling or visually "pops," recompute with a tighter chroma cap.
 

--- a/skills/clud-bug-collaboration/SKILL.md
+++ b/skills/clud-bug-collaboration/SKILL.md
@@ -72,6 +72,23 @@ When you write a custom skill, follow the SKILL.md frontmatter format
 Generic advice gets ignored; rules with examples and quoted-line evidence
 move the bot's behavior.
 
+### Example: a good custom skill
+
+Don't write generic prose like "be careful with database code" — not
+actionable. Anchor to specific files + behaviors: name the exact path
+(e.g. `lib/db/queries.ts`), the exact pattern to flag, and what to quote.
+
+```ts
+// BAD — flag: string-interpolated SQL
+db.query(`SELECT * FROM users WHERE id = ${userId}`)
+// GOOD — parameterized
+db.query('SELECT * FROM users WHERE id = ?', [userId])
+```
+
+Pair each rule with a bad/good snippet like this. A generic warning gets
+ignored; a rule anchored to a real path and pattern moves the bot's
+review behavior.
+
 ## When you edit `.github/workflows/clud-bug-*.yml`
 
 `anthropics/claude-code-action` **refuses to run on PRs that modify its
@@ -154,7 +171,7 @@ CLUD_BUG_QUIET=1 clud-bug add evidence-based-review
 # → ok added: .claude/skills/evidence-based-review/SKILL.md
 ```
 
-## Why reviews are cheap (cost-control wiring, v0.6.3–v0.6.11)
+## Why reviews are cheap (cost-control wiring)
 
 The bot is engineered for token frugality, several layers deep:
 
@@ -164,17 +181,33 @@ The bot is engineered for token frugality, several layers deep:
   window. The first review in a fresh window writes the cache (1.25×); the
   next ones in that window read at 10%. Visible via `cache_read_input_tokens`
   in the run's result JSON (`show_full_output: true`).
-- **Per-section byte budgets** (v0.6.4): `MAX_DIFF_BYTES=80000`,
-  `MAX_COMMENT_BYTES=20000`, `MAX_SKILL_BYTES=4000`. Caps the PR diff /
-  prior-comment / skill-content section that the bot ingests on each run.
-  When a section hits its cap, an explicit truncation marker appears and
-  the bot is instructed to request the omitted hunks if relevant.
-- **`MAX_THINKING_TOKENS=8000`** + **`--max-turns 15`** (v0.6.8): thinking
-  budget + agentic-loop ceiling. Stops runaway turn-storms.
-- **Model pin** (v0.6.11): clud-bug-review now runs on
-  `claude-sonnet-4-6`, not Opus. Per Anthropic docs: "Sonnet handles most
-  coding tasks well and costs less than Opus." ~80% per-token reduction vs
-  Opus 4.7 default.
+- **Per-section byte budgets**: `MAX_COMMENT_BYTES=20000`,
+  `MAX_SKILL_BYTES=4000`, and **`MAX_DIFF_BYTES=5000000`** (bumped from an
+  original 80000 by a 2026-06-08 directive — the old 80KB default silently
+  truncated any real-world PR diff over that size, producing half-reviews;
+  5MB is far above a realistic single-PR diff but bounded enough that the
+  runner doesn't OOM). Caps the PR diff / prior-comment / skill-content
+  section the bot ingests per run; when a section hits its cap, an explicit
+  truncation marker appears and the bot is told to request the omitted
+  hunks if relevant.
+- **`MAX_THINKING_TOKENS=8000`** (v0.6.8) caps the extended-thinking budget
+  per turn.
+- **Two independent fast paths — don't conflate them**:
+  - **Workflow-only PRs** (clud-bug-update's own output: a workflow file
+    plus an allowlist like `AGENTS.md` / the baseline skills) skip review
+    entirely. The classify step emits `model=$MODEL` then `exit 0` —
+    **no `max_turns` is emitted at all** — and the review job itself is
+    gated `if: needs.paths-check.outputs.is_workflow_only != 'true'`, so
+    it never runs.
+  - **Trivial PRs** (dependency-bump bot authors, or a <2KB diff touching
+    only dependency-manifest files) get a flat `max-turns=10` and route
+    to Haiku 4.5 (`claude-haiku-4-5-20251001`, pinned in the template) —
+    roughly a third of Sonnet's per-input-token cost.
+  - **Everything else**: a pre-flight classify step estimates turns from
+    PR size (files/lines/prior threads) and sets `max(estimated × 1.2,
+    15)`, capped at 60, on the default `claude-sonnet-4-6` (not Opus —
+    per Anthropic docs, "Sonnet handles most coding tasks well and costs
+    less than Opus").
 - **Incremental-diff on fix-push** (v0.6.10): on a re-review, the bot reads
   only the delta since its prior pass (`git diff <prior_sha>..HEAD`),
   identified via a `<!-- last-reviewed-sha: <sha> -->` HTML marker in the

--- a/skills/logmind/SKILL.md
+++ b/skills/logmind/SKILL.md
@@ -43,184 +43,88 @@ logmind log "Use PostgreSQL for primary database" \
   -i "Schema migrations needed"
 ```
 
-## What `logmind log` does automatically
+## `logmind log` IS the commit primitive — no manual git after it
 
-A single `logmind log` invocation is the complete `git add` + `git commit` +
-`git push` primitive — you do NOT need to follow up with any manual git
-command, and you do NOT need to run `logmind timeline --write` separately:
+A single invocation replaces `git add` + `git commit` + `git push`:
 
-1. **(v0.6.1+, opt-in) Auto-rebase** — if `git.auto_rebase: true` is set in
-   `.logmind/config.yml`, runs `maybe_auto_rebase()` BEFORE any local state
-   changes. See [Deterministic auto-rebase](#deterministic-auto-rebase-v061-opt-in) below.
-2. Appends the decision entry to the active log file (default branch →
-   `docs/decisions.md`; feature branch → `docs/decisions-branches/<branch>.md`).
-3. Archives the oldest decision if `decisions.md` exceeds `max_recent` (rotation).
-4. Regenerates `docs/file-structure.md` (default branch only — on feature
-   branches the tree snapshot diverges and would conflict).
-5. **Regenerates `docs/timeline.md` on every branch (v0.2.3+)** — the derived
-   index that `check-derived-docs` CI verifies.
-6. **`git add` every change in the working tree (default since v0.2.7)** —
-   so the decision and the code that prompted it travel together in one
-   commit. Override with `--stage scoped` if you have unrelated WIP.
-7. **`git commit`** with message `logmind: <decision>`.
-8. **`git push`** to remote (configurable via `auto_push` in
-   `.logmind/config.yml`).
+1. Appends the decision to the active log file (default branch →
+   `docs/decisions.md`; feature branch →
+   `docs/decisions-branches/<branch>.md`).
+2. Archives the oldest decision if `decisions.md` exceeds `max_recent`.
+3. Regenerates `docs/file-structure.md` (default branch only) and
+   `docs/timeline.md` (every branch).
+4. **Stages the whole working tree** (`--stage all`, the default since
+   v0.2.7) — the decision and the code that prompted it land in one
+   commit. Pass `--stage scoped` to stage only the decision file(s) when
+   you have unrelated WIP you don't want swept in.
+5. `git commit` with message `logmind: <decision>`, then `git push`
+   (configurable via `auto_push`).
 
-## `logmind log` IS the commit primitive (no manual git after it)
-
-`logmind log` defaults to `--stage all` (since v0.2.7): every change in
-the working tree gets bundled into the decision commit. No follow-up
-`git add`, no follow-up `git commit`, no follow-up `git push`. One command,
-one commit, working tree clean.
-
-If you find yourself running `git add`, `git commit`, `git push`, or
-`logmind timeline --write` **after** a `logmind log`, you're working
-against the design. Two likely causes:
-
-1. **Pre-v0.2.7 logmind installed** — check `logmind --version` and
-   `logmind doctor`. v0.2.6 and earlier defaulted to `--stage scoped`.
-2. **You actually need `--stage scoped`** — see below.
-
-### `--stage scoped` (escape hatch)
-
-Pass `--stage scoped` to stage only the decision file + companion files
-(`file-structure.md`, archive if rotated, `timeline.md` if regenerated).
-Unrelated working-tree changes stay unstaged. Use when:
-
-- You have WIP in the working tree you don't want to commit yet.
-- You're doing a multi-step refactor where the decision should be
-  reviewable on its own, separately from the implementation.
-
-Rare for automated agents — they should be working on one task at a
-time and want the single-commit shape.
+Don't follow up with `git add`, `git commit`, `git push`, or
+`logmind timeline --write` — all three are already done, and the
+timeline is already regenerated and staged.
 
 ## Enforcement: raw `git commit` is blocked
 
 A substantive commit that bypasses `logmind log` is **blocked**, not just
-discouraged. Two layers enforce it: the git `commit-msg` hook, and (inside
-Claude Code) a PreToolUse hook that intercepts the `git commit` Bash call
-before it runs. Use `logmind log` in place of `git add` + `git commit` +
-`git push`.
+discouraged — a git `commit-msg` hook, plus (inside Claude Code) a
+PreToolUse hook that intercepts the `git commit` Bash call before it runs.
 
-Escape hatches, for genuinely no-decision commits (typo fixes, dependency
-bumps):
+Escape hatches, for genuinely no-decision commits (typos, dep bumps):
 - Add `[skip-logmind]` to the commit subject.
 - Set `LOGMIND_ALLOW_GIT_COMMIT=1` for one command.
 - `git.enforce_commits: false` in `.logmind/config.yml` disables
-  enforcement for the whole repo.
+  enforcement repo-wide.
 
 ## Branch-aware routing (automatic)
 
 On a feature branch the entry lands in
-`docs/decisions-branches/<sanitized-branch>.md`. On PR merge a workflow
+`docs/decisions-branches/<sanitized-branch>.md`. On PR merge, a workflow
 appends a one-line summary linking the PR + the per-branch file to
-`docs/decisions.md`. You do not manage this — `logmind log` does.
-
-## Deterministic auto-rebase (v0.6.1+, opt-in)
-
-When PRs land out-of-order, a trailing branch can go DIRTY because
-`main`'s `docs/timeline.md` gained new entries. Recovery is mechanical
-(rebase + regen timeline + force-with-lease push). v0.6.1 automates this
-behind a strong opt-in flag.
-
-**Default: OFF.** Enable in `.logmind/config.yml`:
-
-```yaml
-git:
-  auto_rebase: true
-```
-
-When enabled, `logmind log` checks **all 6 conditions** before touching
-any local state:
-
-1. `auto_rebase: true` in config
-2. Branch is NOT the default branch
-3. `git fetch origin <default>` succeeds
-4. `origin/<default>` ref exists
-5. Branch is behind `origin/<default>` (commits_behind > 0)
-6. **The gap touches EXACTLY `docs/timeline.md`** — no code, no other
-   derived docs, not even `docs/file-structure.md`
-
-If all 6 hold: rebase → (on conflict only in `timeline.md`) regen +
-continue → `git push --force-with-lease`. On any unexpected conflict
-surface: `git rebase --abort` + bail safely (no half-applied state).
-
-**Always `--force-with-lease`, never `--force`.** The scope is deliberately
-narrow: `docs/timeline.md` is fully derived (regenerated from
-`docs/decisions.md` + per-branch decision files), so conflict resolution
-= re-run the generator. Other files — even `docs/file-structure.md` —
-depend on broader repo state and are NOT in scope for this release.
-
-User-visible log line when it fires:
-
-```
-↻ logmind auto-rebased 'feature' onto origin/main
-  (was 2 commits behind, only docs/timeline.md affected
-  — safely deterministic).
-```
-
-When enabled but conditions don't hold, logmind emits a predictive
-heads-up naming the disqualifying files — no action is taken.
+`docs/decisions.md`. `logmind log` manages this; you don't.
 
 ## Reading prior context
 
 Before starting non-trivial work, read in order:
 
-1. **`docs/timeline.md`** — auto-generated overview across every branch;
-   start here. **Since v2.0 it is the single canonical timeline**: a
-   deterministic, source-derived UNION of decision entries across all
-   branches, each branch led by its one-sentence **headline** (see
-   [Branch summaries](#branch-summaries-headline) below). There is one
-   timeline format — the old brief/full distinction is gone (`--full` is
-   accepted but inert, kept only for backward compatibility).
+1. **`docs/timeline.md`** — the canonical, source-derived union of
+   decision entries across every branch, each led by its **headline**
+   (see below). Start here.
 2. **`docs/decisions.md`** — direct-on-main decisions in detail (20 most
    recent).
 3. **`docs/decisions-branches/<your-branch>.md`** if present — decisions
    made earlier on the same feature branch.
-4. **`docs/file-structure.md`** — current project tree. **Since v0.5.0
-   the on-disk tree is capped at depth 2 by default.** For a deeper
-   view, run `logmind file-structure --max-depth N` (or
-   `logmind tree --max-depth 0` for fully unbounded).
-5. **The canonical spec file, if configured** (v2.0+, SPEC §16) — the
-   project's forward-looking intended contract: the WHERE-TO beside the
-   timeline's WHY and the file tree's WHAT. Check
-   `.logmind/config.yml`'s `context.spec_file` (a nonzero
-   `logmind config get context.spec_file` exit means "not configured" —
-   not an error); it also arrives automatically, first, in
-   `logmind context`. **Build toward it — don't assume it already
-   describes the code.** Refine it via an ordinary PR when intent
-   changes, like any other doc; nothing regenerates it.
+4. **`docs/file-structure.md`** — current project tree (capped at depth 2
+   by default; `logmind file-structure --max-depth N`, or
+   `logmind tree --max-depth 0` for the unbounded view).
+5. **The canonical spec file, if configured** — `.logmind/config.yml`'s
+   `context.spec_file`; the forward-looking intended contract. Build
+   toward it, don't assume it already describes the code; nothing
+   regenerates it, so refine it via an ordinary PR when intent changes.
+
+`logmind context` bundles the file structure + timeline (+ spec file, when
+configured) into one cache-friendly read.
 
 ```bash
 logmind show                       # recent decisions on the current branch
-logmind show --all                 # include archive
-
-# Agent-friendly views (v0.5.2+) — combinable.
-logmind show --brief               # one line per entry: "YYYY-MM-DD HH:MM — title [source]"
-logmind show --brief --limit 10    # last 10 in brief form
-logmind show --json --limit 20     # parseable JSON array
-logmind show --json --all          # JSON across main + archive sources
-
+logmind show --brief --limit 10    # one line per entry
+logmind show --json --all          # parseable JSON, main + archive
 logmind search "postgres"          # full-text across both files
 ```
 
 ## Branch summaries (headline)
 
-On a feature branch, set a one-sentence, plain-English summary of what the
-**whole branch** does — its "headline." The canonical timeline shows this
-line for the branch, and it's the first thing the next agent reads.
+On a feature branch, set a one-sentence summary of what the **whole
+branch** does — the canonical timeline shows this line for the branch.
 
 ```bash
 logmind headline "Add JWT session auth with refresh-token rotation"
-
-# or bundle it into a decision commit:
-logmind log "Wire refresh-token rotation" -r "..." -H "Add JWT session auth with refresh-token rotation"
+# or bundle into a decision commit:
+logmind log "Wire refresh-token rotation" -r "..." -H "Add JWT session auth..."
 ```
 
-Refine it as the branch grows — the entry's key stays stable, so re-running
-`logmind headline` just rewrites the visible sentence. It's a no-op on the
-default branch (which logs to `docs/decisions.md` directly). `logmind doctor
---fix` backfills a headline for any branch file that's missing one.
+No-op on the default branch. `logmind doctor --fix` backfills a missing
+headline.
 
 ## The pulse: read the advisories after `logmind log`
 
@@ -230,272 +134,134 @@ a stale component (workflow/hook/AGENTS.md drift; run `logmind doctor
 decisions; worth a review). These never block the commit that already
 landed — act on them anyway.
 
-## Agent-invocation mode: `LOGMIND_QUIET=1` (v0.5.1+)
+## Agent-invocation mode: `LOGMIND_QUIET=1`
 
-When an agent (CI script, Claude Code session, downstream tool) runs
-logmind, the verbose progress chatter (`ℹ Default --stage all`,
-`✓ Logged decision`, sync messages) lands in the agent's context and
-burns tokens. Set `LOGMIND_QUIET=1` (or pass `--quiet` / `-q` on the
-group) to suppress progress and emit a single `ok <key-value>`
-summary line per command. Errors and warnings still print.
+Set `LOGMIND_QUIET=1` (or pass `--quiet` / `-q`) so an agent session gets
+terse output: progress chatter is suppressed and each command emits one
+`ok <key-value>` summary line. Errors and warnings still print.
 
 ```bash
 LOGMIND_QUIET=1 logmind log "..." -r "..."
 # → ok logged: <commit-sha> "<title>"
-
-LOGMIND_QUIET=1 logmind tree --write docs/file-structure.md
-# → ok file-structure: docs/file-structure.md (10240 bytes, depth=2)
 ```
 
-`logmind show --json` always emits parseable JSON to stdout
-regardless of `--quiet` (JSON is primary output, not progress). The
-`ok` summary in JSON mode goes to stderr so pipelines like
-`logmind show --json | jq` stay clean. Internally v0.5.3 patched
-`click.secho` so red/yellow error/warning output still prints under
-`LOGMIND_QUIET=1` — only progress chatter (cyan/green) is suppressed.
+`logmind show --json` always emits parseable JSON to stdout regardless of
+`--quiet`; the `ok` summary in JSON mode goes to stderr so pipelines like
+`logmind show --json | jq` stay clean.
 
 ## Verifying install health
 
-`logmind doctor` (v0.2.4+) reports installed-vs-latest versions for logmind
-(and clud-bug if present), flags stale workflow templates AND a stale
-`AGENTS.md` block-version (v0.2.9+) against bundled markers, and exits
-non-zero on drift so it's CI-pluggable.
+`logmind doctor` reports installed-vs-latest versions (logmind and
+clud-bug, if present) and flags stale workflow templates or an outdated
+`AGENTS.md` block-version, exiting non-zero on drift so it's CI-pluggable.
+Add `--json` for scripts, `--exit-zero` for informational CI runs. Run it
+after `init` or whenever pins might have drifted — `init` auto-heals
+stale-pin drift even when no template body changed.
+
+### Derived docs are main-only — don't edit them on a branch
+
+`docs/timeline.md` and `docs/file-structure.md` regenerate on `main` only,
+straight from source (per-branch decision logs + `decisions.md` for the
+timeline; a tree walk for file-structure). A branch's own decisions live in
+`docs/decisions-branches/<branch>.md` instead — that file is what you
+commit to.
+
+The shipped `regen-timeline.yml` GH Action enforces this with a **blocking**
+PR-time gate: if your branch's diff touches either derived doc, the check
+fails with `::error title=Derived docs were edited on this branch` and
+`exit 1` — editing them on a branch is exactly what causes cross-PR merge
+conflicts the derived-doc design exists to eliminate. Fix by resetting your
+copy to main's:
 
 ```bash
-logmind doctor             # one-shot status table
-logmind doctor --json      # for scripts
-logmind doctor --offline   # skip PyPI / npm probes
-logmind doctor --exit-zero # always exit 0 (informational CI runs)
+logmind warp                                    # read-only refresh
+# or
+git checkout origin/main -- docs/timeline.md docs/file-structure.md
 ```
 
-Run after `logmind init` to confirm a clean install, or any time
-templates / pins / instructions might have drifted. Stale-pin drift is
-auto-healed by `logmind init` itself in v0.2.5+, even when no template
-body changed. **If `doctor` reports an `AGENTS.md` stale row, your repo's
-embedded logmind instructions are older than what the installed logmind
-would write — re-run `logmind init` to refresh in place.**
+On a push to `main`, a separate job regenerates both files for real and
+pushes the update; if no `LOGMIND_AUTO_REGEN_PAT` secret is configured that
+push step degrades to a non-blocking `::warning title=Derived docs stale on
+main` (freshness-only — no conflict risk). Repos still on the older
+fail-fast template instead block on *staleness* (missing file, fork PR, or
+no PAT) rather than on branch edits — same spirit, different trigger.
 
-### Derived-doc freshness check (v0.5.13+ / v0.6.9+)
-
-Both derived docs now have CI-friendly fail-fast modes — exit non-zero
-when the on-disk file differs from a fresh regen, so CI fails the build
-before the auto-fix step (or pre-commit hooks can guard pushes).
+### `logmind warp` — pull main's derived docs into your branch
 
 ```bash
-# v0.5.13+:
-logmind timeline --write docs/timeline.md --check
-# v0.6.9+ (symmetric with timeline):
-logmind file-structure --write docs/file-structure.md --check
-
-#   → exit 0 + "✓ … is up to date"   if current
-#   → exit 1 + "✗ … is stale — re-run …" if regen would change the file
-#   → exit 2 + "requires --write"     if --write is missing
+logmind warp
+# → ok warp: refreshed 2 derived doc(s) from origin/main (read-only — not committed) · main is +3 decision commit(s) ahead
 ```
 
-The shipped `regen-timeline.yml` GH Action uses these to gate every PR,
-and (when `LOGMIND_AUTO_REGEN_PAT` secret is set) auto-regenerates and
-pushes the fix back to the PR branch before failing the check.
+Fetches `origin/<default-branch>` and overwrites your working copies of
+`docs/timeline.md` + `docs/file-structure.md` from it. **Never stages or
+commits** — it exists so your context (and the PR gate above) sees main's
+current state without you hand-running `git checkout origin/main -- ...`.
+Run it after pulling, or whenever the PR gate flags your branch as having
+drifted derived docs.
 
-## Parallel-PR merges: timeline + file-structure merge driver (v0.3.0+)
+## Parallel-PR merges: the timeline / file-structure merge driver
 
-Two PRs that both run `logmind log` no longer textually conflict on
-`docs/timeline.md` or `docs/file-structure.md` on rebase. v0.3.0's
-`logmind init` installs three pieces that handle this together:
+Two PRs that both run `logmind log` don't textually conflict on the
+derived docs. `logmind init` installs three pieces — a `.gitattributes`
+merge-driver block, the per-clone `git config` defining the drivers, and a
+`.git/hooks/post-merge` sweep for anything the driver missed; `logmind
+doctor` reports drift on all three. The driver is client-side, so it can't
+help a server-side merge — which is why the main-only pin above exists.
 
-- **`.gitattributes` block** (idempotent, marker-bracketed) — registers
-  `merge=logmind-timeline` and `merge=logmind-file-structure` for the
-  two derived files.
-- **Per-clone `git config`** — defines the merge drivers themselves
-  (`merge.logmind-timeline.driver = 'logmind timeline --write %A'`,
-  similar for file-structure). Lives in `.git/config`, not committed
-  (git refuses to auto-run a merge driver that isn't explicitly
-  configured locally — security guard against untrusted repos). Fresh
-  clones need `logmind init` once to pick this up.
-- **`.git/hooks/post-merge`** — re-regenerates both derived files from
-  the full post-merge working tree. Belt + suspenders: the driver runs
-  per-file mid-merge before the other branch's `docs/decisions-branches/`
-  files are checked out, so its output can miss decisions; the hook
-  sweeps any incomplete regen at end-of-merge.
+## Authoring skills locally — `logmind skill …`
 
-`logmind doctor` reports three new rows for these (v0.3.0+):
-`.gitattributes (merge driver)`, `git config (merge driver)`, and
-`post-merge hook`. Missing rows are not drift — they're "not yet
-installed for this logmind version" — the next `logmind init` resolves
-them silently.
-
-The merge driver invokes `logmind file-structure --write <path>`
-(v0.3.0+), the mirror of `logmind timeline --write`. Like the timeline
-command, you should not run it by hand in the normal flow — it exists
-for the merge driver and as an escape hatch (corrupted file, externally
-modified tree).
-
-## Authoring skills locally (v0.6.0+ — `logmind skill …`)
-
-logmind ships a CLI surface for authoring skills *in your own project*
-(under `.claude/skills/<name>/SKILL.md`). The surface is deliberately
-human-gated — logmind never auto-creates or auto-PRs a skill on your
-behalf. Use this for project-specific skills; promote to a public
-catalog like agent-skills via the new-skill issue gate when ready.
+A CLI surface for authoring skills *in your own project*
+(`.claude/skills/<name>/SKILL.md`). All local-only and read-only against
+remotes — **except `push`, which is the one command that reaches out.**
 
 ```bash
-logmind skill new <name>                # scaffold .claude/skills/<name>/SKILL.md
+logmind skill new <name>                # scaffold a SKILL.md
 logmind skill test <name>               # frontmatter + structural validation
-logmind skill bench <name>              # per-call token-cost measurement
-logmind skill audit                     # author's-side staleness read
-logmind skill suggest --since 30d       # pattern-detect candidate skills
+logmind skill bench <name>              # per-call token-cost measurement + trim suggestions
+logmind skill audit                     # every local SKILL.md: bytes, decision-mentions, staleness
+logmind skill suggest --since 30d       # pattern-detect candidate skills from recent decisions
+logmind skill push <name> --dry-run     # preview; ALWAYS run this first (see below)
+logmind skill push <name>               # opens a real PR against the catalog — no confirmation prompt
 ```
 
-### `logmind skill bench <name>` (v0.6.3+) — measure the cost
+`bench` buckets a skill by loaded cost (tight / typical / verbose /
+over-budget); `audit` flags **ghost** (loaded every context, author never
+iterates) and **aging** (untouched 90+ days) skills; `suggest` scans
+decision entries for repeated tokens and drafts a candidate-skill issue.
+Pair with `clud-bug usage --health` (loads vs. citations on real PRs) for
+the full cost-vs-value picture.
 
-Reports exactly what a skill costs when loaded: bytes, estimated tokens,
-status bucket, per-section breakdown, and trim suggestions when over
-budget. Every load of `SKILL.md` puts the whole file into the agent's
-context, so the budget matters.
-
-- **tight**: ≤ 2000 bytes (~500 tokens) — focused, well-trimmed
-- **typical**: ≤ 6000 bytes (~1500 tokens) — most skills land here
-- **verbose**: ≤ 8000 bytes (~2000 tokens) — past budget, suggestions emitted
-- **over-budget**: > 8000 bytes — past hard cap, split recommended
-
-Pair with `clud-bug usage --health` (which reports loads vs. citations
-on real PR reviews) to know whether a skill EARNS its budget — bench
-says what it COSTS, usage says what it RETURNS.
-
-### `logmind skill audit` (v0.6.4+) — author's-side staleness read
-
-One-shot table for every `.claude/skills/<name>/SKILL.md` with bytes,
-decision-log mention count, last-touched (via `git log -1 --format=%cs`),
-and a deterministic status:
-
-- **ghost**: `decision_count == 0` AND `bytes > 2000` — loaded into every
-  context but author never iterates; candidate for archive after
-  usage-side confirmation.
-- **aging**: last-modified > 90 days — was useful, hasn't been touched
-  in a quarter.
-- **active**: otherwise.
-
-```bash
-logmind skill audit          # human-readable, sorted by name
-logmind skill audit --json   # machine-readable, status enriched
-```
-
-Pairs with `bench` (cost) and `clud-bug usage --health` (effectiveness)
-for the complete skill-lifecycle picture.
-
-### `logmind skill suggest` (v0.6.5+) — pattern-detect candidate skills
-
-Scans recent decision-log entries for tokens that appear across many
-distinct decisions — a heuristic signal that "we keep talking about X,
-maybe X should have its own skill." Output is a pre-filled GH-issue
-draft matching agent-skills's `new-skill.yml` template. The human reads,
-decides, opens (or discards).
-
-```bash
-logmind skill suggest                       # last 30d, ≥3 decisions, top 5
-logmind skill suggest --since 7d --top 10
-logmind skill suggest --min-decisions 5     # tighter signal
-logmind skill suggest --write-drafts /tmp/proposals/
-logmind skill suggest --json                # machine-readable
-```
-
-**Never auto-PR. Never auto-create a skill.** This is intentional — the
-pragmatic SkDD design (2026-05-30) gates skill lifecycle on humans, not
-agents. `suggest` proposes; the human disposes.
-
-## Upgrading: `logmind init` prints the changelog
-
-When you run `brew upgrade thrillmade/tap/logmind && logmind init` (or
-re-run `curl -fsSL https://logmind.dev/install.sh | bash`) in an
-already-initialized repo (v0.2.10+), refresh-mode detects the prior
-installed version (via the existing binary's `--version` in v1.x;
-previously via `regen-timeline.yml`'s pip-pin in v0.x) and prints
-**every CHANGELOG section between that version and the now-installed
-binary's reported version** inline:
-
-```
-📋 What's new in logmind since v0.2.6 (currently installed: v0.2.10):
-
-## [0.2.10] - ...
-### Added
-- logmind init refresh-mode prints CHANGELOG sections...
-
-## [0.2.9] - ...
-### Changed
-- actions/checkout@v4 → @v6 across all shipped templates...
-
-...
-```
-
-Read it. The whole point is that your in-session memory might predate
-the upgrade, and the printed sections tell you exactly what changed.
-Common deltas you'll see if you're upgrading across a stretch:
-
-- **v0.2.7**: `logmind log` defaults to `--stage all` (single
-  add+commit+push primitive — stop running `git add` first).
-- **v0.2.9**: `logmind log` prints a visible `--stage` notice on every
-  invocation so the actual behavior is unmissable in output.
-- **v0.2.9**: `logmind doctor` flags stale `AGENTS.md` block-version.
-- **v0.3.0**: `logmind init` registers a git merge driver for
-  `timeline.md` / `file-structure.md` so parallel-PR merges no longer
-  conflict on the derived files. Doctor gains three rows tracking it.
-- **v0.6.1**: `logmind log` gains opt-in deterministic auto-rebase via
-  `git.auto_rebase: true` in `.logmind/config.yml`. Narrow scope: only
-  fires when the gap between your branch and `origin/<default>` is
-  exactly `docs/timeline.md`. Always uses `--force-with-lease`.
+`new` / `test` / `bench` / `audit` / `suggest` never touch a remote — they
+read and write local files only. **`push` is the exception: without
+`--dry-run` it clones the catalog, pushes a branch, and opens a real pull
+request the moment you run it — no confirmation prompt.** Preview with
+`--dry-run` first, every time. Nomination still isn't publication: the
+catalog's editor gate decides, and can say no.
 
 ## Setup (one-time, per project)
 
-If the project doesn't yet have logmind:
-
 ```bash
 brew install thrillmade/tap/logmind   # macOS + Linux; or: curl -fsSL https://logmind.dev/install.sh | bash
-logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block, merge drivers + post-merge hook (v0.3.0+)
+logmind init               # scaffolds docs/, AGENTS.md, GH Actions, merge drivers + post-merge hook
 logmind doctor             # confirm clean install
 ```
 
-**Unified SkDD install (v0.6.8+)**: one command bootstraps logmind AND clud-bug
-together via the `--with-skdd` flag:
-
-```bash
-brew install thrillmade/tap/logmind   # or: curl -fsSL https://logmind.dev/install.sh | bash
-logmind init --with-skdd   # subprocesses to `npx clud-bug init` after logmind setup
-```
-
-Behavior:
-- Default (no flag): logmind init unchanged — logmind only (no clud-bug).
-- With `--with-skdd` + `npx` on PATH: subprocesses to `npx --yes clud-bug@latest init` after logmind setup completes. Streams output (not silenced).
-- With `--with-skdd` + no `npx`: emits a clear warning with the recovery command, exit code 0 (logmind side succeeded).
-- Subprocess failure (non-zero, OSError, 5-minute timeout): warning surfaced; logmind init still succeeds — clud-bug is an additive layer.
-- **Anti-loop guarantee**: `--with-skdd` only goes one level deep. `logmind init --with-skdd` invokes `npx clud-bug init` (NOT `clud-bug init --with-skdd`), and v0.6.33's mirror in clud-bug does the reverse. No mutual recursion.
-
-The flag name describes the BUNDLE TARGET (the SkDD toolchain), not a specific tool — so as the toolchain grows beyond logmind + clud-bug, the same flag stays.
+`logmind init --with-skdd` accepts the flag but currently **defers** —
+it prints a note to run `npx clud-bug@latest init` yourself rather than
+chaining. Run the two separately.
 
 ## Don'ts
 
-- **Don't run `git add`, `git commit`, or `git push` for changes that
-  carry a decision.** `logmind log` is the commit primitive — it handles
-  all three in one step. Running them manually either bypasses the
-  logging entirely or splits the work across separate commits, both of
-  which lose the value of having the reasoning attached to the code.
-- **Don't run `git add` BEFORE `logmind log` either.** Default
-  `--stage all` already sweeps the working tree; pre-staging is
-  redundant. (Exception: if you're using `--stage scoped` and have
-  extra files you specifically want included, pre-stage them and they
-  carry through — but `--stage all` is the right answer 99% of the
-  time for agents.)
-- **Don't run `logmind timeline --write docs/timeline.md` after a `logmind
-  log`** — it's already regenerated and staged. The standalone command is
-  an escape hatch for unusual situations (a corrupted timeline, a tree
-  someone touched outside logmind), not part of the normal flow.
-- **Don't use `--force` instead of `--force-with-lease` in any git push
-  associated with logmind workflows.** The auto-rebase feature (v0.6.1+)
-  enforces `--force-with-lease` exclusively; never substitute `--force`.
-- **Don't expect auto-rebase to handle anything beyond `docs/timeline.md`.**
-  If the gap between branches includes code files, `docs/file-structure.md`,
-  or any file other than `docs/timeline.md`, auto-rebase will refuse and
-  emit a heads-up — handle the rebase manually.
+- **Don't run `git add`, `git commit`, or `git push`** for changes that
+  carry a decision — `logmind log` handles all three in one step.
+- **Don't run `git add` before `logmind log`** — default `--stage all`
+  already sweeps the working tree.
+- **Don't run `logmind timeline --write` after a `logmind log`** — it's
+  already regenerated and staged; the standalone command is an escape
+  hatch for a corrupted timeline or an externally-modified tree.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.
-- Don't bypass the auto-commit (`--no-commit`) unless you know the project's
-  branch protection requires it.
+- Don't bypass the auto-commit (`--no-commit`) unless you know the
+  project's branch protection requires it.

--- a/skills/oklch-color-space/SKILL.md
+++ b/skills/oklch-color-space/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oklch-color-space
-description: Use when picking color values for a design-token system, constructing a palette around a starting hue, or generating colors against an accessibility contrast target. Names the OKLCH primitive ranges, the hue-angle naming convention, the gamut-mapping rule for sRGB vs Display P3, and the APCACH inverse-composition approach for guaranteed-contrast color generation. Cite when an agent reaches for "pick a color then check contrast" — the inversion is the load-bearing move.
+description: Use when picking color values for a design-token system, constructing a palette around a starting hue, or generating colors against an accessibility contrast target. Names the OKLCH primitive ranges, the hue-angle naming convention, the gamut-mapping rule (Display P3 for computation, sRGB for the emitted fallback), and the APCACH inverse-composition approach for guaranteed-contrast color generation. Cite when an agent reaches for "pick a color then check contrast" — the inversion is the load-bearing move.
 ---
 
 # OKLCH color space
@@ -26,7 +26,7 @@ Every OKLCH primitive that lands in a catalog uses the hue-angle naming conventi
 | Channel | Range | Notes |
 |---|---|---|
 | L | 0–1 | 0 = pure black, 1 = pure white; UDTS palette stops typically land 0.10–0.99 |
-| C | 0–~0.4 | Theoretical max varies by hue; in sRGB-gamut the practical ceiling is ~0.16–0.20 at moderate L |
+| C | 0–~0.4 | Theoretical max varies by hue; UDTS composes in **Display P3** by default (apcach's `colorSpace: 'p3'`), whose practical ceiling at moderate L is wider than sRGB's ~0.16–0.20 — the sRGB figure applies only to the emitted hex fallback, not the compute-time ceiling |
 | H | 0–360° | Cyclic; 0 ≈ red, 90 ≈ yellow, 180 ≈ teal/cyan, 270 ≈ blue, 360 = 0 |
 
 ## Compose to a contrast target — don't pick L and test
@@ -47,9 +47,19 @@ This applies to every contrast-bound token (text, surface, border, ui). For free
 
 ## Gamut mapping
 
-When emitting hex, gamut-map from OKLCH source into the output color space. For sRGB output, clamp chroma at the gamut boundary at the given (L, H). For Display P3 / figma-p3 output, the gamut is wider; emit the OKLCH value directly when the target supports it, fall back to sRGB clamp otherwise.
+The **compose space is P3-native**: chroma caps, `displayable()` checks, and APCACH composition all default to Display P3 (UDTS's compose gamut) — apcach's `apcach()`, `cssToApcach()`, and `maxChroma()` all default `colorSpace` to `'p3'`, and UDTS's wrapper never overrides that default.
 
-Practical rule for picking a chroma cap: stay ≥10% below the sRGB gamut ceiling at your declared (L, H) so rounding errors and downstream conversions don't push the color out of gamut. Use a culori/`displayable()` style check before shipping.
+sRGB legitimately enters the pipeline at exactly three points — nowhere else:
+
+1. **Emission edge (fallback export).** Materializing the hex fallback for legacy consumers: gamut-map the OKLCH source into sRGB and clamp chroma at that narrower boundary. Emit the Display P3 (`figma-p3`) representation directly wherever the target supports it; fall back to the sRGB clamp only for the compatibility hex export.
+2. **Background-anchor round-trip (apcach's own API shape).** APCACH inverse composition takes its background as a CSS color string — it has no OKLCH-object entry point for the anchor color. UDTS's compose wrapper round-trips the OKLCH background through sRGB hex on *every* compose call to satisfy that string-shaped API; apcach then converts it into P3 internally for the actual composition. This happens mid-computation, on every generated palette variant — it's correct because the library boundary forces it, not because the pipeline chose to compute in sRGB there.
+3. **WCAG 2 cross-check.** WCAG 2.2 AA contrast is only defined against sRGB-space luminance, so the cross-check step is sRGB by definition, not a compromise.
+
+**Known open gap — do not teach as fixed:** the shipped APCA *meter* still gamut-clamps both colors into sRGB before scoring, on every call path, while the *composer* (apcach) targets P3. That composer/meter mismatch is a documented, tolerated gap in the codebase today, not something later resolved — never state that the live meter measures in P3.
+
+Practical rule for picking a chroma cap: compose against the **Display P3 ceiling** and stay ≥10% below it at your declared (L, H) — this protects the eventual sRGB-fallback materialization and display-driver quirks from pushing the color out of gamut. Use a culori/`displayable()` check against **P3** before shipping; check sRGB separately only when validating the emitted hex fallback.
+
+**The actual doctrine:** sRGB/hex intermediates are correct only at the three points above. Anywhere else — picking L or C, doing hue math, or resolving a gamut boundary that isn't the fallback edge, the WCAG check, or apcach's background-string requirement — stay in culori-native OKLCH objects end-to-end. An 8-bit hex round-trip outside those three points quantizes precision a P3-native pipeline doesn't need, and is the pattern to flag in review.
 
 ## Cross-references
 
@@ -62,8 +72,8 @@ Practical rule for picking a chroma cap: stay ≥10% below the sRGB gamut ceilin
 After picking an OKLCH value:
 
 1. **Range check:** `0 ≤ L ≤ 1`, `0 ≤ C ≤ 0.4`, `0 ≤ H < 360`.
-2. **Gamut check:** `displayable(oklch(L C H))` returns true for the target color space (sRGB by default).
-3. **Round-trip check:** convert OKLCH → hex → OKLCH; the round-trip delta on L and C should be < 0.01.
+2. **Gamut check:** `displayable(oklch(L C H))` returns true for the target color space (**Display P3 by default** — UDTS's compute gamut; check sRGB separately only for the emitted hex fallback).
+3. **Round-trip check (fallback-emission path only):** convert OKLCH → sRGB hex → OKLCH; the round-trip delta on L and C should be < 0.01. This validates the emitted hex fallback. (A different sRGB round-trip happens inside APCACH composition for the background anchor — see Gamut mapping; that one is exercised by the compose step's own Lc tolerance, not by this check.)
 4. **Contrast check (contrast-bound tokens):** APCA Lc against the declared pairing background hits the target ± 1 Lc.
 
 If any of the four fails, fix the value before emitting the token.


### PR DESCRIPTION
## F2 — the docs truth pass

Every load-bearing claim in this repo's docs, traced to a real file or workflow. Three findings were **live defects**, not prose nits.

### The three that mattered

**1. Two skills taught wrong colour math.** `chroma-harmonization` and `oklch-color-space` taught an sRGB default that [#170](https://github.com/thrillmade/agent-skills/issues/170)'s locked ruling bans from computation. Corrected — but *not* to the blanket ban the issue implies, because the shipped pipeline contradicts that too: `tokenomics/packages/core/src/color/apcach.ts:61` round-trips the background through sRGB hex on **every** `apcachCompose` call, mid-computation, because apcach's API takes a CSS string. The skills now name the three places sRGB is legitimately correct (emission edge, the apcach background anchor, the WCAG-2 checker) so a reviewer can tell a correct use from the bug — and carry an explicit "known open gap, do not teach as fixed" note, because `apcaContrast()` still measures in sRGB while the composer targets P3.

**2. The catalog→clud-bug sync has been dead since clud-bug's TS migration.** `notify-clud-bug.yml` sed'd `lib/skills.js`, deleted in v0.7.0 — so under `set -euo pipefail` the "automatic sync" our docs advertise hard-failed on every run. Retargeted to `src/cli/skills.ts` **and reproduced**: copied clud-bug's real file, ran the new sed with a synthetic SHA, confirmed the rewrite. Added a fail-loud guard so a future path-miss errors instead of silently rotting.

**3. The census was polluting its own docket.** Identical verdicts re-filed three cycles running because nothing gave a verdict a stable identity. Verdicts now carry a deterministic `census_key` and the workflow comments on the live issue instead of duplicating it. **The search must be `in:body,comments`** — the four canonical seeds carry their marker in a *comment*, so `in:body` alone finds none of them and would have silently re-filed everything anyway.

### Also corrected

`npx skdd init` de-promised to the real four-command flow (skdd has no implementation); the `logmind` skill reconciled against v2 source; `clud-bug-collaboration`'s stale constants fixed (`MAX_DIFF_BYTES` 80000 → 5000000) and its two independent classifiers un-conflated (workflow-only PRs skip review entirely and never get a `max-turns`; only the separate trivial classifier gets the flat 10 + Haiku); the steward rename split honestly between shipped and roadmap; `external` → `baseline`; the four `undecided` placement-map entries resolved to `catalog` per clud-bug#243 Ruling 2.

### How this was built, and why it took three rounds

Build → adversarial pass → fix batch → and the fix batch's own verifier caught a **new** defect. Worth stating plainly:

- **Five facts in my brief were false, and the builders refused all five.** `logmind skill bench` is live (`internal/cli/skill.go:57`), not retired. `logmind warp` and the blocking gate weren't on `origin/main` when briefed — **I'd read a stale local feature branch**. The `skdd-steward` rename isn't shipped. My `in:body` search finds none of the markers. #170's chroma "recompose rule" doesn't exist in `harmonization.ts` on main or seven branches.
- **Ground truth moved mid-run:** logmind#236 merged at 19:06 *during* the wave, making one builder's correct finding stale before it reported.
- **The fix round introduced a HIGH of its own:** `logmind skill push` was listed under a blanket *"none of these auto-PR anything on your behalf"* while `skill_push.go` clones the catalog, pushes a branch, and opens a real PR with no confirmation. An agent trusting that line would have opened a PR against the public catalog thinking it ran a local command. Now called out as the exception, with the `--dry-run` the skill never mentioned.

### Verification

- **All 46 skills pass the validator** (frontmatter, name↔dir, single H1 — fence-stripped, since counting `# ` inside code blocks produces false failures)
- `python3 -m py_compile` on both census scripts; every touched YAML/JSON parses; placement-map key↔dir parity holds
- **All 60 relative links across the 7 changed markdown files resolve**
- Adversarial test of the new `census-key` marker writer: eight payloads (embedded `-->`, newline injection, NUL/ESC, column-0 forged marker, quote-breaking, empty, all-punctuation, 300 chars) — all safe; `_slugify` whitelists to `[a-z0-9-]`. The `kind` field is interpolated verbatim and *does* leak marker characters, but is unreachable: `census_panel.py:660` drops any verdict whose kind isn't in `VALID_KINDS` before the key is built.

### One deliberate non-fix

`skills/logmind/SKILL.md` is **267 lines** against a catalog median of 81. Down from 501 in this pass, and every remaining section is verified-true. Nothing in CI enforces a line budget — the 250 figure was my own brief's, not a rule. The honest fix is *splitting* it (decision-logging workflow vs. the skill-authoring CLI are two jobs), which is a catalog decision for the census to rule on, not a trim to rush at the end of a fix batch.
