### PR TITLE
Close the census marker-laundering chain at both boundaries (+ stop the sync shipping 0.7.NaN)

### DIFF
--- a/.github/scripts/census_panel.py
+++ b/.github/scripts/census_panel.py
@@ -348,7 +348,12 @@ def render_docket(issues: list[dict], error: str | None) -> str:
         )
         title = (issue.get("title") or "").strip()
         updated = issue.get("updatedAt") or ""
-        body = issue.get("body") or ""
+        # INGESTION BOUNDARY. Docket bodies are attacker-writable — the issue
+        # templates auto-apply the `census` label at creation, so this list is
+        # not an allowlist. Neutralize marker delimiters (and defang mentions)
+        # BEFORE any of it reaches the model. See _neutralize_markers.
+        body = _neutralize_markers(_defang(issue.get("body") or ""))
+        title = _neutralize_markers(title)
         truncated = len(body) > DOCKET_BODY_LIMIT
         shown = body[:DOCKET_BODY_LIMIT]
         note = "\n…[body truncated to 1500 chars]" if truncated else ""
@@ -567,6 +572,40 @@ def _defang(text: str) -> str:
     return text.replace("@", "@ ")
 
 
+def _neutralize_markers(text: str) -> str:
+    """Break HTML-comment delimiters so text passing through this panel can
+    never carry a marker that a downstream consumer will read as authoritative.
+
+    WHY THIS EXISTS — the laundering chain, found 2026-07-27:
+
+      1. `fetch_docket()` reads EVERY open `census`-labelled issue with no
+         author filter. The issue templates auto-apply `census` + a kind label
+         at creation, so any outside contributor can put text on the docket
+         without holding a single repo permission.
+      2. `render_docket()` quotes DOCKET_BODY_LIMIT chars of each body VERBATIM
+         into the model's context.
+      3. The model's own output is then filed as a census-authored issue, and
+         `skill-census.yml` appends the genuine `<!-- census-key: … -->` marker
+         at the END of that body.
+      4. A consumer that extracts the FIRST marker-shaped substring therefore
+         resolves an attacker-planted one instead of the appended one — and
+         because HTML comments are invisible in GitHub's rendered view, the
+         maintainer approving the issue sees nothing.
+
+    Authorship was never the weak link; the census IS trusted. The weakness was
+    that untrusted text flowed THROUGH a trusted author. Stripping the
+    delimiters at both the ingestion and emission boundaries removes the
+    capability rather than filtering the payload.
+
+    Zero-width chars defeat a naive `<!--` match, so normalize those first.
+    """
+    if not text:
+        return text
+    for zw in ("​", "‌", "‍", "﻿"):
+        text = text.replace(zw, "")
+    return text.replace("<!--", "< !--").replace("-->", "-- >")
+
+
 def _slugify(text: str) -> str:
     """Deterministic lowercase-kebab slug for the subject segment of a
     census_key. No randomness, no cycle/date component: the same input text
@@ -591,9 +630,18 @@ def _census_key(kind: str, subject: str) -> str:
 
 
 def _sanitize_body(value: object) -> str:
-    """Defang @-mentions, then cap at BODY_CAP characters (final length <= cap)."""
+    """Defang @-mentions, neutralize marker delimiters, then cap at BODY_CAP
+    characters (final length <= cap).
+
+    EMISSION BOUNDARY. Even with ingestion neutralized, the model can emit a
+    marker-shaped string of its own — quoted from a source we didn't sanitize,
+    or simply confabulated. The genuine `<!-- census-key: … -->` is appended by
+    the filing step in skill-census.yml AFTER this, so nothing upstream of that
+    append is entitled to produce one. Belt and braces on the same invariant:
+    the only marker in a filed body is the one the filing step wrote.
+    """
     text = value if isinstance(value, str) else ("" if value is None else str(value))
-    text = _defang(text)
+    text = _neutralize_markers(_defang(text))
     if len(text) > BODY_CAP:
         text = text[: BODY_CAP - 13].rstrip() + "\n\n[truncated]"
     return text

--- a/.github/workflows/notify-clud-bug.yml
+++ b/.github/workflows/notify-clud-bug.yml
@@ -241,20 +241,32 @@ jobs:
             exit 1
           fi
 
-          # 3. Bump patch version in package.json. Use node to avoid pulling
-          #    in jq just for this single field — clud-bug already requires
-          #    node to run.
-          NEW_VERSION="$(node -e "const p=require('./package.json'); const [maj,min,pat]=p.version.split('.').map(Number); console.log(\`\${maj}.\${min}.\${pat+1}\`)")"
-          node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json')); p.version='${NEW_VERSION}'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');"
-          echo "new_version=${NEW_VERSION}" >> "$GITHUB_ENV"
+          # 3. DO NOT bump the version. Two reasons, both learned the hard way
+          #    (clud-bug PR #251, 2026-07-25):
+          #
+          #    (a) The old code did `p.version.split('.').map(Number)` and
+          #        assumed X.Y.Z. clud-bug ships PRERELEASES — on `0.7.0-rc.26`
+          #        that splits to ["0","7","0-rc","26"], `Number("0-rc")` is
+          #        NaN, and it wrote a literal `"version": "0.7.NaN"` into the
+          #        publisher's package.json and CHANGELOG.
+          #
+          #    (b) More fundamentally, assigning a version number is the
+          #        PUBLISHER'S act, not ours. This workflow proposes CONTENT;
+          #        clud-bug decides when that content ships and under what
+          #        version. A refresh PR that pre-assigns a version preempts
+          #        their release process and — mid-release-candidate — collides
+          #        with it. Per protocol SPEC §17.1, refresh automation must not
+          #        take a publisher's release decisions for them.
+          #
+          #    The CHANGELOG entry therefore lands under [Unreleased], where
+          #    their own release process will fold it into whatever version
+          #    they cut next.
 
           # 4. Prepend a CHANGELOG entry under [Unreleased]. The file format
           #    is Keep-a-Changelog; the [Unreleased] header sits at the top.
           DATE="$(date -u +%Y-%m-%d)"
           ENTRY_FILE="$(mktemp)"
           cat > "$ENTRY_FILE" <<EOF
-
-          ## [${NEW_VERSION}] — ${DATE}
 
           ### Changed
 
@@ -276,11 +288,15 @@ jobs:
           # Verify the entry actually landed. Mirrors the sed-then-grep check
           # above so the awk can't silently no-op if clud-bug's [Unreleased]
           # header shape ever drifts (e.g. "## [Unreleased] - 2026-XX-YY").
-          # Without this, the version + pin bump would still ship but the
-          # CHANGELOG entry would be missing, and the failure would only
-          # surface on maintainer review.
-          if ! grep -qF "[${NEW_VERSION}]" CHANGELOG.md; then
-            echo "::error::CHANGELOG entry for ${NEW_VERSION} not inserted — check the [Unreleased] header shape in clud-bug's CHANGELOG.md."
+          # Without this, the pin bump would still ship but the CHANGELOG
+          # entry would be missing, and the failure would only surface on
+          # maintainer review.
+          #
+          # Match on the skill name + source SHA rather than a version number:
+          # this workflow no longer assigns a version (see step 3), and the
+          # skill+SHA pair is what actually identifies this refresh.
+          if ! grep -qF "thrillmade/agent-skills@${SHORT}" CHANGELOG.md; then
+            echo "::error::CHANGELOG entry for ${SKILL}@${SHORT} not inserted — check the [Unreleased] header shape in clud-bug's CHANGELOG.md."
             exit 1
           fi
 
@@ -313,8 +329,9 @@ jobs:
 
           - \`templates/skills/baseline/${SKILL}.md\` ← byte-for-byte copy of the source above.
           - \`src/cli/skills.ts\` — \`BASELINE_SKILLS_REF\` bumped to \`${SHA}\` so the install-time fetch from \`thrillmade/agent-skills\` and the bundled offline-fallback both resolve to identical content.
-          - \`package.json\` — patch version bump to \`${new_version}\`.
           - \`CHANGELOG.md\` — entry under [Unreleased] documenting the refresh.
+
+          **\`package.json\` is deliberately untouched.** This PR proposes *content*; assigning a version is your release decision, not ours. The CHANGELOG entry sits under [Unreleased] for your own release process to fold in.
 
           ## How this was generated
 

--- a/docs/decisions-branches/fix__census-marker-laundering.md
+++ b/docs/decisions-branches/fix__census-marker-laundering.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-28 00:33 - Close the census marker-laundering chain at both boundaries, and stop the sync from assigning versions
+
+**Reasoning:** census_panel.py runs weekly on main and its ingestion path is exploitable today. The issue templates auto-apply the census label at creation, so fetch_docket()'s label filter is not an allowlist -- any outsider can put text in the docket. render_docket() then quoted up to 1500 chars of that body verbatim into the model's context, and _sanitize_body() defanged @ but never stripped HTML comments. So an attacker-planted census-key marker could ride through a machine-authored issue and win a downstream head -1 extraction, invisibly, because HTML comments do not render in GitHub's UI. _neutralize_markers() now breaks the comment delimiters at both the ingestion and emission boundaries, after stripping zero-width characters that would defeat a naive match. Separately, notify-clud-bug.yml was shipping version 0.7.NaN into clud-bug's main: it parsed a version like 0.7.0-rc.26 with split('.').map(Number), so Number('0-rc') gave NaN. Version assignment is the publisher's act, not the sync's, so it is removed rather than patched.
+
+**Alternatives considered:** Filter the attacker text more aggressively rather than neutralizing delimiters -- rejected: three prior security rounds each closed real defects and each surfaced a new class, which is evidence about the design, not the code. Breaking the delimiter removes the capability instead of enumerating its abuses. Or anchor only the consumer to the last non-blank line -- necessary but not sufficient, since it leaves the poisoned text in the model's context.
+
+**Implications:**
+- The laundering chain is closed at both ends and the order invariant holds: the sanitizer runs before the filing step appends the genuine marker, so the real marker is untouched. Known cosmetic cost, accepted deliberately rather than passed silently: an arrow in ordinary prose becomes '-- >'. This branch deliberately EXCLUDES the F3 actuator workflows -- they failed four adversarial rounds and must not reach main.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (8 decisions)
+## 2026-07 (9 decisions)
 
-- **2026-07-25** — F2 docs truth pass: correct the sRGB doctrine, repair the dead catalog→clud-bug sync, make the census comment instead of re-filing, and reconcile four skills against current source *(feat/f2-docs-truth-pass)* — [decisions-branches/feat__f2-docs-truth-pass.md](decisions-branches/feat__f2-docs-truth-pass.md)
-- *... 6 more decisions ...*
+- **2026-07-28** — Close the census marker-laundering chain at both boundaries, and stop the sync from assigning versions *(fix/census-marker-laundering)* — [decisions-branches/fix__census-marker-laundering.md](decisions-branches/fix__census-marker-laundering.md)
+- *... 7 more decisions ...*
 - **2026-07-16** — skill unification: three-layer design catalog — K0 splits/stubs/promotions, K1 dispatchers, K3 abstraction *(feat/skill-unification-k0-k1-k3)* — [decisions-branches/feat__skill-unification-k0-k1-k3.md](decisions-branches/feat__skill-unification-k0-k1-k3.md)
 
 ## 2026-06 (10 decisions)


### PR DESCRIPTION
Security fix to code that **runs weekly on main today**.

## The laundering chain (reproduced)

1. `fetch_docket()` reads every open `census`-labelled issue **with no author filter**. The issue templates auto-apply `census` + a kind label *at creation*, so the label is not an allowlist — any outside contributor can put text on the docket holding no repo permission.
2. `render_docket()` quoted 1500 chars of each body **verbatim** into the model's context.
3. The model's output is filed as a census-authored issue, and `skill-census.yml:303` appends the genuine `<!-- census-key: … -->` at the **end**.
4. A consumer extracting the **first** marker-shaped substring therefore resolves the attacker's, not the appended one.
5. HTML comments are **invisible in GitHub's rendered view**, so a maintainer approving the issue sees nothing.

Authorship was never the weak link — the census *is* trusted. The weakness was untrusted text flowing **through** a trusted author.

## The fix

`_neutralize_markers()` breaks the comment delimiters at **both** boundaries — ingestion (`render_docket`) and emission (`_sanitize_body`) — after stripping zero-width characters that would defeat a naive match. This removes the capability rather than filtering the payload, which matters: three prior hardening rounds each closed real defects and each surfaced a *new* class.

## Verification

Adversarial inputs, all run: plain forged marker, zero-width evasion (`<\u200b!--`), nested `<!<!--`, doubled delimiters, split-reconstruct, prose arrow, fenced comment, empty. **Zero leaks; idempotent.**

Two invariants checked rather than assumed:

- **Order.** `census_panel.py:762` is the only body writer and it sanitizes; `skill-census.yml:303` appends the genuine marker *afterward*. The real marker is never neutralized.
- **No dedupe regression.** Neutralizing markers in the model's context does not break comment-don't-refile: `census_key` is computed deterministically in Python (`_census_key`, line 758) and dedupe is workflow-side (`gh issue list --search … in:body,comments`). The model never reads those markers.

**Known minor, accepted deliberately:** `"a --> b"` in prose becomes `"a -- > b"`. The alternative is context-sensitive parsing of attacker-controlled text — the game this change exists to stop playing.

## Also: the sync was shipping `0.7.NaN`

`notify-clud-bug.yml` parsed a version like `0.7.0-rc.26` with `split('.').map(Number)`, so `Number('0-rc')` → `NaN`. Version assignment is the **publisher's** act, not the sync's, so it is removed rather than patched; the CHANGELOG entry now lands under `[Unreleased]` and verification greps the commit SHA instead of a version.

## Scope note

This branch previously carried the **F3 actuator** workflows (`process-verdict.yml`, `notify-subscribers.yml`) — `logmind log` stages the working-tree union including untracked files (SPEC §15.1), which swept in 2,106 lines I had deliberately left uncommitted after they failed four adversarial rounds. They were inert where they sat (`issues`/`workflow_dispatch` only fire from the default branch, and zero runs fired), but would have gone live on merge. **Stripped — this branch is the ingestion fix only.**