### PR TITLE
Fix two self-update workflows red for six weeks + make future failures visible

### DIFF
--- a/.github/workflows/clud-bug-self-update.yml
+++ b/.github/workflows/clud-bug-self-update.yml
@@ -19,12 +19,34 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write   # needed for the failure-notification step (opens/comments an issue on `if: failure()`)
+  # NOTE: there is no `permissions:` knob that lets GITHUB_TOKEN push to
+  # .github/workflows/*.yml — GitHub rejects that at the git layer no
+  # matter what is granted here (confirmed by the remote's own rejection
+  # message: "refusing to allow a GitHub App to create or update workflow
+  # ... without `workflows` permission" — that scope only exists for PATs
+  # / GitHub Apps, not the ephemeral GITHUB_TOKEN). `clud-bug update`
+  # refreshes the workflow templates (clud-bug-review.yml,
+  # clud-bug-self-update.yml) on every real version bump, so a push with
+  # plain GITHUB_TOKEN fails once that diff touches a workflow file — see
+  # the "Run clud-bug update + open PR" step below, which uses the same
+  # LOGMIND_AUTO_REGEN_PAT secret that logmind-self-update.yml /
+  # regen-timeline.yml use for the identical reason when configured, and
+  # otherwise skips the PR gracefully with a `::notice::` instead of
+  # failing.
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Use the regen PAT when available so we can push refreshed
+          # workflow files. Falls through to GITHUB_TOKEN when absent —
+          # push still works for non-workflow-file changes but will be
+          # rejected for workflow-file changes (handled in the update
+          # step below via the smart skip).
+          token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v7
         with:
@@ -64,6 +86,7 @@ jobs:
           INSTALLED: ${{ steps.compare.outputs.installed }}
           LATEST: ${{ steps.compare.outputs.latest }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT: ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
         run: |
           BRANCH="clud-bug/self-update-${LATEST}"
           # Use github-actions[bot]'s real identity so commits resolve to a
@@ -81,6 +104,28 @@ jobs:
           # branch. We rely on `git diff` simply to detect *real* file changes
           # outside the manifest, and let the PR open either way.
           git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::No file changes after clud-bug update — nothing to PR."
+            exit 0
+          fi
+
+          # SMART WORKFLOW-SKIP (same shape as logmind-self-update.yml's).
+          # `clud-bug update` refreshes clud-bug-review.yml /
+          # clud-bug-self-update.yml on every real release, and GITHUB_TOKEN
+          # can never push a workflow-file change (GitHub blocks it at the
+          # git layer, not via any `permissions:` grant). Without a PAT
+          # configured, skip the release with a clear `::notice::` instead
+          # of committing/pushing and hitting the remote's hard rejection.
+          WORKFLOW_CHANGES=$(git diff --cached --name-only -- '.github/workflows/*.yml' '.github/workflows/*.yaml' || true)
+          if [ -n "$WORKFLOW_CHANGES" ] && [ -z "${PAT:-}" ]; then
+            echo "::notice title=Skipping workflow-touching release::This release would update workflow file(s):"
+            echo "::notice::$WORKFLOW_CHANGES"
+            echo "::notice::No \`LOGMIND_AUTO_REGEN_PAT\` is configured, so this run will skip pushing/opening a PR."
+            echo "::notice::To enable: configure a fine-grained PAT with Contents:write + Workflows:write + Pull-requests:write as the \`LOGMIND_AUTO_REGEN_PAT\` repo or org secret (same secret used by logmind-self-update.yml / regen-timeline.yml)."
+            echo "::notice::OR: skip this release by running \`npx clud-bug@${LATEST} update\` locally and opening a PR manually."
+            exit 0
+          fi
+
           git commit -m "🐛 Clud Bug self-update: ${INSTALLED} → ${LATEST}"
           git push -u origin "$BRANCH"
           # Build the PR body via printf so the embedded newlines don't break
@@ -90,6 +135,60 @@ jobs:
           # line and rejected the next line as an unexpected top-level value,
           # which broke `workflow_dispatch` on every consuming repo.
           BODY=$(printf 'Automated update from clud-bug %s → %s. Custom and skills.sh-installed specimens were left alone; only baseline specimens and the workflow templates were refreshed.\n\nReview the diff. To stay on this version permanently, add `"pinVersion": "%s"` to `.claude/skills/.clud-bug.json` before merging.' "${INSTALLED}" "${LATEST}" "${INSTALLED}")
-          gh pr create \
+          # `gh pr create` uses PAT too when available. Per-repo "Allow
+          # GitHub Actions to create and approve pull requests" setting
+          # blocks GITHUB_TOKEN from opening PRs on some org/repo configs.
+          # Using the PAT for this step too eliminates the second per-repo
+          # setup checkbox.
+          PR_TOKEN="${PAT:-${GH_TOKEN}}"
+          GH_TOKEN="$PR_TOKEN" gh pr create \
             --title "🐛 Clud Bug self-update: ${INSTALLED} → ${LATEST}" \
             --body "$BODY"
+
+      # Scheduled workflows fail silently — nobody watches a cron's status
+      # page. Surface it instead of leaving it red-and-unnoticed (this
+      # exact workflow ran red for 6+ consecutive weeks before anyone
+      # caught it). Idempotent: dedupes on an HTML-comment marker via
+      # `gh issue list --search`, same shape as skill-census.yml's
+      # census-key pattern — comments on the existing open issue instead
+      # of re-filing one every week.
+      - name: Notify on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- workflow-failure-key: clud-bug-self-update -->"
+          TITLE="Scheduled workflow failing: Clud Bug 🐛 Self-Update"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          gh label create automation-failure --color B60205 --force >/dev/null 2>&1 || true
+
+          # AUTHOR FILTER, NOT OPTIONAL. `--search` matches any issue whose body
+          # carries the marker, and anyone can open an issue containing it. Without
+          # this filter an outsider redirects every future failure notice onto an
+          # issue they control, silently defeating the visibility this step exists
+          # to provide. Only a workflow in THIS repo can author as github-actions,
+          # and changing a workflow requires a merged PR through the gate.
+          EXISTING=$(gh issue list --state open --search "\"${MARKER}\" in:body,comments" \
+            --json number,author 2>/dev/null \
+            | jq -r '[.[] | select(.author.is_bot == true and .author.login == "github-actions")][0].number // empty') || EXISTING=""
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still failing as of $(date -u +%Y-%m-%dT%H:%MZ): ${RUN_URL}"
+            echo "::notice::Commented on existing failure issue #${EXISTING}."
+          else
+            BODY_FILE="$(mktemp)"
+            {
+              echo "The **Clud Bug 🐛 Self-Update** scheduled workflow (\`.github/workflows/clud-bug-self-update.yml\`) failed."
+              echo ""
+              echo "Failing run: ${RUN_URL}"
+              echo ""
+              echo "This issue is commented on (not re-filed) on every subsequent failure — see the marker below."
+              echo ""
+              echo "$MARKER"
+            } > "$BODY_FILE"
+            gh issue create --title "$TITLE" --label automation-failure --body-file "$BODY_FILE"
+            echo "::notice::Filed new failure issue."
+          fi

--- a/.github/workflows/clud-bug-self-update.yml
+++ b/.github/workflows/clud-bug-self-update.yml
@@ -173,7 +173,7 @@ jobs:
           # and changing a workflow requires a merged PR through the gate.
           EXISTING=$(gh issue list --state open --search "\"${MARKER}\" in:body,comments" \
             --json number,author 2>/dev/null \
-            | jq -r '[.[] | select(.author.is_bot == true and .author.login == "github-actions")][0].number // empty') || EXISTING=""
+            | jq -r '[.[] | select(.author.is_bot == true and (.author.login | test("^(app/)?github-actions$")))][0].number // empty') || EXISTING=""
 
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body "Still failing as of $(date -u +%Y-%m-%dT%H:%MZ): ${RUN_URL}"

--- a/.github/workflows/logmind-self-update.yml
+++ b/.github/workflows/logmind-self-update.yml
@@ -244,7 +244,7 @@ jobs:
           # and changing a workflow requires a merged PR through the gate.
           EXISTING=$(gh issue list --state open --search "\"${MARKER}\" in:body,comments" \
             --json number,author 2>/dev/null \
-            | jq -r '[.[] | select(.author.is_bot == true and .author.login == "github-actions")][0].number // empty') || EXISTING=""
+            | jq -r '[.[] | select(.author.is_bot == true and (.author.login | test("^(app/)?github-actions$")))][0].number // empty') || EXISTING=""
 
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body "Still failing as of $(date -u +%Y-%m-%dT%H:%MZ): ${RUN_URL}"

--- a/.github/workflows/logmind-self-update.yml
+++ b/.github/workflows/logmind-self-update.yml
@@ -32,6 +32,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write   # needed for the failure-notification step (opens/comments an issue on `if: failure()`)
   # NOTE: there is NO `permissions:` knob that lets GITHUB_TOKEN push
   # to .github/workflows/*.yml — GitHub blocks that at the git layer
   # for security. When a logmind refresh would touch a workflow file
@@ -138,10 +139,19 @@ jobs:
       # `logmind init` (the refresh) runs against the same binary
       # version consumer repos will see after this workflow lands its
       # PR. The action's version tracks the LATEST step output.
+      #
+      # NOTE: `compare.outputs.latest` is a bare `X.Y.Z` (the leading `v`
+      # is stripped for the INSTALLED/LATEST string comparison above).
+      # setup-logmind's `resolve_version()` only accepts 'latest',
+      # 'v<MAJOR>', or 'v<MAJOR>.<MINOR>.<PATCH>' — passing the bare
+      # number through unprefixed fails with "unrecognized version
+      # input '<X.Y.Z>'" (root cause of every run since the first real
+      # version bump after this workflow's v1.1.0 rewrite). Re-add the
+      # `v` prefix here.
       - uses: thrillmade/setup-logmind@v1.0.1
         if: steps.compare.outputs.skip == 'false'
         with:
-          version: ${{ steps.compare.outputs.latest }}
+          version: v${{ steps.compare.outputs.latest }}
 
       - name: Run logmind init + open PR
         if: steps.compare.outputs.skip == 'false'
@@ -205,3 +215,51 @@ jobs:
           Refresh mode only touched workflow templates whose \`# logmind-template-version:\` marker is stale; \`docs/\`, \`.logmind/config.yml\`, and agent files were left alone.
 
           Review the diff. To stop self-updates after this, add \`pinVersion: \"${LATEST}\"\` to \`.logmind/config.yml\` before merging."
+
+      # Scheduled workflows fail silently — nobody watches a cron's status
+      # page. Surface it instead of leaving it red-and-unnoticed (this
+      # exact workflow ran red for 6+ consecutive weeks before anyone
+      # caught it). Idempotent: dedupes on an HTML-comment marker via
+      # `gh issue list --search`, same shape as skill-census.yml's
+      # census-key pattern — comments on the existing open issue instead
+      # of re-filing one every week.
+      - name: Notify on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- workflow-failure-key: logmind-self-update -->"
+          TITLE="Scheduled workflow failing: logmind self-update"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          gh label create automation-failure --color B60205 --force >/dev/null 2>&1 || true
+
+          # AUTHOR FILTER, NOT OPTIONAL. `--search` matches any issue whose body
+          # carries the marker, and anyone can open an issue containing it. Without
+          # this filter an outsider redirects every future failure notice onto an
+          # issue they control, silently defeating the visibility this step exists
+          # to provide. Only a workflow in THIS repo can author as github-actions,
+          # and changing a workflow requires a merged PR through the gate.
+          EXISTING=$(gh issue list --state open --search "\"${MARKER}\" in:body,comments" \
+            --json number,author 2>/dev/null \
+            | jq -r '[.[] | select(.author.is_bot == true and .author.login == "github-actions")][0].number // empty') || EXISTING=""
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still failing as of $(date -u +%Y-%m-%dT%H:%MZ): ${RUN_URL}"
+            echo "::notice::Commented on existing failure issue #${EXISTING}."
+          else
+            BODY_FILE="$(mktemp)"
+            {
+              echo "The **logmind self-update** scheduled workflow (\`.github/workflows/logmind-self-update.yml\`) failed."
+              echo ""
+              echo "Failing run: ${RUN_URL}"
+              echo ""
+              echo "This issue is commented on (not re-filed) on every subsequent failure — see the marker below."
+              echo ""
+              echo "$MARKER"
+            } > "$BODY_FILE"
+            gh issue create --title "$TITLE" --label automation-failure --body-file "$BODY_FILE"
+            echo "::notice::Filed new failure issue."
+          fi

--- a/docs/decisions-branches/fix__self-update-workflows.md
+++ b/docs/decisions-branches/fix__self-update-workflows.md
@@ -11,3 +11,14 @@
 
 ---
 
+## 2026-07-28 01:39 - Correct the failure-notify author filter: gh reports the login as app/github-actions
+
+**Reasoning:** Caught by testing the filter rather than reasoning about it. gh issue list --json author emits login 'app/github-actions' for a GITHUB_TOKEN-authored issue, not 'github-actions' -- verified against census issue #177, which is known bot-authored. My filter compared against the bare form, so it would have matched nothing, left EXISTING empty on every run, and filed a brand-new issue on each weekly failure. That is spam, and it is exactly the behaviour the dedupe exists to prevent -- the fix would have replaced six weeks of silence with an unbounded pile of duplicate issues. Now matches ^(app/)?github-actions$ so either spelling works, still requiring is_bot.
+
+**Alternatives considered:** Match on is_bot alone -- rejected, any bot could then claim the marker, which reopens the redirection hole the filter was added to close. Hardcode app/github-actions only -- rejected, gh has changed this rendering before and a tolerant anchored pattern costs nothing.
+
+**Implications:**
+- Proven by execution against live data, both directions: the corrected filter matches the one bot-authored issue (#177) and rejects all five human-authored ones. Third time this exact class has bitten -- an identity string that is almost but not quite what the API returns. The durable lesson is that an identity comparison must be tested against a real payload from the API that will be used at runtime, never against the name as a human would write it.
+
+---
+

--- a/docs/decisions-branches/fix__self-update-workflows.md
+++ b/docs/decisions-branches/fix__self-update-workflows.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-28 01:38 - Fix two self-update workflows red for six weeks, and make future failures visible
+
+**Reasoning:** Both scheduled workflows have failed every weekly run since early June and nobody noticed, because a scheduled workflow that fails notifies no one. Two distinct root causes, each confirmed from the actual run logs rather than from reading the YAML. logmind-self-update strips the v prefix for a string comparison and then passes the bare version straight to setup-logmind, whose resolver only accepts latest, vMAJOR, or vMAJOR.MINOR.PATCH -- so it errors on 1.2.0. It only surfaced once installed and latest diverged; before that the compare step short-circuited and never reached the bug. clud-bug-self-update is rejected by GitHub itself: GITHUB_TOKEN may never push changes to .github/workflows, and clud-bug update always refreshes those files. That is not grantable through the permissions block -- the repo already solved the identical problem for logmind-self-update with a PAT plus a graceful skip, and this workflow never got that treatment.
+
+**Alternatives considered:** Fix only the version prefix and leave the clud-bug push failing -- rejected, it would stay red and keep training everyone to ignore red. Grant a workflows permission in the permissions block -- not possible; no such GITHUB_TOKEN scope exists. File an issue and defer -- rejected, six weeks of silence is the argument against deferring.
+
+**Implications:**
+- Both now go green or skip deliberately. The failure-visibility step matters more than either fix: it opens one issue per workflow and comments on it thereafter, so the next six-week silence cannot happen. I added an AUTHOR FILTER to that dedupe search that the original did not have -- gh issue list --search matches any issue carrying the marker and anyone can open one, so without it an outsider redirects every future failure notice onto an issue they control. Same defect class as the census marker laundering closed in #178, found because I went looking for it. Upstream caveat: the buggy bodies may still ship in the logmind and clud-bug template sources, so a future successful self-update could reintroduce both bugs -- filing that separately.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (9 decisions)
+## 2026-07 (10 decisions)
 
-- **2026-07-28** — Close the census marker-laundering chain at both boundaries, and stop the sync from assigning versions *(fix/census-marker-laundering)* — [decisions-branches/fix__census-marker-laundering.md](decisions-branches/fix__census-marker-laundering.md)
-- *... 7 more decisions ...*
+- **2026-07-28** — Fix two self-update workflows red for six weeks, and make future failures visible *(fix/self-update-workflows)* — [decisions-branches/fix__self-update-workflows.md](decisions-branches/fix__self-update-workflows.md)
+- *... 8 more decisions ...*
 - **2026-07-16** — skill unification: three-layer design catalog — K0 splits/stubs/promotions, K1 dispatchers, K3 abstraction *(feat/skill-unification-k0-k1-k3)* — [decisions-branches/feat__skill-unification-k0-k1-k3.md](decisions-branches/feat__skill-unification-k0-k1-k3.md)
 
 ## 2026-06 (10 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (10 decisions)
+## 2026-07 (11 decisions)
 
-- **2026-07-28** — Fix two self-update workflows red for six weeks, and make future failures visible *(fix/self-update-workflows)* — [decisions-branches/fix__self-update-workflows.md](decisions-branches/fix__self-update-workflows.md)
-- *... 8 more decisions ...*
+- **2026-07-28** — Correct the failure-notify author filter: gh reports the login as app/github-actions *(fix/self-update-workflows)* — [decisions-branches/fix__self-update-workflows.md](decisions-branches/fix__self-update-workflows.md)
+- *... 9 more decisions ...*
 - **2026-07-16** — skill unification: three-layer design catalog — K0 splits/stubs/promotions, K1 dispatchers, K3 abstraction *(feat/skill-unification-k0-k1-k3)* — [decisions-branches/feat__skill-unification-k0-k1-k3.md](decisions-branches/feat__skill-unification-k0-k1-k3.md)
 
 ## 2026-06 (10 decisions)


### PR DESCRIPTION
Both scheduled self-update workflows have failed **every weekly run since early June** — six-plus consecutive silent failures. A scheduled workflow that fails notifies nobody, so nobody noticed.

Root causes confirmed from the **actual run logs**, not from reading the YAML. They are unrelated.

## 1. `logmind self-update` — a version-prefix bug

The compare step strips the `v` for string comparison, then passes that bare value straight into `setup-logmind`, whose resolver accepts only `latest`, `v<MAJOR>`, or `v<MAJOR>.<MINOR>.<PATCH>`:

```
##[error]unrecognized version input '1.2.0' — expected 'latest', 'v<MAJOR>', or 'v<MAJOR>.<MINOR>.<PATCH>'
```

Latent until `INSTALLED != LATEST` first became true — before that the compare step short-circuited to `skip=true` and never reached the bug. **Fix: one character.** `version: v${{ … }}`.

## 2. `Clud Bug Self-Update` — GitHub refuses the push

```
! [remote rejected] clud-bug/self-update-0.6.34
  (refusing to allow a GitHub App to create or update workflow
  `.github/workflows/clud-bug-review.yml` without `workflows` permission)
```

`clud-bug update` always refreshes those workflow files, and **`GITHUB_TOKEN` may never push `.github/workflows/*`** — there is no `workflows` key to add to `permissions:`. This repo already solved the identical problem for `logmind-self-update.yml` with a PAT + graceful skip; this workflow never got it. **Fix: adopt the same pattern** — skip deliberately with a `::notice::` when the diff touches a workflow and no PAT is configured, succeed when one is.

## 3. The part that matters most — failures become visible

Both gain an `if: failure()` step that opens **one** issue per workflow and comments on it thereafter. Six weeks of silence is the argument for this; the fixes alone would not prevent a recurrence.

**Dedupe carries an author filter the pattern it was copied from didn't have:**

```
--json number,author
| jq -r '[.[] | select(.author.is_bot == true and .author.login == "github-actions")][0].number // empty'
```

`gh issue list --search` matches **any** issue whose body carries the marker, and anyone can open one. Without this filter an outsider opens an issue containing `<!-- workflow-failure-key: … -->` and every future failure notice gets redirected onto an issue they control — silently defeating the visibility this step exists to create. Same defect class as the census marker-laundering closed in #178; found because I went looking for it after writing that fix.

Only a workflow **in this repo** can author as `github-actions`, and changing a workflow requires a merged PR through the gate.

## Verification

- Both files parse (`yaml.safe_load`).
- Neither workflow was triggered — both have `workflow_dispatch`, deliberately unused.

## ⚠️ Not fixed here — needs upstream

Both files carry `# …-template-version:` markers used by their own self-update engines to detect drift. **If the upstream `logmind` / `clud-bug` templates still ship the buggy bodies, a future successful self-update silently reintroduces both bugs.** Filing separately against those repos — flagging it here so this PR isn't mistaken for a durable fix.

Also untouched: `clud-bug-self-update`'s version compare currently wants to "update" `0.7.0-rc.20` → npm's `0.6.34`, i.e. a **downgrade**, because the installed build is an unpublished RC ahead of `latest`. Not the cause of the red state — a correct comparison would still hit the push wall — but a real oddity worth a maintainer's eye.