### PR TITLE
Drop review_mode from skill bodies and repoint dead SPEC sections

### DIFF
--- a/skills/reviewing-design-work/SKILL.md
+++ b/skills/reviewing-design-work/SKILL.md
@@ -33,7 +33,7 @@ the station's own skill to actually run it.
 
 Run the lenses in this order **within a review session**. (In clud-bug's pipeline the
 code lens and the design lenses are two *orthogonal, independently gated passes* —
-protocol SPEC §12.2 — so this ordering governs how a reviewer or orchestrator sequences
+SPEC §2.2 — so this ordering governs how a reviewer or orchestrator sequences
 the work and prioritizes findings, not a cross-pass scheduling constraint; the
 elite-bar-last placement is this dispatcher's guidance.)
 
@@ -73,7 +73,7 @@ spacing math: `oklch-color-space`, `apca-contrast`, `wcag-contrast`,
 | PR touches UI code, **no** visual surface change (routing, state wiring, refactor) | Code lens only; the rendered lenses stay silent. |
 | PR changes a visual surface (component, layout, styles, theme) | Code lens **and** rendered lenses, with `designing-elite-ui` running last after the objective lenses; the rendered pass is browser-driven — screenshots light + dark, states exercised — per `orchestrating-elite-agent-qa` (**REQUIRED BACKGROUND** for orchestrating that gate). |
 | Design spec / Figma handoff, **no code yet** | `web-interface-guidelines-review` applies to the spec; `designing-elite-ui` sets the bar the build must hit; the rendered lenses defer to post-build review. |
-| clud-bug-installed repo | The 4 dedicated design lenses (`design-system-consistency`, `frontend-a11y`, `visual-polish`, `designing-elite-ui`) are `kind: design` / `review_mode: dedicated` — they run as the separate **design pass** (protocol SPEC §12), never inline with the code review, and **only when the repo opts in**: `design.enabled: true` in `.clud-bug.json`, at least one design skill applies to the diff, and the trigger is a PR review (§12.3). Installation alone never fires the pass. |
+| clud-bug-installed repo | The 4 dedicated design lenses (`design-system-consistency`, `frontend-a11y`, `visual-polish`, `designing-elite-ui`) are `kind: design` — they run as the separate **design pass** (SPEC §4.8), never inline with the code review, and **only when the repo opts in**: the design pass is listed in `review.passes` in `.clud-bug.json`, at least one design skill applies to the diff, and the trigger is a pull request. Installation alone never fires the pass, and design findings are advisory unless the repo marks that pass blocking. |
 
 ## System-specific layers
 

--- a/skills/skill-frontmatter-quality/SKILL.md
+++ b/skills/skill-frontmatter-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-frontmatter-quality
-description: Review SKILL.md frontmatter for trigger surface, specificity, voice, and completeness. Apply on PRs that add or modify a skills/*/SKILL.md file. Catches descriptions that won't be discoverable, that wave at the topic instead of naming concrete buckets, that drift from the prescriptive house voice, or that omit fields like `review_mode` that downstream tools depend on.
+description: Review SKILL.md frontmatter for trigger surface, specificity, voice, and completeness. Apply on PRs that add or modify a skills/*/SKILL.md file. Catches descriptions that won't be discoverable, that wave at the topic instead of naming concrete buckets, that drift from the prescriptive house voice, or that omit fields downstream tools depend on.
 ---
 
 # Skill frontmatter quality
@@ -21,7 +21,7 @@ When reviewing a PR that adds or modifies a `skills/*/SKILL.md`, surface issues 
 
 5. **Frontmatter-body mismatch.** The frontmatter promises one thing (e.g. "flag X, Y, Z") and the body delivers a different list. Quote both. The description is the contract — fix whichever side is wrong.
 
-6. **Missing `review_mode` on a clud-bug-routed skill.** If the skill is intended for clud-bug review (lives in or is being added to `.claude/skills/`, or referenced from `.clud-bug.json`), and its frontmatter has no `review_mode: shared` or `review_mode: dedicated` field, flag it. Default-route ambiguity drops review coverage silently.
+6. **`kind` that does not match what the skill judges.** A skill about prose carrying `kind: rule` can be the sole citation for a finding about code behaviour, which SPEC §2.2 reserves for `rule` skills. Check the body against the value: code correctness → `rule`, shipped prose → `writing`, the rendered surface → `design`. An absent `kind` means `rule`, so omitting it on a prose skill has the same effect as declaring it wrongly.
 
 ## Do not surface
 


### PR DESCRIPTION
Follow-up to #181, which removed `review_mode` from all 46 skills' **frontmatter** and missed two **body** references. Caught by checking `main` after the merge rather than assuming the regex was complete.

## The one that mattered

`skill-frontmatter-quality:24` carried a **check rule** flagging any skill *missing* `review_mode`:

> **Missing `review_mode` on a clud-bug-routed skill.** … and its frontmatter has no `review_mode: shared` or `review_mode: dedicated` field, flag it.

After #181 that rule would flag **all 46 skills in this catalog as defective** — the skill that reviews frontmatter, generating a false positive on every skill in the repo it reviews.

Replaced with a check that is live: does `kind` match what the skill actually judges? A prose skill carrying `kind: rule` can be the sole citation for a finding about code behaviour, which SPEC §2.2 reserves for `rule` skills — and since an absent `kind` means `rule`, omitting it on a prose skill has the same effect as declaring it wrongly.

## Dead section numbers

`reviewing-design-work` cited **SPEC §12** and `§12.2` — sections that do not exist; the rewrite is organised by the loop. It also documented `design.enabled: true` as the opt-in, which is now the design pass being listed in `review.passes` (SPEC §4.8, §1.6).

Also added there: design findings are advisory unless the repository marks that pass blocking — the opt-in that was ruled in during the rewrite.

## Verified

`review_mode|design.enabled|SPEC §1[0-9]` → **zero** hits across all 46 skills.