### PR TITLE
Resync the skill-frontmatter-quality mirror — it taught a retired rule and omitted the live one

### DIFF
--- a/.claude/skills/skill-frontmatter-quality/SKILL.md
+++ b/.claude/skills/skill-frontmatter-quality/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: skill-frontmatter-quality
-description: Review SKILL.md frontmatter for trigger surface, specificity, voice, and completeness. Apply on PRs that add or modify a skills/*/SKILL.md file. Catches descriptions that won't be discoverable, that wave at the topic instead of naming concrete buckets, that drift from the prescriptive house voice, or that omit fields like `review_mode` that downstream tools depend on.
-review_mode: dedicated
+description: Review SKILL.md frontmatter for trigger surface, specificity, voice, and completeness. Apply on PRs that add or modify a skills/*/SKILL.md file. Catches descriptions that won't be discoverable, that wave at the topic instead of naming concrete buckets, that drift from the prescriptive house voice, or that omit fields downstream tools depend on.
 ---
 
 # Skill frontmatter quality
@@ -22,7 +21,7 @@ When reviewing a PR that adds or modifies a `skills/*/SKILL.md`, surface issues 
 
 5. **Frontmatter-body mismatch.** The frontmatter promises one thing (e.g. "flag X, Y, Z") and the body delivers a different list. Quote both. The description is the contract — fix whichever side is wrong.
 
-6. **Missing `review_mode` on a clud-bug-routed skill.** If the skill is intended for clud-bug review (lives in or is being added to `.claude/skills/`, or referenced from `.clud-bug.json`), and its frontmatter has no `review_mode: shared` or `review_mode: dedicated` field, flag it. Default-route ambiguity drops review coverage silently.
+6. **`kind` that does not match what the skill judges.** A skill about prose carrying `kind: rule` can be the sole citation for a finding about code behaviour, which SPEC §2.2 reserves for `rule` skills. Check the body against the value: code correctness → `rule`, shipped prose → `writing`, the rendered surface → `design`. An absent `kind` means `rule`, so omitting it on a prose skill has the same effect as declaring it wrongly.
 
 ## Do not surface
 

--- a/docs/decisions-branches/fix__resync-frontmatter-quality-mirror.md
+++ b/docs/decisions-branches/fix__resync-frontmatter-quality-mirror.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-15 07:55 - Resync the skill-frontmatter-quality mirror, and record that clud-bug-collaboration's divergence is by design
+
+**Reasoning:** The copy at .claude/skills/skill-frontmatter-quality/SKILL.md had drifted from its catalog source in three places. Two were cosmetic — a description mentioning review_mode and a review_mode: dedicated field, both referring to a schema key this repo deliberately removed. The third was not: rule 6 had been REPLACED. The catalog teaches that a kind value must match what the skill judges, which SPEC 2.2 makes load-bearing because only a rule skill may be the sole citation for a finding about code behaviour. The mirror taught a review_mode presence check instead. So the copy did not merely carry a stale field, it omitted a live rule and substituted a retired one. Resynced byte-for-byte from the catalog rather than hand-patched, so the two cannot disagree about anything.
+
+**Alternatives considered:** Delete the mirror instead of resyncing, since it is absent from .clud-bug.json's installed array and the resolved review plan names only four skills; hand-patch the three differences
+
+**Implications:**
+- clud-bug-collaboration also differs between catalog and mirror, by 224 lines, and that one is NOT drift. The mirror is 5,538 bytes, the catalog 8,719, and the catalog before #206 was 11,510 — so the mirror is neither the current nor the previous catalog version. It is clud-bug's own leaner baseline, which that project ships and owns; notify-clud-bug.yml exists to tell them when ours changes. Two artifacts sharing a name, not one that drifted
+- That kills byte-identity as the rule for the planned mirror-integrity gate. A gate requiring identical bytes would be permanently red on clud-bug-collaboration, which is a legitimate state. The gate must scope to non-baseline mirrors, or compare only against skills whose authoring home is the catalog
+- skill-frontmatter-quality is a mirror with a catalog counterpart that is absent from .clud-bug.json's installed array, and the resolved review plan names four skills without it. So it was not actively teaching reviewers the wrong rule — it was dead weight that looked like it was. The gate should flag an undeclared mirror for that reason
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (8 decisions)
+## 2026-08 (9 decisions)
 
-- **2026-08-14** — Extract the skill validator from its heredoc and give the repo a real test job *(chore/extract-skill-validator)* — [decisions-branches/chore__extract-skill-validator.md](decisions-branches/chore__extract-skill-validator.md)
-- *... 6 more decisions ...*
+- **2026-08-15** — Resync the skill-frontmatter-quality mirror, and record that clud-bug-collaboration's divergence is by design *(fix/resync-frontmatter-quality-mirror)* — [decisions-branches/fix__resync-frontmatter-quality-mirror.md](decisions-branches/fix__resync-frontmatter-quality-mirror.md)
+- *... 7 more decisions ...*
 - **2026-08-14** — Gate skill size with a shrink-only ratchet, and deprecate skillforge into the three skills that own its job *(feat/skill-depth-and-interlinking)* — [decisions-branches/feat__skill-depth-and-interlinking.md](decisions-branches/feat__skill-depth-and-interlinking.md)
 
 ## 2026-07 (13 decisions)


### PR DESCRIPTION
Closes #199. **The issue names the wrong file**, and the real one is worse than "stale".

## What #199 says vs what is true

The issue says `skills/skill-frontmatter-quality/SKILL.md` still carries `review_mode`. **It does not — the catalog copy is clean.** Control-tested: `grep -rn review_mode skills/` returns 0, while `grep -rn "^name:" skills/*/SKILL.md` returns 48, so the probe works.

The drifted file is **`.claude/skills/skill-frontmatter-quality/SKILL.md`** — a mirror sitting outside `validate-skills.yml`s trigger paths *and* outside its scan root. **Nothing checks it.**

## The third difference is the real one

Two were cosmetic — a description mentioning `review_mode`, and a `review_mode: dedicated` field, both naming a schema key this repo deliberately removed.

The third was not. **Rule 6 had been replaced:**

| | rule 6 |
|---|---|
| **catalog** | *"`kind` that does not match what the skill judges"* — a prose skill carrying `kind: rule` can be the sole citation for a finding about code behaviour, which SPEC 2.2 reserves for `rule` skills |
| **mirror** | *"Missing `review_mode` on a clud-bug-routed skill"* |

So the copy did not merely carry a stale field. **It omitted a live rule and substituted a retired one.** Resynced byte-for-byte rather than hand-patched, so the two cannot disagree about anything else.

## Two findings that change the planned mirror gate

**1. `clud-bug-collaboration` also differs — and it is NOT drift.**

```
mirror                    5,538 bytes
catalog                   8,719
catalog before #206      11,510
```

The mirror is neither the current nor the previous catalog version. It is clud-bugs own leaner **baseline**, shipped and owned by that project; `notify-clud-bug.yml` exists to tell them when ours changes. Two artifacts sharing a name, not one that drifted.

**That kills byte-identity as the rule for the mirror-integrity gate** — it would be permanently red on a legitimate state. The gate must scope to non-baseline mirrors, or compare only where `authoring_home` is the catalog.

**2. This mirror was dead weight, not an active hazard.**

`skill-frontmatter-quality` is absent from `.clud-bug.json`s `installed` array, and the resolved review plan names four skills without it. So it was **not** actively teaching reviewers the wrong rule; it looked like it was.

Resynced rather than deleted anyway: a file nothing reads costs nothing, and if anything ever does read it, it is now correct. But **the gate should flag an undeclared mirror** for exactly this reason — a copy that looks authoritative and is not.

## Audit of every mirror

```
OK  critical-issues-only          identical
OK  evidence-based-review         identical
OK  respect-existing-conventions  identical
--  clud-bug-collaboration        by design (baseline, owned by clud-bug)
XX  skill-frontmatter-quality     DRIFTED - fixed here
```