### PR TITLE
Delete the skill gate's paths filter — it never covered its own budget file

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -17,20 +17,29 @@ name: validate-skills
 # at -- a gate whose only way to fail is "push a branch and watch CI" has no
 # regression guard.
 
+# NO `paths:` FILTER, DELIBERATELY. Do not add one back.
+#
+# Two reasons, and the second is why deleting beats extending.
+#
+# 1. A filtered run interacts badly with `required_status_checks`. GitHub
+#    treats a filter-skipped check as "expected but never reported" and blocks
+#    the merge forever — the failure this repo's own check-doc-links.yml:8-12
+#    documents. No such rule exists here today, which is exactly why this is
+#    free to fix now and expensive later.
+#
+# 2. A filter has to enumerate every input, and the list only ever grows. This
+#    one already missed `skills/skill-size-budget.json` for its whole life —
+#    the size gate could not see edits to its own budget, so raising the limit
+#    never even triggered the gate it disabled. Extending the list fixes one
+#    instance and ships the next: the mirror gate will read `.claude/skills/**`,
+#    and the suite reads `tests/**`.
+#
+# The run is 11-13s over 48 files. Unconditional is cheaper than being wrong.
+# A committed test asserts this filter stays absent.
 on:
   pull_request:
-    paths:
-      - "skills/**/SKILL.md"
-      - "docs/placement-map.json"
-      - ".github/scripts/validate_skills.py"
-      - ".github/workflows/validate-skills.yml"
   push:
     branches: [main]
-    paths:
-      - "skills/**/SKILL.md"
-      - "docs/placement-map.json"
-      - ".github/scripts/validate_skills.py"
-      - ".github/workflows/validate-skills.yml"
 
 permissions:
   contents: read

--- a/docs/decisions-branches/fix__unfilter-the-skill-gate.md
+++ b/docs/decisions-branches/fix__unfilter-the-skill-gate.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-15 07:59 - Delete the skill gate's paths filter rather than extending it, and assert it stays gone
+
+**Reasoning:** The filter had to enumerate every input the validator reads, and the enumeration rotted. It never listed skills/skill-size-budget.json, so for the entire life of the size ratchet a pull request editing only the budget did not run the gate that budget configures — raising the limit could disable the gate without triggering it. Extending the list fixes that instance and ships the next: the planned mirror gate reads .claude/skills, the suite reads tests. The second reason is the one this repo already wrote down: GitHub treats a filter-skipped check as expected but never reported, so once a required_status_checks rule names it, a pull request touching none of the filtered paths blocks forever. check-doc-links.yml says exactly that at lines 8 to 12. agent-skills has zero required status checks today, which is why this is free to fix now and expensive later. The run is 11 to 13 seconds over 48 files.
+
+**Alternatives considered:** Add the missing paths one at a time, which fixes the instance and leaves the class; keep the filter and accept that a budget-only edit skips its own gate
+
+**Implications:**
+- A committed test now fails if any paths or paths-ignore key is reintroduced on validate-skills.yml or test.yml, with the reason in the assertion message. Mutation-tested: adding a filter back turns two tests red, removing it returns 112 green. So the next filter has to be argued for rather than merely typed
+- The test scopes to merge gates only. A scheduled refresh or a notifier has no such constraint and may filter freely; the list of unconditional gates is explicit in the test file
+- PyYAML resolves the workflow key on: to the boolean True under YAML 1.1, so the test looks the key up both ways. A naive doc.get('on') finds nothing and the assertion passes by vacuity — which would be a guard that never fires, the exact defect class this repo keeps finding
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -77,7 +77,8 @@ agent-skills
 ├── tests
 │   ├── conftest.py
 │   ├── test_validate_skills.py
-│   └── test_validate_skills_cli.py
+│   ├── test_validate_skills_cli.py
+│   └── test_workflow_triggers.py
 ├── .cursorrules
 ├── .gitattributes
 ├── .gitignore

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (9 decisions)
+## 2026-08 (10 decisions)
 
-- **2026-08-15** — Resync the skill-frontmatter-quality mirror, and record that clud-bug-collaboration's divergence is by design *(fix/resync-frontmatter-quality-mirror)* — [decisions-branches/fix__resync-frontmatter-quality-mirror.md](decisions-branches/fix__resync-frontmatter-quality-mirror.md)
-- *... 7 more decisions ...*
+- **2026-08-15** — Delete the skill gate's paths filter rather than extending it, and assert it stays gone *(fix/unfilter-the-skill-gate)* — [decisions-branches/fix__unfilter-the-skill-gate.md](decisions-branches/fix__unfilter-the-skill-gate.md)
+- *... 8 more decisions ...*
 - **2026-08-14** — Gate skill size with a shrink-only ratchet, and deprecate skillforge into the three skills that own its job *(feat/skill-depth-and-interlinking)* — [decisions-branches/feat__skill-depth-and-interlinking.md](decisions-branches/feat__skill-depth-and-interlinking.md)
 
 ## 2026-07 (13 decisions)

--- a/skills/apca-contrast/SKILL.md
+++ b/skills/apca-contrast/SKILL.md
@@ -66,9 +66,9 @@ If APCA passes but WCAG fails (or vice versa), reject the value and recompose.
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `oklch-color-space` for the underlying perceptual model and the APCACH library context.
-- **For multi-hue palette generation:** `chroma-harmonization` (the chroma cap at each Lc target is the cross-hue minimum).
-- **For the WCAG side:** `wcag-contrast` for the cross-check thresholds and large-text rules.
+- **REQUIRED BACKGROUND:** [oklch-color-space](../oklch-color-space/SKILL.md) for the underlying perceptual model and the APCACH library context.
+- **For multi-hue palette generation:** [chroma-harmonization](../chroma-harmonization/SKILL.md) (the chroma cap at each Lc target is the cross-hue minimum).
+- **For the WCAG side:** [wcag-contrast](../wcag-contrast/SKILL.md) for the cross-check thresholds and large-text rules.
 
 ## Sources
 

--- a/skills/chroma-harmonization/SKILL.md
+++ b/skills/chroma-harmonization/SKILL.md
@@ -17,7 +17,7 @@ Multi-hue palettes look unbalanced when one hue is more saturated than the rest 
 ## When NOT to use
 
 - Single-hue palettes (no other hues to harmonize against — chroma is unconstrained by the procedure).
-- Brand-spot or accent palettes where one hue *should* dominate. Use the `max` palette variant instead — see `oklch-color-space`.
+- Brand-spot or accent palettes where one hue *should* dominate. Use the `max` palette variant instead — see [oklch-color-space](../oklch-color-space/SKILL.md).
 - Palettes constrained to legacy sRGB-only output, where the narrower gamut shifts the bottleneck calculus back toward the classic blue-at-~220° limiter (the procedure still applies — Display P3 is the default target space; substitute the sRGB boundary deliberately for legacy-only catalogs).
 
 ## The algorithm
@@ -44,7 +44,7 @@ Average would push half the hues out of gamut at the bottleneck. Maximum would p
 
 ## Headroom rule
 
-Stay ≥ 10% below the computed ceiling. This headroom is for the **emission edge**, not the harmonization math itself: rounding when materializing the sRGB hex fallback (the compatibility export for legacy consumers — see `oklch-color-space`) and display-driver quirks can push a borderline-in-gamut P3 value out of gamut once flattened to 8-bit sRGB. A headroom margin prevents those fallback-materialization failures; it does not change the P3-native chroma math above.
+Stay ≥ 10% below the computed ceiling. This headroom is for the **emission edge**, not the harmonization math itself: rounding when materializing the sRGB hex fallback (the compatibility export for legacy consumers — see [oklch-color-space](../oklch-color-space/SKILL.md)) and display-driver quirks can push a borderline-in-gamut P3 value out of gamut once flattened to 8-bit sRGB. A headroom margin prevents those fallback-materialization failures; it does not change the P3-native chroma math above.
 
 ## Relationship to UDTS palette variants
 
@@ -68,9 +68,9 @@ If any hue clips at the ceiling or visually "pops," recompute with a tighter chr
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `oklch-color-space` — the OKLCH primitive, the gamut-mapping rule.
-- **For the contrast targets at each stop:** `apca-contrast` — the Lc targets that fix each L value.
-- **For starting-hue palette construction before harmonization:** `palette-relationships`.
+- **REQUIRED BACKGROUND:** [oklch-color-space](../oklch-color-space/SKILL.md) — the OKLCH primitive, the gamut-mapping rule.
+- **For the contrast targets at each stop:** [apca-contrast](../apca-contrast/SKILL.md) — the Lc targets that fix each L value.
+- **For starting-hue palette construction before harmonization:** [palette-relationships](../palette-relationships/SKILL.md).
 
 ## Sources
 

--- a/skills/clud-bug-collaboration/SKILL.md
+++ b/skills/clud-bug-collaboration/SKILL.md
@@ -54,12 +54,10 @@ it off to get unblocked. A person runs
 
 Skills live in `.claude/skills/<slug>/SKILL.md`. Three groups:
 
-- **Baseline** ([critical-issues-only](../critical-issues-only/SKILL.md),
-  [evidence-based-review](../evidence-based-review/SKILL.md),
-  [respect-existing-conventions](../respect-existing-conventions/SKILL.md)) —
-  managed by clud-bug; in-place edits are overwritten on the next
-  `clud-bug update`. To customize this repo, write a NEW skill rather than
-  mutating a baseline.
+- **Baseline** (`critical-issues-only`, `evidence-based-review`,
+  `respect-existing-conventions`) — managed by clud-bug; in-place edits are
+  overwritten on the next `clud-bug update`. To customize this repo, write a
+  NEW skill rather than mutating a baseline.
 - **From skills.sh** — `clud-bug add <source/name>`, tracked in
   `.claude/skills/.clud-bug.json`; `clud-bug refresh` syncs them.
 - **Custom** (anything not in the manifest) — yours, never touched by any
@@ -120,6 +118,13 @@ Explanation with quoted evidence.
 On a re-read trust the headline and skip the collapsed `Reasoning`; expand
 only when chasing a finding. A review with **zero findings** is that triage
 line (all zeros) plus the standard summary header — no per-finding bullets.
+
+## Agent invocation: `CLUD_BUG_QUIET=1` (v0.6.7+)
+
+From an agent session, not interactively, set `CLUD_BUG_QUIET=1` or pass
+`--quiet` / `-q`: each command emits one `ok <key-value>` line (e.g.
+`ok updated: @v0.6.11, N changed`) instead of progress chatter. Errors
+still hit stderr.
 
 ## Cost-control wiring
 

--- a/skills/clud-bug-collaboration/SKILL.md
+++ b/skills/clud-bug-collaboration/SKILL.md
@@ -54,10 +54,12 @@ it off to get unblocked. A person runs
 
 Skills live in `.claude/skills/<slug>/SKILL.md`. Three groups:
 
-- **Baseline** (`critical-issues-only`, `evidence-based-review`,
-  `respect-existing-conventions`) — managed by clud-bug; in-place edits are
-  overwritten on the next `clud-bug update`. To customize this repo, write a
-  NEW skill rather than mutating a baseline.
+- **Baseline** ([critical-issues-only](../critical-issues-only/SKILL.md),
+  [evidence-based-review](../evidence-based-review/SKILL.md),
+  [respect-existing-conventions](../respect-existing-conventions/SKILL.md)) —
+  managed by clud-bug; in-place edits are overwritten on the next
+  `clud-bug update`. To customize this repo, write a NEW skill rather than
+  mutating a baseline.
 - **From skills.sh** — `clud-bug add <source/name>`, tracked in
   `.claude/skills/.clud-bug.json`; `clud-bug refresh` syncs them.
 - **Custom** (anything not in the manifest) — yours, never touched by any
@@ -118,13 +120,6 @@ Explanation with quoted evidence.
 On a re-read trust the headline and skip the collapsed `Reasoning`; expand
 only when chasing a finding. A review with **zero findings** is that triage
 line (all zeros) plus the standard summary header — no per-finding bullets.
-
-## Agent invocation: `CLUD_BUG_QUIET=1` (v0.6.7+)
-
-From an agent session, not interactively, set `CLUD_BUG_QUIET=1` or pass
-`--quiet` / `-q`: each command emits one `ok <key-value>` line (e.g.
-`ok updated: @v0.6.11, N changed`) instead of progress chatter. Errors
-still hit stderr.
 
 ## Cost-control wiring
 

--- a/skills/component-sizing-principles/SKILL.md
+++ b/skills/component-sizing-principles/SKILL.md
@@ -6,7 +6,7 @@ description: |
 
 # Component sizing principles
 
-Component heights and icon sizes are **curated**, not formula-derived. A good ladder picks each height so it pairs cleanly with a font from the type scale, an icon from the icon set, and target-size requirements — and so each rung distinguishes visually from its neighbors. This skill names the universal principles; it is deliberately system-neutral. For one concrete instantiation — the per-density rung sets with their exact heights, fonts, and icon pairings — see `udts-component-sizing-ladders`.
+Component heights and icon sizes are **curated**, not formula-derived. A good ladder picks each height so it pairs cleanly with a font from the type scale, an icon from the icon set, and target-size requirements — and so each rung distinguishes visually from its neighbors. This skill names the universal principles; it is deliberately system-neutral. For one concrete instantiation — the per-density rung sets with their exact heights, fonts, and icon pairings — see [udts-component-sizing-ladders](../udts-component-sizing-ladders/SKILL.md).
 
 ## When to use
 
@@ -25,7 +25,7 @@ Component heights and icon sizes are **curated**, not formula-derived. A good la
 A formula `height → font-size → icon-size` produces *mathematically clean* values that *render poorly*. Curate the rungs by hand instead, for three reasons:
 
 - **Formula heights create visually indistinct rungs.** Heights at every fixed step (24, 28, 32, 36, ...) are hard to tell apart in a stack — adjacent rungs blur, so the ladder loses its job of signalling hierarchy.
-- **Off-scale font sizes clash with the typography system.** A formula lands on sizes like 13, 15, 17 that sit outside the modular scale and read as noise next to type set from `type-scale`.
+- **Off-scale font sizes clash with the typography system.** A formula lands on sizes like 13, 15, 17 that sit outside the modular scale and read as noise next to type set from [type-scale](../type-scale/SKILL.md).
 - **Off-curve icon sizes glitch at common zoom levels.** Icon sizes outside the curated set render with hairline artifacts at ordinary zoom.
 
 A curated ladder trades flexibility for visual distinguishability, predictable pairing, and target-size safety. Design systems benefit from less flexibility at this layer.
@@ -50,7 +50,7 @@ Interactive control heights clear **24 CSS px** per WCAG 2.5.8 AA Target Size (a
 - Start interactive rungs at the **first rung that clears the floor**.
 - In a roomier, lower-density mode whose smallest rung already exceeds 24 px, the entire ladder is interactive-safe.
 
-Failing this floor is one of the most common WCAG 2.2 audit misses. The floor itself is defined alongside the spacing primitives in `spacing-system`.
+Failing this floor is one of the most common WCAG 2.2 audit misses. The floor itself is defined alongside the spacing primitives in [spacing-system](../spacing-system/SKILL.md).
 
 ## Sibling consistency
 
@@ -77,10 +77,10 @@ After picking a rung:
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `spacing-system` — the unit primitives drive which density ladder applies, and the 24 CSS px WCAG 2.5.8 floor is defined there.
-- **For the font sizes paired with each rung:** `type-scale` — the per-rung font is taken from the canonical scale, not free-picked.
-- **For line-heights inside each rung:** `line-height-grid` — interactive controls use `lh-ui`, not `lh-prose`.
-- **For one system's worked rung sets:** `udts-component-sizing-ladders` — concrete per-density heights with their font and icon pairings (incubating L2 stub).
+- **REQUIRED BACKGROUND:** [spacing-system](../spacing-system/SKILL.md) — the unit primitives drive which density ladder applies, and the 24 CSS px WCAG 2.5.8 floor is defined there.
+- **For the font sizes paired with each rung:** [type-scale](../type-scale/SKILL.md) — the per-rung font is taken from the canonical scale, not free-picked.
+- **For line-heights inside each rung:** [line-height-grid](../line-height-grid/SKILL.md) — interactive controls use `lh-ui`, not `lh-prose`.
+- **For one system's worked rung sets:** [udts-component-sizing-ladders](../udts-component-sizing-ladders/SKILL.md) — concrete per-density heights with their font and icon pairings (incubating L2 stub).
 
 ## Sources
 

--- a/skills/component-sizing/SKILL.md
+++ b/skills/component-sizing/SKILL.md
@@ -59,7 +59,7 @@ UDTS ships three default density modes. Each is a 5-rung ladder labeled `xs` / `
 UDTS's canonical icon sizes: **12, 16, 24, 32, 40, 48**. Picked because:
 
 - These are the sizes at which Material Icons, Lucide, Heroicons, and Phosphor families render cleanly without hairline glitches.
-- They pair with the font-sizes from `type-scale` naturally (icon ≥ font-size at every rung; never undersized).
+- They pair with the font-sizes from [type-scale](../type-scale/SKILL.md) naturally (icon ≥ font-size at every rung; never undersized).
 - They subdivide into 4 px steps at the small end (where it matters for inline alignment) and 8 px steps at the large end (where it doesn't).
 
 **Don't formula-derive icon sizes.** A height-to-icon ratio (e.g. `icon = height / 2`) produces sizes like 14, 18, 22, 28 — every one of which renders worse than the curated neighbor.
@@ -96,9 +96,9 @@ Sibling controls in the same UI surface should share a rung — mixing `sm` and 
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `spacing-system` — the unit primitives (minor + major) drive which density mode applies, and the WCAG 2.5.8 floor lives there.
-- **For the font sizes paired with each rung:** `type-scale` — the per-rung font is taken from the canonical scale, not free-picked.
-- **For line-heights inside each rung:** `line-height-grid` — interactive controls use `lh-ui` (1.20), not `lh-prose`.
+- **REQUIRED BACKGROUND:** [spacing-system](../spacing-system/SKILL.md) — the unit primitives (minor + major) drive which density mode applies, and the WCAG 2.5.8 floor lives there.
+- **For the font sizes paired with each rung:** [type-scale](../type-scale/SKILL.md) — the per-rung font is taken from the canonical scale, not free-picked.
+- **For line-heights inside each rung:** [line-height-grid](../line-height-grid/SKILL.md) — interactive controls use `lh-ui` (1.20), not `lh-prose`.
 
 ## Verification
 

--- a/skills/consuming-a-design-system/SKILL.md
+++ b/skills/consuming-a-design-system/SKILL.md
@@ -18,27 +18,27 @@ You are wiring a product to a design system someone else owns: installing its to
 
 ## When NOT to use
 
-- Building, extending, or authoring a design system's own token catalog — load `designing-a-design-system` instead.
-- Reviewing a PR or rendered UI for compliance with a system's rules — load `reviewing-design-work` instead.
+- Building, extending, or authoring a design system's own token catalog — load [designing-a-design-system](../designing-a-design-system/SKILL.md) instead.
+- Reviewing a PR or rendered UI for compliance with a system's rules — load [reviewing-design-work](../reviewing-design-work/SKILL.md) instead.
 - This skill is for the consumer side of the relationship only; it assumes the system already exists.
 
 ## 1. Token discipline
 
 Product source references tokens through CSS variables or framework bindings — never raw hex, rgb, or px values. Picking the *right* token depends on reading its name correctly (class, kind, role) rather than guessing from context.
 
-**REQUIRED BACKGROUND:** `token-naming-conventions`
+**REQUIRED BACKGROUND:** [token-naming-conventions](../token-naming-conventions/SKILL.md)
 
-For user-facing string consistency alongside token consistency, see `brand-voice-review`.
+For user-facing string consistency alongside token consistency, see [brand-voice-review](../brand-voice-review/SKILL.md).
 
 ## 2. Composition rules
 
-Prefer semantic tokens over primitives in product code; theme and density are runtime axes, not name segments — see `token-naming-conventions`.
+Prefer semantic tokens over primitives in product code; theme and density are runtime axes, not name segments — see [token-naming-conventions](../token-naming-conventions/SKILL.md).
 
 ## 3. Install patterns
 
 A system publishes its source of truth as a DTCG snapshot; everything a product consumes — CSS variables, Tailwind config, iOS/Android/Flutter primitives — is transformed from that snapshot, not authored by hand.
 
-**REQUIRED BACKGROUND:** `dtcg-format`
+**REQUIRED BACKGROUND:** [dtcg-format](../dtcg-format/SKILL.md)
 
 Pin the version you consume. Treat the transform pipeline (snapshot → transformer → CSS variables / framework primitives) as the install contract: if a product hand-edits the generated output, the next re-generation silently reverts it.
 
@@ -46,9 +46,9 @@ Pin the version you consume. Treat the transform pipeline (snapshot → transfor
 
 Before bumping a consumed system's version, read its token-diff report rather than diffing files by eye — the diff is what tells you what actually changed at the resolved-value level, not just the source paths. Map every deprecated token to its replacement during the deprecation window; don't let a removal land as a silent breakage on the next major.
 
-**REQUIRED BACKGROUND:** `semver-design-tokens`
+**REQUIRED BACKGROUND:** [semver-design-tokens](../semver-design-tokens/SKILL.md)
 
-The bump severity tells you whether product code must change — see `semver-design-tokens`.
+The bump severity tells you whether product code must change — see [semver-design-tokens](../semver-design-tokens/SKILL.md).
 
 ## 5. Extending vs. consuming
 
@@ -56,20 +56,20 @@ The bump severity tells you whether product code must change — see `semver-des
 - **Fork only when you own the whole lifecycle.** A fork means you now maintain contrast floors, SemVer discipline, and migrations yourself; that's a heavier commitment than most product-specific needs justify.
 - **Upstream recurring extensions.** If the same product-local alias keeps getting reinvented across teams, that's a signal to propose it to the system's maintainers rather than let it live as private drift.
 
-One system's worked instantiation of a consumer-facing contract (incubating, not yet loadable): `udts-token-model`, `udts-linter-rules`.
+One system's worked instantiation of a consumer-facing contract (incubating, not yet loadable): [udts-token-model](../udts-token-model/SKILL.md), [udts-linter-rules](../udts-linter-rules/SKILL.md).
 
 ## Cross-references
 
 **L0 primitives:**
-- `token-naming-conventions` — name-shape rules for picking/validating a token by its name.
-- `dtcg-format` — the DTCG interchange format a system's snapshot is published in.
-- `semver-design-tokens` — SemVer bump severity and deprecation-cycle discipline for token releases.
-- `brand-voice-review` — microcopy voice consistency for user-facing strings.
+- [token-naming-conventions](../token-naming-conventions/SKILL.md) — name-shape rules for picking/validating a token by its name.
+- [dtcg-format](../dtcg-format/SKILL.md) — the DTCG interchange format a system's snapshot is published in.
+- [semver-design-tokens](../semver-design-tokens/SKILL.md) — SemVer bump severity and deprecation-cycle discipline for token releases.
+- [brand-voice-review](../brand-voice-review/SKILL.md) — microcopy voice consistency for user-facing strings.
 
 **L2 stances (incubating — parity markers, not yet loadable guidance):**
-- `udts-token-model` — one system's worked token taxonomy as a consumer-facing contract.
-- `udts-linter-rules` — one system's worked machine-enforceable consumer rules.
+- [udts-token-model](../udts-token-model/SKILL.md) — one system's worked token taxonomy as a consumer-facing contract.
+- [udts-linter-rules](../udts-linter-rules/SKILL.md) — one system's worked machine-enforceable consumer rules.
 
 **Sibling L1 dispatchers:**
-- `designing-a-design-system` — building or extending a system (not consuming one).
-- `reviewing-design-work` — reviewing design output against a system's rules.
+- [designing-a-design-system](../designing-a-design-system/SKILL.md) — building or extending a system (not consuming one).
+- [reviewing-design-work](../reviewing-design-work/SKILL.md) — reviewing design output against a system's rules.

--- a/skills/curating-a-skill-catalog/SKILL.md
+++ b/skills/curating-a-skill-catalog/SKILL.md
@@ -25,10 +25,10 @@ of Keep must survive an attempt to refute it, on evidence you can quote.
 ## When NOT to use
 
 - Reviewing a skill's *content* quality at nomination time — frontmatter
-  discoverability, voice, missing fields. That's `skill-frontmatter-quality`,
+  discoverability, voice, missing fields. That's [skill-frontmatter-quality](../skill-frontmatter-quality/SKILL.md),
   gated by the human editor, not a catalog-lifecycle question.
 - One-off authoring of a single new skill with no catalog-fit question in
-  play. That's `skillforge`.
+  play. That's [skillforge](../skillforge/SKILL.md).
 
 ## Lifecycle state machine
 
@@ -47,7 +47,7 @@ incubating → active → needs-revision → deprecated → retired
 
 Demotion follows the catalog's own SemVer deprecation discipline, not an
 ad-hoc cut: **warn in a minor, remove in a major, notify subscribers**. See
-`semver-design-tokens` for the underlying warn/remove cycle this borrows.
+[semver-design-tokens](../semver-design-tokens/SKILL.md) for the underlying warn/remove cycle this borrows.
 
 ## The six verdict kinds
 
@@ -88,7 +88,7 @@ descriptions before proposing anything new: when an existing skill's scope
 should absorb it, the verdict files as **Revise** on the owning skill (an
 amendment), not Gap. Only when no existing skill is the right home does it
 stay Gap — and the grounds must say why not. (Precedent: the dual-review gap
-that first had to check overlap with `orchestrating-elite-agent-qa` before
+that first had to check overlap with [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md) before
 forging.)
 
 Filed labels are symmetric candidates: a demote verdict files as
@@ -103,7 +103,7 @@ the prosecutor missed, a structural role overlooked, an L0 exemption that
 applies?). A verdict survives only if the defender's refutation fails. **A
 verdict whose grounds you cannot quote is a Keep** — no exceptions. This
 frame is the same refute-first adversarial-review discipline as
-`orchestrating-agent-delegation`; the census panel is one instance of a
+[orchestrating-agent-delegation](../orchestrating-agent-delegation/SKILL.md); the census panel is one instance of a
 delegated adversarial review, not a special case.
 
 ## Signals hierarchy
@@ -149,7 +149,7 @@ and stops. The editor decides.
    explicit structural-role check (or a stated L0-primitive grace).
 3. At most ~5 individual issues filed; the rest sit in one digest; more than
    ~6 total triggers a `revise:` against this rubric itself.
-4. Any deprecation cites `semver-design-tokens`'s warn-in-a-minor /
+4. Any deprecation cites [semver-design-tokens](../semver-design-tokens/SKILL.md)'s warn-in-a-minor /
    remove-in-a-major cycle, not an ad-hoc removal.
 5. No issue merges, deprecates, or promotes anything directly — output is
    proposals to the human editor only.
@@ -159,12 +159,12 @@ and stops. The editor decides.
 
 ## Cross-references
 
-- **For content quality at nomination:** `skill-frontmatter-quality` — judges
+- **For content quality at nomination:** [skill-frontmatter-quality](../skill-frontmatter-quality/SKILL.md) — judges
   a skill's prose and discoverability, not its catalog-lifecycle standing.
-- **For one-off skill authoring:** `skillforge` — creating a single new skill
+- **For one-off skill authoring:** [skillforge](../skillforge/SKILL.md) — creating a single new skill
   outside a census cycle.
-- **For the deprecation mechanics Demote follows:** `semver-design-tokens` —
+- **For the deprecation mechanics Demote follows:** [semver-design-tokens](../semver-design-tokens/SKILL.md) —
   warn-in-a-minor, remove-in-a-major, notify subscribers.
-- **For the adversarial review frame:** `orchestrating-agent-delegation` —
+- **For the adversarial review frame:** [orchestrating-agent-delegation](../orchestrating-agent-delegation/SKILL.md) —
   refute-first reviewer prompts; the census panel is a delegated adversarial
   review.

--- a/skills/design-token-naming/SKILL.md
+++ b/skills/design-token-naming/SKILL.md
@@ -22,7 +22,7 @@ UDTS names tokens so that an agent or linter can derive the token's class and co
 
 ## The prefix-loaded convention
 
-Every UDTS token name is `<prefix>-<role-or-kind>-<modifier>-<stop>-<state>`. The first segment — the **prefix** — declares the token's [class](https://github.com/thrillmade/agent-skills/tree/main/skills/apca-contrast) (contrast-bound vs free, defined in `apca-contrast`) and kind (text / surface / border / ui / illustration / decorative / brand-spot, defined in the UDTS spec).
+Every UDTS token name is `<prefix>-<role-or-kind>-<modifier>-<stop>-<state>`. The first segment — the **prefix** — declares the token's [class](https://github.com/thrillmade/agent-skills/tree/main/skills/apca-contrast) (contrast-bound vs free, defined in [apca-contrast](../apca-contrast/SKILL.md)) and kind (text / surface / border / ui / illustration / decorative / brand-spot, defined in the UDTS spec).
 
 ### Contrast-bound prefixes
 
@@ -103,9 +103,9 @@ Anti-pattern: `button-bg-primary-default-dense` (density in the name). Correct: 
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `oklch-color-space` for the hue-angle convention; `apca-contrast` for the contrast-class concept.
-- **For the DTCG schema that mirrors the prefix:** `dtcg-format` — the `$extensions.udts.class` and `$extensions.udts.kind` fields that redundantly encode what the prefix declares.
-- **For SemVer behavior on naming changes:** `semver-design-tokens` — renames are always major.
+- **REQUIRED BACKGROUND:** [oklch-color-space](../oklch-color-space/SKILL.md) for the hue-angle convention; [apca-contrast](../apca-contrast/SKILL.md) for the contrast-class concept.
+- **For the DTCG schema that mirrors the prefix:** [dtcg-format](../dtcg-format/SKILL.md) — the `$extensions.udts.class` and `$extensions.udts.kind` fields that redundantly encode what the prefix declares.
+- **For SemVer behavior on naming changes:** [semver-design-tokens](../semver-design-tokens/SKILL.md) — renames are always major.
 
 ## Verification
 

--- a/skills/designing-a-design-system/SKILL.md
+++ b/skills/designing-a-design-system/SKILL.md
@@ -17,72 +17,72 @@ You are building a design-token system from zero, or extending an existing one w
 
 ## When NOT to use
 
-- Reviewing rendered UI or a PR against a system's existing rules — load `reviewing-design-work` instead.
-- Wiring a product to a system someone else owns (install, theme, upgrade) — load `consuming-a-design-system` instead.
+- Reviewing rendered UI or a PR against a system's existing rules — load [reviewing-design-work](../reviewing-design-work/SKILL.md) instead.
+- Wiring a product to a system someone else owns (install, theme, upgrade) — load [consuming-a-design-system](../consuming-a-design-system/SKILL.md) instead.
 - This skill is for authoring the system itself, not for consuming or auditing one.
 
 ## 1. Naming & taxonomy
 
 Pick every token's name and class *before* color work starts — the prefix is the load-bearing decision every downstream station reads off (contrast obligation, DTCG extension fields, and SemVer severity of a rename all derive from the name).
 
-**REQUIRED BACKGROUND:** `token-naming-conventions`
+**REQUIRED BACKGROUND:** [token-naming-conventions](../token-naming-conventions/SKILL.md)
 
-One worked instantiation (incubating): `udts-naming-convention`.
+One worked instantiation (incubating): [udts-naming-convention](../udts-naming-convention/SKILL.md).
 
 ## 2. Color
 
 Pick the color space first, then set contrast targets with a dual-model stance — APCA as the primary generation target, WCAG as the legal-baseline cross-check — then generate the palette: hue-relationship math for the seed hue, chroma caps for equal-looking saturation across hues at each contrast stop.
 
-**REQUIRED BACKGROUND:** `oklch-color-space`, `apca-contrast`, `wcag-contrast`, `palette-relationships`, `chroma-harmonization`
+**REQUIRED BACKGROUND:** [oklch-color-space](../oklch-color-space/SKILL.md), [apca-contrast](../apca-contrast/SKILL.md), [wcag-contrast](../wcag-contrast/SKILL.md), [palette-relationships](../palette-relationships/SKILL.md), [chroma-harmonization](../chroma-harmonization/SKILL.md)
 
 ## 3. Non-color families
 
 Typography is a paired pair — a modular size ratio plus a line-height grid that snaps to the same units. Spacing follows a two-unit (minor + major) model. Component sizing is a curated, not formula-derived, height ladder that pairs with both.
 
-**REQUIRED BACKGROUND:** `type-scale`, `line-height-grid`, `spacing-system`, `component-sizing-principles`
+**REQUIRED BACKGROUND:** [type-scale](../type-scale/SKILL.md), [line-height-grid](../line-height-grid/SKILL.md), [spacing-system](../spacing-system/SKILL.md), [component-sizing-principles](../component-sizing-principles/SKILL.md)
 
-Worked instantiations (incubating): `udts-spacing-defaults`, `udts-component-sizing-ladders`.
+Worked instantiations (incubating): [udts-spacing-defaults](../udts-spacing-defaults/SKILL.md), [udts-component-sizing-ladders](../udts-component-sizing-ladders/SKILL.md).
 
 ## 4. Format & versioning
 
 Serialize the system to the DTCG interchange snapshot every consumer transforms from. Compute the version bump from the resolved-value diff, never from intuition.
 
-**REQUIRED BACKGROUND:** `dtcg-format`, `semver-design-tokens`
+**REQUIRED BACKGROUND:** [dtcg-format](../dtcg-format/SKILL.md), [semver-design-tokens](../semver-design-tokens/SKILL.md)
 
-Worked instantiations (incubating): `udts-dtcg-extensions`, `udts-semver-defaults`.
+Worked instantiations (incubating): [udts-dtcg-extensions](../udts-dtcg-extensions/SKILL.md), [udts-semver-defaults](../udts-semver-defaults/SKILL.md).
 
 ## 5. The elite bar
 
 A token system exists so shipped UI clears a concrete visual standard, not so tokens exist for their own sake. Encode that standard in the tokens plus a short design-system doc, so builders and critics measure against one shared source of truth.
 
-**REQUIRED BACKGROUND:** `designing-elite-ui`
+**REQUIRED BACKGROUND:** [designing-elite-ui](../designing-elite-ui/SKILL.md)
 
 ## 6. Testing & maintenance
 
 Snapshot-test against the DTCG export, lint contrast floors and alias cycles in CI, and run deprecation cycles per the SemVer discipline above rather than breaking consumers silently.
 
-One system's enforcement layer (incubating): `udts-linter-rules`.
+One system's enforcement layer (incubating): [udts-linter-rules](../udts-linter-rules/SKILL.md).
 
 ## Cross-references
 
 **L0 primitives:**
-- `token-naming-conventions` — token name/class/kind shape.
-- `oklch-color-space` — color space and hue-angle primitives.
-- `palette-relationships` — hue-relationship math for a seed hue.
-- `chroma-harmonization` — cross-hue chroma caps per contrast stop.
-- `type-scale` — modular type-size ratio and stops.
-- `line-height-grid` — grid-aligned line-height per font size.
-- `spacing-system` — two-unit (minor + major) spacing model.
-- `component-sizing-principles` — curated component-height and icon-size ladders.
-- `dtcg-format` — token interchange snapshot format.
-- `semver-design-tokens` — version-bump severity from a resolved-value diff.
+- [token-naming-conventions](../token-naming-conventions/SKILL.md) — token name/class/kind shape.
+- [oklch-color-space](../oklch-color-space/SKILL.md) — color space and hue-angle primitives.
+- [palette-relationships](../palette-relationships/SKILL.md) — hue-relationship math for a seed hue.
+- [chroma-harmonization](../chroma-harmonization/SKILL.md) — cross-hue chroma caps per contrast stop.
+- [type-scale](../type-scale/SKILL.md) — modular type-size ratio and stops.
+- [line-height-grid](../line-height-grid/SKILL.md) — grid-aligned line-height per font size.
+- [spacing-system](../spacing-system/SKILL.md) — two-unit (minor + major) spacing model.
+- [component-sizing-principles](../component-sizing-principles/SKILL.md) — curated component-height and icon-size ladders.
+- [dtcg-format](../dtcg-format/SKILL.md) — token interchange snapshot format.
+- [semver-design-tokens](../semver-design-tokens/SKILL.md) — version-bump severity from a resolved-value diff.
 
 **L0 critic lenses:**
-- `apca-contrast` — primary perceptual contrast target.
-- `wcag-contrast` — legal-baseline contrast cross-check.
-- `designing-elite-ui` — the visual quality bar tokens must clear.
+- [apca-contrast](../apca-contrast/SKILL.md) — primary perceptual contrast target.
+- [wcag-contrast](../wcag-contrast/SKILL.md) — legal-baseline contrast cross-check.
+- [designing-elite-ui](../designing-elite-ui/SKILL.md) — the visual quality bar tokens must clear.
 
-**L1 sibling dispatchers:** `reviewing-design-work`, `consuming-a-design-system`.
+**L1 sibling dispatchers:** [reviewing-design-work](../reviewing-design-work/SKILL.md), [consuming-a-design-system](../consuming-a-design-system/SKILL.md).
 
 **L2 stances (incubating — one system's worked instantiation, not yet loadable guidance):**
-- `udts-naming-convention`, `udts-spacing-defaults`, `udts-component-sizing-ladders`, `udts-dtcg-extensions`, `udts-semver-defaults`, `udts-linter-rules`.
+- [udts-naming-convention](../udts-naming-convention/SKILL.md), [udts-spacing-defaults](../udts-spacing-defaults/SKILL.md), [udts-component-sizing-ladders](../udts-component-sizing-ladders/SKILL.md), [udts-dtcg-extensions](../udts-dtcg-extensions/SKILL.md), [udts-semver-defaults](../udts-semver-defaults/SKILL.md), [udts-linter-rules](../udts-linter-rules/SKILL.md).

--- a/skills/dtcg-format/SKILL.md
+++ b/skills/dtcg-format/SKILL.md
@@ -139,21 +139,21 @@ Composite tokens can alias individual sub-values — useful for systems that sha
 - **Unknown namespaces are ignored by other tooling — that's the design.** Each tool reads only the namespaces it owns and passes the rest through untouched.
 - **Keep extension schemas versioned and documented.** Pin a schema version inside the bag so consumers can detect drift, and document the fields somewhere durable.
 
-One worked extension schema is UDTS's, documented in `udts-dtcg-extensions` (an incubating L2 stub).
+One worked extension schema is UDTS's, documented in [udts-dtcg-extensions](../udts-dtcg-extensions/SKILL.md) (an incubating L2 stub).
 
 ## Common pitfalls
 
 1. **Bare `value` / `type` keys.** Legacy systems use unprefixed names; DTCG ignores them as group children. Codemod before migration.
-2. **Top-level `$modes` key.** Multi-mode theming isn't in the DTCG draft. Valid approaches include a namespaced extension (see `udts-dtcg-extensions`), Style Dictionary's `$extensions["studio.tokens"].modes`, Tokens Studio sets, or per-mode files. Pick one explicitly.
+2. **Top-level `$modes` key.** Multi-mode theming isn't in the DTCG draft. Valid approaches include a namespaced extension (see [udts-dtcg-extensions](../udts-dtcg-extensions/SKILL.md)), Style Dictionary's `$extensions["studio.tokens"].modes`, Tokens Studio sets, or per-mode files. Pick one explicitly.
 3. **Alias cycles.** Not caught by the spec; CI must verify.
 4. **Composite-token sub-aliasing with wrong type.** `shadow.color` must reference a color token, not a dimension. Validators flag this; if your validator doesn't, your runtime will.
 5. **`$type` repeated on leaves under a typed group.** Redundant but not wrong; clean DTCG omits it.
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `token-naming-conventions` — the naming principles that extension metadata redundantly encodes.
-- **For the version-bump policy when DTCG files change:** `semver-design-tokens`.
-- **For one system's concrete extension schema:** `udts-dtcg-extensions` — the worked example.
+- **REQUIRED BACKGROUND:** [token-naming-conventions](../token-naming-conventions/SKILL.md) — the naming principles that extension metadata redundantly encodes.
+- **For the version-bump policy when DTCG files change:** [semver-design-tokens](../semver-design-tokens/SKILL.md).
+- **For one system's concrete extension schema:** [udts-dtcg-extensions](../udts-dtcg-extensions/SKILL.md) — the worked example.
 
 ## Verification
 

--- a/skills/line-height-grid/SKILL.md
+++ b/skills/line-height-grid/SKILL.md
@@ -89,8 +89,8 @@ Rounding down can put the resolved line-height *below* the natural ratio, which 
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `type-scale` — provides the font sizes this skill snaps line-heights for. The two skills are paired.
-- **For the unit primitive that drives snapping:** `spacing-system` — the minor / major grid is what `snap up to nearest minor-unit multiple` refers to.
+- **REQUIRED BACKGROUND:** [type-scale](../type-scale/SKILL.md) — provides the font sizes this skill snaps line-heights for. The two skills are paired.
+- **For the unit primitive that drives snapping:** [spacing-system](../spacing-system/SKILL.md) — the minor / major grid is what `snap up to nearest minor-unit multiple` refers to.
 
 ## Verification
 

--- a/skills/oklch-color-space/SKILL.md
+++ b/skills/oklch-color-space/SKILL.md
@@ -43,7 +43,7 @@ OUTPUT  oklch(L, c_max, 220) — hits Lc 75 against the near-white surface
 
 This applies to every contrast-bound token (text, surface, border, ui). For free-class tokens (illustration, decorative, brand-spot) the contrast obligation doesn't apply — compose freely.
 
-**REQUIRED BACKGROUND:** Use `apca-contrast` for the Lc target table (Lc 90 fluent body, 75 body minimum, 60 secondary, etc.) and the WCAG 2.2 AA cross-check rule.
+**REQUIRED BACKGROUND:** Use [apca-contrast](../apca-contrast/SKILL.md) for the Lc target table (Lc 90 fluent body, 75 body minimum, 60 secondary, etc.) and the WCAG 2.2 AA cross-check rule.
 
 ## Gamut mapping
 
@@ -63,9 +63,9 @@ Practical rule for picking a chroma cap: compose against the **Display P3 ceilin
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `apca-contrast` for the Lc target table, when contrast Lc applies, and the WCAG cross-check.
-- **REQUIRED for multi-hue palettes:** `chroma-harmonization` — cap chroma at the lowest-achievable value across all hues at the same stop, so no hue is a neon outlier.
-- **For starting-hue palette construction:** `palette-relationships` — analogous, complementary, triadic, etc., as hue-angle math.
+- **REQUIRED BACKGROUND:** [apca-contrast](../apca-contrast/SKILL.md) for the Lc target table, when contrast Lc applies, and the WCAG cross-check.
+- **REQUIRED for multi-hue palettes:** [chroma-harmonization](../chroma-harmonization/SKILL.md) — cap chroma at the lowest-achievable value across all hues at the same stop, so no hue is a neon outlier.
+- **For starting-hue palette construction:** [palette-relationships](../palette-relationships/SKILL.md) — analogous, complementary, triadic, etc., as hue-angle math.
 
 ## Verification
 
@@ -83,4 +83,4 @@ If any of the four fails, fix the value before emitting the token.
 - [Björn Ottosson's OKLCH spec](https://bottosson.github.io/posts/oklab/) — the math.
 - [APCACH library](https://github.com/antiflasher/apcach) — inverse composition primitive.
 - [oklch.com](https://oklch.com) — interactive picker for sanity-checks.
-- The `apca-contrast` and `chroma-harmonization` skills in this catalog.
+- The [apca-contrast](../apca-contrast/SKILL.md) and [chroma-harmonization](../chroma-harmonization/SKILL.md) skills in this catalog.

--- a/skills/orchestrating-elite-agent-qa/SKILL.md
+++ b/skills/orchestrating-elite-agent-qa/SKILL.md
@@ -15,7 +15,7 @@ One build pass plus one agreeable review ships bugs. Quality comes from three in
 
 Gate the merge on all three. Each catches a class the others miss.
 
-(The general delegation mechanics beneath this pipeline — brief structure, model tiering, trust-but-verify — live in `orchestrating-agent-delegation`; this skill is the UI-quality-gate specialization.)
+(The general delegation mechanics beneath this pipeline — brief structure, model tiering, trust-but-verify — live in [orchestrating-agent-delegation](../orchestrating-agent-delegation/SKILL.md); this skill is the UI-quality-gate specialization.)
 
 ## The Per-Slice Pipeline (run in order)
 
@@ -53,7 +53,7 @@ Gate the merge on all three. Each catches a class the others miss.
 
 ## Cross-references
 
-- **For a run that outlives one sitting:** `session-heartbeat` — this skill says which gates a slice must clear, but nothing about a pipeline continuing across a usage-limit reset or a resumed session. That is where pacing, the checkpoint, and re-firing a gate whose producer was killed mid-flight live.
+- **For a run that outlives one sitting:** [session-heartbeat](../session-heartbeat/SKILL.md) — this skill says which gates a slice must clear, but nothing about a pipeline continuing across a usage-limit reset or a resumed session. That is where pacing, the checkpoint, and re-firing a gate whose producer was killed mid-flight live.
 
 ## Deploying This Skill (per writing-skills)
 

--- a/skills/palette-relationships/SKILL.md
+++ b/skills/palette-relationships/SKILL.md
@@ -15,7 +15,7 @@ When a designer hands an agent a single starting hue and asks for "the rest of t
 
 ## When NOT to use
 
-- The palette is already specified (all hues given). Use `chroma-harmonization` to balance them, not this skill.
+- The palette is already specified (all hues given). Use [chroma-harmonization](../chroma-harmonization/SKILL.md) to balance them, not this skill.
 - The brief is for a single-hue system (just stops of one palette). No relationship to pick.
 
 ## The relationships
@@ -70,9 +70,9 @@ After picking hues:
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `oklch-color-space` — hues are OKLCH angles; the relationship math operates on those.
-- **For palette balance after picking hues:** `chroma-harmonization` — cap chroma at the cross-hue minimum.
-- **For contrast targets across stops:** `apca-contrast`.
+- **REQUIRED BACKGROUND:** [oklch-color-space](../oklch-color-space/SKILL.md) — hues are OKLCH angles; the relationship math operates on those.
+- **For palette balance after picking hues:** [chroma-harmonization](../chroma-harmonization/SKILL.md) — cap chroma at the cross-hue minimum.
+- **For contrast targets across stops:** [apca-contrast](../apca-contrast/SKILL.md).
 
 ## Sources
 

--- a/skills/reviewing-design-work/SKILL.md
+++ b/skills/reviewing-design-work/SKILL.md
@@ -19,14 +19,14 @@ the station's own skill to actually run it.
 - Reviewing a PR that adds or changes UI code, styles, tokens, or theme.
 - Critiquing a rendered surface or screenshot (light and dark).
 - Reviewing a design spec or a Figma → code handoff before the build lands.
-- Running the design-critic gate on a slice (see `orchestrating-elite-agent-qa`).
+- Running the design-critic gate on a slice (see [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md)).
 
 ## When NOT to use
 
 - **Building a design system** (tokens, scales, palettes, naming) — load
-  `designing-a-design-system`, not this dispatcher.
+  [designing-a-design-system](../designing-a-design-system/SKILL.md), not this dispatcher.
 - **Consuming a design system** (wiring an existing token set into a product) — load
-  `consuming-a-design-system`.
+  [consuming-a-design-system](../consuming-a-design-system/SKILL.md).
 - Pure logic / backend review with no design surface — this dispatcher adds nothing.
 
 ## Lens order
@@ -37,58 +37,58 @@ SPEC §2.2 — so this ordering governs how a reviewer or orchestrator sequences
 the work and prioritizes findings, not a cross-pass scheduling constraint; the
 elite-bar-last placement is this dispatcher's guidance.)
 
-1. **Code + markup lens — `web-interface-guidelines-review`.** The opinionated rule set
+1. **Code + markup lens — [web-interface-guidelines-review](../web-interface-guidelines-review/SKILL.md).** The opinionated rule set
    (WIG, Material 3, Radix) plus token-driven contrast/typography/spacing rules: APCA-preferred
    contrast cross-checked with WCAG 2.2 AA, atomic typography class, token-not-raw-hex,
    verb-noun labels, the focus-ring contract, the 24 CSS px interactive floor. Findings
-   cite rules, not vibes. **REQUIRED BACKGROUND:** `web-interface-guidelines-review`.
+   cite rules, not vibes. **REQUIRED BACKGROUND:** [web-interface-guidelines-review](../web-interface-guidelines-review/SKILL.md).
 2. **Rendered-surface lenses — on screenshots in light AND dark.** Three lenses judge the
    render itself:
-   - **`design-system-consistency`** — token / scale / color-discipline drift visible on
+   - **[design-system-consistency](../design-system-consistency/SKILL.md)** — token / scale / color-discipline drift visible on
      the render, not just the source line.
-   - **`frontend-a11y`** — contrast ratios, focus visibility, tap targets, semantics, and
+   - **[frontend-a11y](../frontend-a11y/SKILL.md)** — contrast ratios, focus visibility, tap targets, semantics, and
      motion on the rendered surface, in both themes.
-   - **`visual-polish`** — alignment, optical centering, spacing rhythm, glyph/pattern
+   - **[visual-polish](../visual-polish/SKILL.md)** — alignment, optical centering, spacing rhythm, glyph/pattern
      quality, state coverage, theme parity ("fine but not elite" counts).
 
-   **REQUIRED BACKGROUND:** `design-system-consistency`, `frontend-a11y`, `visual-polish`.
-3. **Opinion lens last — `designing-elite-ui`.** The concrete elite / Figma-grade bar
+   **REQUIRED BACKGROUND:** [design-system-consistency](../design-system-consistency/SKILL.md), [frontend-a11y](../frontend-a11y/SKILL.md), [visual-polish](../visual-polish/SKILL.md).
+3. **Opinion lens last — [designing-elite-ui](../designing-elite-ui/SKILL.md).** The concrete elite / Figma-grade bar
    (one-axis color, APCA-gated contrast, floating stable chrome, dark verified). It runs
    last because it is the subjective bar; the objective violations should already be
-   caught. **REQUIRED BACKGROUND:** `designing-elite-ui`.
+   caught. **REQUIRED BACKGROUND:** [designing-elite-ui](../designing-elite-ui/SKILL.md).
 
 **Rationale:** objective rule violations before subjective bar judgments, so findings land
 in severity order — and the cheap code lens runs before the browser-driving rendered
 passes.
 
 Each lens judges against the L0 primitives it does not re-derive — the color / type /
-spacing math: `oklch-color-space`, `apca-contrast`, `wcag-contrast`,
-`palette-relationships`, `chroma-harmonization`, `type-scale`, `line-height-grid`,
-`token-naming-conventions`, `component-sizing-principles`.
+spacing math: [oklch-color-space](../oklch-color-space/SKILL.md), [apca-contrast](../apca-contrast/SKILL.md), [wcag-contrast](../wcag-contrast/SKILL.md),
+[palette-relationships](../palette-relationships/SKILL.md), [chroma-harmonization](../chroma-harmonization/SKILL.md), [type-scale](../type-scale/SKILL.md), [line-height-grid](../line-height-grid/SKILL.md),
+[token-naming-conventions](../token-naming-conventions/SKILL.md), [component-sizing-principles](../component-sizing-principles/SKILL.md).
 
 ## What fires when
 
 | Situation | What fires |
 |---|---|
 | PR touches UI code, **no** visual surface change (routing, state wiring, refactor) | Code lens only; the rendered lenses stay silent. |
-| PR changes a visual surface (component, layout, styles, theme) | Code lens **and** rendered lenses, with `designing-elite-ui` running last after the objective lenses; the rendered pass is browser-driven — screenshots light + dark, states exercised — per `orchestrating-elite-agent-qa` (**REQUIRED BACKGROUND** for orchestrating that gate). |
-| Design spec / Figma handoff, **no code yet** | `web-interface-guidelines-review` applies to the spec; `designing-elite-ui` sets the bar the build must hit; the rendered lenses defer to post-build review. |
-| clud-bug-installed repo | The 4 dedicated design lenses (`design-system-consistency`, `frontend-a11y`, `visual-polish`, `designing-elite-ui`) are `kind: design` — they run as the separate **design pass** (SPEC §4.8), never inline with the code review, and **only when the repo opts in**: the design pass is listed in `review.passes` in `.clud-bug.json`, at least one design skill applies to the diff, and the trigger is a pull request. Installation alone never fires the pass, and design findings are advisory unless the repo marks that pass blocking. |
+| PR changes a visual surface (component, layout, styles, theme) | Code lens **and** rendered lenses, with [designing-elite-ui](../designing-elite-ui/SKILL.md) running last after the objective lenses; the rendered pass is browser-driven — screenshots light + dark, states exercised — per [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md) (**REQUIRED BACKGROUND** for orchestrating that gate). |
+| Design spec / Figma handoff, **no code yet** | [web-interface-guidelines-review](../web-interface-guidelines-review/SKILL.md) applies to the spec; [designing-elite-ui](../designing-elite-ui/SKILL.md) sets the bar the build must hit; the rendered lenses defer to post-build review. |
+| clud-bug-installed repo | The 4 dedicated design lenses ([design-system-consistency](../design-system-consistency/SKILL.md), [frontend-a11y](../frontend-a11y/SKILL.md), [visual-polish](../visual-polish/SKILL.md), [designing-elite-ui](../designing-elite-ui/SKILL.md)) are `kind: design` — they run as the separate **design pass** (SPEC §4.8), never inline with the code review, and **only when the repo opts in**: the design pass is listed in `review.passes` in `.clud-bug.json`, at least one design skill applies to the diff, and the trigger is a pull request. Installation alone never fires the pass, and design findings are advisory unless the repo marks that pass blocking. |
 
 ## System-specific layers
 
 These lenses are generic — they compose with a system's own opinionated stance rather than
-replacing it. `udts-review` is one system's worked instantiation (incubating): the
+replacing it. [udts-review](../udts-review/SKILL.md) is one system's worked instantiation (incubating): the
 UDTS-specific rules a reviewer checks *on top of* this dispatcher. Treat it as a parity
 marker pointing at tokenomics, not as loadable guidance yet.
 
 ## Cross-references
 
-- **L0 primitives:** `oklch-color-space`, `apca-contrast`, `wcag-contrast`,
-  `palette-relationships`, `chroma-harmonization`, `type-scale`, `line-height-grid`,
-  `token-naming-conventions`, `component-sizing-principles`.
-- **L0 critic lenses:** `web-interface-guidelines-review`, `design-system-consistency`,
-  `frontend-a11y`, `visual-polish`, `designing-elite-ui`; and `orchestrating-elite-agent-qa`
+- **L0 primitives:** [oklch-color-space](../oklch-color-space/SKILL.md), [apca-contrast](../apca-contrast/SKILL.md), [wcag-contrast](../wcag-contrast/SKILL.md),
+  [palette-relationships](../palette-relationships/SKILL.md), [chroma-harmonization](../chroma-harmonization/SKILL.md), [type-scale](../type-scale/SKILL.md), [line-height-grid](../line-height-grid/SKILL.md),
+  [token-naming-conventions](../token-naming-conventions/SKILL.md), [component-sizing-principles](../component-sizing-principles/SKILL.md).
+- **L0 critic lenses:** [web-interface-guidelines-review](../web-interface-guidelines-review/SKILL.md), [design-system-consistency](../design-system-consistency/SKILL.md),
+  [frontend-a11y](../frontend-a11y/SKILL.md), [visual-polish](../visual-polish/SKILL.md), [designing-elite-ui](../designing-elite-ui/SKILL.md); and [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md)
   (the QA gate that drives the browser-driven rendered pass).
-- **L1 sibling dispatchers:** `designing-a-design-system`, `consuming-a-design-system`.
-- **L2 stances (incubating):** `udts-review`.
+- **L1 sibling dispatchers:** [designing-a-design-system](../designing-a-design-system/SKILL.md), [consuming-a-design-system](../consuming-a-design-system/SKILL.md).
+- **L2 stances (incubating):** [udts-review](../udts-review/SKILL.md).

--- a/skills/semver-design-tokens/SKILL.md
+++ b/skills/semver-design-tokens/SKILL.md
@@ -68,7 +68,7 @@ Source-path diffs miss this. A linter that only diffs source paths reports "no c
 
 ## Pre-1.0 relaxation
 
-Per the standard SemVer caveat, `0.x.y` is "anything goes." A `0.x` catalog is still shaping its contract, so document an **explicit** relaxation rather than leave the behavior undefined. One reasonable relaxation (the one UDTS documents — see `udts-semver-defaults`):
+Per the standard SemVer caveat, `0.x.y` is "anything goes." A `0.x` catalog is still shaping its contract, so document an **explicit** relaxation rather than leave the behavior undefined. One reasonable relaxation (the one UDTS documents — see [udts-semver-defaults](../udts-semver-defaults/SKILL.md)):
 
 - **Removals are minor**, not major. Pre-1.0 catalogs are still actively shaping their contract; removing tokens that turn out to be wrong shouldn't burn a major.
 - **Renames remain minor** for the same reason.
@@ -110,9 +110,9 @@ A theme's resolved values changing is a separate axis:
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `dtcg-format` — the snapshot format the diff operates on.
-- **For name conventions that the bump rules reference:** `token-naming-conventions`.
-- **For one system's concrete policy choices (worked example):** `udts-semver-defaults`.
+- **REQUIRED BACKGROUND:** [dtcg-format](../dtcg-format/SKILL.md) — the snapshot format the diff operates on.
+- **For name conventions that the bump rules reference:** [token-naming-conventions](../token-naming-conventions/SKILL.md).
+- **For one system's concrete policy choices (worked example):** [udts-semver-defaults](../udts-semver-defaults/SKILL.md).
 
 ## Verification
 
@@ -128,5 +128,5 @@ For each release candidate:
 ## Sources
 
 - [SemVer 2.0.0](https://semver.org/) — the underlying spec.
-- The `udts-semver-defaults` skill — one system's concrete versioning-policy choices (incubating).
+- The [udts-semver-defaults](../udts-semver-defaults/SKILL.md) skill — one system's concrete versioning-policy choices (incubating).
 - [Style Dictionary's release notes](https://github.com/amzn/style-dictionary/releases) — practitioner reference for how token systems version in practice.

--- a/skills/session-heartbeat/SKILL.md
+++ b/skills/session-heartbeat/SKILL.md
@@ -8,8 +8,6 @@ description: |
 
 A long autonomous run rarely fails at the limit. It fails at the **last dispatch before** the limit — the one nobody could finish. A heartbeat is a self-paced recurring wake that turns the ceiling from a crash into a scheduled pause: every beat reads standing before spending anything, and ends with enough state on disk for another session to take the run over.
 
-This is the **mechanism**. `unattended-operation` is the policy layered on it for runs a human hands over; it inherits everything here and restates none of it.
-
 ## When to use
 
 - An orchestrator is rolling through a multi-slice plan over hours.
@@ -22,7 +20,6 @@ This is the **mechanism**. `unattended-operation` is the policy layered on it fo
 
 - One task inside one sitting. A beat costs a full context read; below the horizon where a limit or handoff is plausible it buys nothing.
 - Waiting on a single result your harness will notify you about. That is a notification, not a schedule.
-- The run is unattended by human handover — load `unattended-operation` too. This skill has no rules about what may not happen while nobody watches.
 
 ## Each beat, in this order
 
@@ -102,9 +99,9 @@ Each of these leaves a green tree and reports nothing.
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `orchestrating-agent-delegation` — brief shape, model tiering, verify-every-"done"-against-the-diff, and the file-isolation rules the occupancy slot records. This skill paces dispatches; that one is how to write and verify one.
-- **For unattended runs:** `unattended-operation` — the policy layer (scope, hard stops, what a wake does *not* authorize, the handback digest). Load both when a human hands the session over.
-- **For the gates a resumed slice must re-fire:** `orchestrating-elite-agent-qa`.
+- **REQUIRED BACKGROUND:** [orchestrating-agent-delegation](../orchestrating-agent-delegation/SKILL.md) — brief shape, model tiering, verify-every-"done"-against-the-diff, and the file-isolation rules the occupancy slot records. This skill paces dispatches; that one is how to write and verify one.
+- **For unattended runs:** [unattended-operation](../unattended-operation/SKILL.md) — the policy layer (scope, hard stops, what a wake does *not* authorize, the handback digest). Load both when a human hands the session over.
+- **For the gates a resumed slice must re-fire:** [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md).
 
 ## Sources
 

--- a/skills/session-heartbeat/SKILL.md
+++ b/skills/session-heartbeat/SKILL.md
@@ -8,6 +8,8 @@ description: |
 
 A long autonomous run rarely fails at the limit. It fails at the **last dispatch before** the limit — the one nobody could finish. A heartbeat is a self-paced recurring wake that turns the ceiling from a crash into a scheduled pause: every beat reads standing before spending anything, and ends with enough state on disk for another session to take the run over.
 
+This is the **mechanism**. `unattended-operation` is the policy layered on it for runs a human hands over; it inherits everything here and restates none of it.
+
 ## When to use
 
 - An orchestrator is rolling through a multi-slice plan over hours.
@@ -20,6 +22,7 @@ A long autonomous run rarely fails at the limit. It fails at the **last dispatch
 
 - One task inside one sitting. A beat costs a full context read; below the horizon where a limit or handoff is plausible it buys nothing.
 - Waiting on a single result your harness will notify you about. That is a notification, not a schedule.
+- The run is unattended by human handover — load `unattended-operation` too. This skill has no rules about what may not happen while nobody watches.
 
 ## Each beat, in this order
 
@@ -99,9 +102,9 @@ Each of these leaves a green tree and reports nothing.
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** [orchestrating-agent-delegation](../orchestrating-agent-delegation/SKILL.md) — brief shape, model tiering, verify-every-"done"-against-the-diff, and the file-isolation rules the occupancy slot records. This skill paces dispatches; that one is how to write and verify one.
-- **For unattended runs:** [unattended-operation](../unattended-operation/SKILL.md) — the policy layer (scope, hard stops, what a wake does *not* authorize, the handback digest). Load both when a human hands the session over.
-- **For the gates a resumed slice must re-fire:** [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md).
+- **REQUIRED BACKGROUND:** `orchestrating-agent-delegation` — brief shape, model tiering, verify-every-"done"-against-the-diff, and the file-isolation rules the occupancy slot records. This skill paces dispatches; that one is how to write and verify one.
+- **For unattended runs:** `unattended-operation` — the policy layer (scope, hard stops, what a wake does *not* authorize, the handback digest). Load both when a human hands the session over.
+- **For the gates a resumed slice must re-fire:** `orchestrating-elite-agent-qa`.
 
 ## Sources
 

--- a/skills/spacing-system/SKILL.md
+++ b/skills/spacing-system/SKILL.md
@@ -30,7 +30,7 @@ A token-driven system declares two unit primitives per foundation theme:
 
 Constraint: `major mod minor == 0`. Both default to 4 when not split (single-unit systems collapse to `minor == major`).
 
-Different density briefs pick different unit pairs — a dense data tool wants a smaller minor unit than a spacious marketing surface, so the same derivation rule yields a 2/4, 4/8, or 4/16 pairing depending on the brief. One system's concrete density-mode unit choices live in `udts-spacing-defaults` (an incubating L2 stub).
+Different density briefs pick different unit pairs — a dense data tool wants a smaller minor unit than a spacious marketing surface, so the same derivation rule yields a 2/4, 4/8, or 4/16 pairing depending on the brief. One system's concrete density-mode unit choices live in [udts-spacing-defaults](../udts-spacing-defaults/SKILL.md) (an incubating L2 stub).
 
 ## What derives from the unit primitives
 
@@ -58,11 +58,11 @@ Same ladder as padding, separately labeled (`gap-*`) because horizontal and vert
 
 ### Icon-size ladder
 
-**Curated**, not formula-derived. A widely-used curated set is `12, 16, 24, 32, 40, 48` — these are the sizes where rendered glyphs (Material, Lucide, Heroicons families) hit pixel boundaries cleanly. Formula-derived sizes (e.g. 14, 18, 22) produce hairline mis-renders on a lot of icon families. See `component-sizing-principles` for the rule that pairs an icon size with a control height.
+**Curated**, not formula-derived. A widely-used curated set is `12, 16, 24, 32, 40, 48` — these are the sizes where rendered glyphs (Material, Lucide, Heroicons families) hit pixel boundaries cleanly. Formula-derived sizes (e.g. 14, 18, 22) produce hairline mis-renders on a lot of icon families. See [component-sizing-principles](../component-sizing-principles/SKILL.md) for the rule that pairs an icon size with a control height.
 
 ### Component-height ladder
 
-Curated per density mode, with the **24 CSS px WCAG 2.5.8 AA Pointer Target floor** for interactive controls (anything clickable / tappable / focusable). See `component-sizing-principles` for the per-density ladder.
+Curated per density mode, with the **24 CSS px WCAG 2.5.8 AA Pointer Target floor** for interactive controls (anything clickable / tappable / focusable). See [component-sizing-principles](../component-sizing-principles/SKILL.md) for the per-density ladder.
 
 ### Border-radius ladder
 
@@ -102,9 +102,9 @@ Failing this is one of the most common WCAG 2.2 misses in design systems. The sk
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND for height + font + icon pairing:** `component-sizing-principles` — the curated per-density component-height ladder + font-pairing + icon-size pairing.
-- **For the typography scale that pairs with spacing:** `type-scale` and `line-height-grid` — line-heights snap to the minor unit declared here.
-- **For one system's concrete density-mode unit choices (worked example):** `udts-spacing-defaults` — an incubating L2 stub that instantiates this model.
+- **REQUIRED BACKGROUND for height + font + icon pairing:** [component-sizing-principles](../component-sizing-principles/SKILL.md) — the curated per-density component-height ladder + font-pairing + icon-size pairing.
+- **For the typography scale that pairs with spacing:** [type-scale](../type-scale/SKILL.md) and [line-height-grid](../line-height-grid/SKILL.md) — line-heights snap to the minor unit declared here.
+- **For one system's concrete density-mode unit choices (worked example):** [udts-spacing-defaults](../udts-spacing-defaults/SKILL.md) — an incubating L2 stub that instantiates this model.
 
 ## Verification
 
@@ -120,4 +120,4 @@ After picking unit primitives + emitting ladders:
 
 - [WCAG 2.5.8 — Target Size (AA, added in 2.2)](https://www.w3.org/TR/WCAG22/#target-size-minimum) — the 24 CSS px floor.
 - [Material Design's icon sizing](https://m3.material.io/styles/icons) — informs the curated icon set.
-- One system's concrete density-mode unit choices: `udts-spacing-defaults` (incubating).
+- One system's concrete density-mode unit choices: [udts-spacing-defaults](../udts-spacing-defaults/SKILL.md) (incubating).

--- a/skills/token-naming-conventions/SKILL.md
+++ b/skills/token-naming-conventions/SKILL.md
@@ -12,7 +12,7 @@ possible is hyphen-separated, prefix-loaded, and redundantly encoded in token
 metadata so a validator can catch a name that disagrees with its own class.
 
 These are system-neutral principles. For one worked instantiation — concrete
-prefix families, spec fields, and worked chains — see `udts-naming-convention`.
+prefix families, spec fields, and worked chains — see [udts-naming-convention](../udts-naming-convention/SKILL.md).
 
 ## When to use
 
@@ -155,13 +155,13 @@ For each new or modified token:
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `oklch-color-space` for the hue-angle convention;
-  `apca-contrast` for the contrast-class concept.
-- **For the metadata-extension mechanism:** `dtcg-format` — how a namespaced
+- **REQUIRED BACKGROUND:** [oklch-color-space](../oklch-color-space/SKILL.md) for the hue-angle convention;
+  [apca-contrast](../apca-contrast/SKILL.md) for the contrast-class concept.
+- **For the metadata-extension mechanism:** [dtcg-format](../dtcg-format/SKILL.md) — how a namespaced
   extension redundantly encodes what the prefix declares.
-- **For SemVer behavior on naming changes:** `semver-design-tokens` — a rename
+- **For SemVer behavior on naming changes:** [semver-design-tokens](../semver-design-tokens/SKILL.md) — a rename
   is always a major change.
-- **For one worked instantiation:** `udts-naming-convention` (an incubating L2
+- **For one worked instantiation:** [udts-naming-convention](../udts-naming-convention/SKILL.md) (an incubating L2
   stub) applies these principles with concrete prefix families and metadata
   fields.
 

--- a/skills/type-scale/SKILL.md
+++ b/skills/type-scale/SKILL.md
@@ -74,7 +74,7 @@ Rounding can be disabled for math-pure systems where fractional sizes are tolera
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `line-height-grid` — every size in the scale needs a line-height; the lh-ui (× 1.20) / lh-prose (× 1.50) tracks pair with this scale.
+- **REQUIRED BACKGROUND:** [line-height-grid](../line-height-grid/SKILL.md) — every size in the scale needs a line-height; the lh-ui (× 1.20) / lh-prose (× 1.50) tracks pair with this scale.
 - **For role assignment after picking sizes:** the typography-styles spec (compound tokens combining size + lh + tracking + weight + paragraph margin).
 - **For the base size choice:** 16 px is the common base; smaller bases (14 px) are valid for dense product UI but require revisiting line-heights and tap targets.
 

--- a/skills/unattended-operation/SKILL.md
+++ b/skills/unattended-operation/SKILL.md
@@ -106,10 +106,10 @@ A chronological narration of beats is the wrong output: it hands the reader the 
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `session-heartbeat` — the beat order, the largest-dispatch threshold, the checkpoint slots, resume-as-survivor. This skill adds policy on top and restates none of the mechanism.
-- **For dispatch discipline that must survive the window:** `orchestrating-agent-delegation` — file isolation, one editor per checkout, verify every "done" against the diff.
-- **For the gates a slice clears before landing, attended or not:** `orchestrating-elite-agent-qa` — including the human-in-the-loop ones, which are hard stops here.
-- **Not this skill:** `designing-elite-ui` for dark mode and night themes.
+- **REQUIRED BACKGROUND:** [session-heartbeat](../session-heartbeat/SKILL.md) — the beat order, the largest-dispatch threshold, the checkpoint slots, resume-as-survivor. This skill adds policy on top and restates none of the mechanism.
+- **For dispatch discipline that must survive the window:** [orchestrating-agent-delegation](../orchestrating-agent-delegation/SKILL.md) — file isolation, one editor per checkout, verify every "done" against the diff.
+- **For the gates a slice clears before landing, attended or not:** [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md) — including the human-in-the-loop ones, which are hard stops here.
+- **Not this skill:** [designing-elite-ui](../designing-elite-ui/SKILL.md) for dark mode and night themes.
 
 ## Sources
 

--- a/skills/wcag-contrast/SKILL.md
+++ b/skills/wcag-contrast/SKILL.md
@@ -16,7 +16,7 @@ WCAG 2.2 Level AA is the **legal-baseline** contrast standard for most jurisdict
 ## When NOT to use
 
 - As the *primary* contrast model when generating new colors. APCACH inverse composition against an APCA Lc target is the generator; this is the cross-check.
-- For free-class tokens (illustration, decorative, brand-spot) — they carry no pairing obligation. See `apca-contrast` for the class system.
+- For free-class tokens (illustration, decorative, brand-spot) — they carry no pairing obligation. See [apca-contrast](../apca-contrast/SKILL.md) for the class system.
 
 ## The rules
 
@@ -63,13 +63,13 @@ For each contrast-bound pairing:
 1. Compute the WCAG ratio with sRGB-linearized luminance.
 2. Apply the role-appropriate threshold (4.5:1 normal text, 3:1 large text or non-text).
 3. Confirm the bold-text size rule in **points** — 14 pt bold (~18.67 CSS px) counts as large; 14 CSS px bold does not. Same for 18 pt regular (= 24 CSS px), not 18 CSS px.
-4. Cross-check the APCA Lc (see `apca-contrast`).
+4. Cross-check the APCA Lc (see [apca-contrast](../apca-contrast/SKILL.md)).
 5. Reject if either model fails.
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** `apca-contrast` — the primary contrast model. WCAG is the cross-check; APCA is the generator target.
-- **For the underlying color space:** `oklch-color-space` — OKLCH source values must be gamut-mapped to sRGB before applying the WCAG formula.
+- **REQUIRED BACKGROUND:** [apca-contrast](../apca-contrast/SKILL.md) — the primary contrast model. WCAG is the cross-check; APCA is the generator target.
+- **For the underlying color space:** [oklch-color-space](../oklch-color-space/SKILL.md) — OKLCH source values must be gamut-mapped to sRGB before applying the WCAG formula.
 
 ## Sources
 

--- a/skills/web-interface-guidelines-review/SKILL.md
+++ b/skills/web-interface-guidelines-review/SKILL.md
@@ -41,7 +41,7 @@ Apply each section in order. Stop and flag at the first failure in each section.
 
 - Padding, gap, margin values are tokens from the spacing scale (`padding-*` / `space-*` / `gap-*`), not raw px. See [spacing-system](../spacing-system/SKILL.md).
 - Component heights come from the system's per-density curated ladder. See [component-sizing-principles](../component-sizing-principles/SKILL.md).
-- **Interactive heights ≥ 24 CSS px** per WCAG 2.5.8 (AA, Target Size Minimum). Rungs below that floor are non-interactive only; whether a ladder's smallest rung is *additionally* reserved is owned by [component-sizing-principles](../component-sizing-principles/SKILL.md).
+- **Interactive heights ≥ 24 CSS px** per WCAG 2.5.8 (AA, Target Size Minimum). Rungs below that floor are non-interactive only; whether a ladder's smallest rung is *additionally* reserved is owned by `component-sizing-principles`.
 - Flag inconsistent rung mixing in the same UI surface (`sm` + `md` buttons side by side reads as a typo, not a hierarchy).
 
 ### 4. Action labels: verb-noun
@@ -75,7 +75,7 @@ Apply each section in order. Stop and flag at the first failure in each section.
 
 - Decorative icons get `aria-hidden="true"` and no accessible name.
 - Functional icons (icon-only buttons) get an accessible name via `aria-label` ("Search", "Close dialog").
-- Icon sizes come from the curated ladder (e.g. 12, 16, 24, 32, 40, 48), paired with the control's rung per [component-sizing-principles](../component-sizing-principles/SKILL.md). No arbitrary `size={14}`.
+- Icon sizes come from the curated ladder (e.g. 12, 16, 24, 32, 40, 48), paired with the control's rung per `component-sizing-principles`. No arbitrary `size={14}`.
 
 ### 9. Motion
 
@@ -86,7 +86,7 @@ Apply each section in order. Stop and flag at the first failure in each section.
 ### 10. Token discipline
 
 - No raw hex, no raw px, no raw rem in source. Every value resolves from a token (a text role token, `padding-md`, `radius-lg`, etc.).
-- Component tokens reference semantic / color-mode tokens, never primitives directly (see [token-naming-conventions](../token-naming-conventions/SKILL.md) for the two chain shapes).
+- Component tokens reference semantic / color-mode tokens, never primitives directly (see `token-naming-conventions` for the two chain shapes).
 - Flag inline `style={{ … }}` carrying values that should be tokens; the only exception is values genuinely computed at runtime.
 
 ## How to phrase findings
@@ -109,6 +109,7 @@ After completing a review:
 2. **Every finding has a fix.** Fixless findings get rejected.
 3. **Sections applied in order.** Contrast and a11y come before token discipline; don't lead with cosmetic findings.
 4. **No bundled comments.**
+5. **Skills cross-referenced.** Contrast findings cite `apca-contrast` / `wcag-contrast`; size findings cite `type-scale` / `component-sizing-principles`.
 
 ## Sources
 

--- a/skills/web-interface-guidelines-review/SKILL.md
+++ b/skills/web-interface-guidelines-review/SKILL.md
@@ -25,22 +25,22 @@ Apply each section in order. Stop and flag at the first failure in each section.
 
 ### 1. Contrast: APCA-preferred, WCAG cross-check
 
-- **Primary model is APCA Lc.** Verify the foreground color hits its declared Lc target (typically 90 fluent body, 75 body minimum, 60 secondary, 45 large display, 30 spot, 15 non-text — see `apca-contrast`).
-- **WCAG 2.2 AA is a cross-check, not the primary.** Verify the pair also meets 4.5:1 (normal) / 3:1 (large or non-text) per `wcag-contrast`. Sizes are in **points**, not pixels (18 pt ≈ 24 CSS px; 14 pt bold ≈ 18.67 CSS px).
+- **Primary model is APCA Lc.** Verify the foreground color hits its declared Lc target (typically 90 fluent body, 75 body minimum, 60 secondary, 45 large display, 30 spot, 15 non-text — see [apca-contrast](../apca-contrast/SKILL.md)).
+- **WCAG 2.2 AA is a cross-check, not the primary.** Verify the pair also meets 4.5:1 (normal) / 3:1 (large or non-text) per [wcag-contrast](../wcag-contrast/SKILL.md). Sizes are in **points**, not pixels (18 pt ≈ 24 CSS px; 14 pt bold ≈ 18.67 CSS px).
 - Flag any review that cites WCAG as the *only* model — APCA catches real perceptual failures WCAG misses.
-- Flag hardcoded hex in source: every contrast-bound color resolves from a token (role families content / surface / border — see `token-naming-conventions`).
+- Flag hardcoded hex in source: every contrast-bound color resolves from a token (role families content / surface / border — see [token-naming-conventions](../token-naming-conventions/SKILL.md)).
 
 ### 2. Typography: atomic classes from the scale
 
 - **Atomic typography classes.** One Tailwind / utility class binds font-family + size + lh + tracking + weight — e.g. `body-md`, `heading-lg`. No à-la-carte composition (`text-sm font-medium tracking-tight`).
 - **Sizes come from the type scale.** Every rendered font-size matches a step from the system's modular scale (1.067 → 1.618 family). Flag arbitrary px like `text-[13px]` — outside the scale.
-- **Line-height per role.** UI text uses `lh-ui` (× 1.20 + grid snap); paragraph body uses `lh-prose` (× 1.50 + grid snap). See `line-height-grid`.
+- **Line-height per role.** UI text uses `lh-ui` (× 1.20 + grid snap); paragraph body uses `lh-prose` (× 1.50 + grid snap). See [line-height-grid](../line-height-grid/SKILL.md).
 - Body text **never below 14 pt** (≈ 18.67 CSS px); UI labels usable down to 12 CSS px for non-fluent content (badges, metadata) but **never below 10 px**.
 
 ### 3. Spacing + sizing: token-driven
 
-- Padding, gap, margin values are tokens from the spacing scale (`padding-*` / `space-*` / `gap-*`), not raw px. See `spacing-system`.
-- Component heights come from the system's per-density curated ladder. See `component-sizing-principles`.
+- Padding, gap, margin values are tokens from the spacing scale (`padding-*` / `space-*` / `gap-*`), not raw px. See [spacing-system](../spacing-system/SKILL.md).
+- Component heights come from the system's per-density curated ladder. See [component-sizing-principles](../component-sizing-principles/SKILL.md).
 - **Interactive heights ≥ 24 CSS px** per WCAG 2.5.8 (AA, Target Size Minimum). Rungs below that floor are non-interactive only; whether a ladder's smallest rung is *additionally* reserved is owned by [component-sizing-principles](../component-sizing-principles/SKILL.md).
 - Flag inconsistent rung mixing in the same UI surface (`sm` + `md` buttons side by side reads as a typo, not a hierarchy).
 
@@ -75,7 +75,7 @@ Apply each section in order. Stop and flag at the first failure in each section.
 
 - Decorative icons get `aria-hidden="true"` and no accessible name.
 - Functional icons (icon-only buttons) get an accessible name via `aria-label` ("Search", "Close dialog").
-- Icon sizes come from the curated ladder (e.g. 12, 16, 24, 32, 40, 48), paired with the control's rung per `component-sizing-principles`. No arbitrary `size={14}`.
+- Icon sizes come from the curated ladder (e.g. 12, 16, 24, 32, 40, 48), paired with the control's rung per [component-sizing-principles](../component-sizing-principles/SKILL.md). No arbitrary `size={14}`.
 
 ### 9. Motion
 
@@ -86,7 +86,7 @@ Apply each section in order. Stop and flag at the first failure in each section.
 ### 10. Token discipline
 
 - No raw hex, no raw px, no raw rem in source. Every value resolves from a token (a text role token, `padding-md`, `radius-lg`, etc.).
-- Component tokens reference semantic / color-mode tokens, never primitives directly (see `token-naming-conventions` for the two chain shapes).
+- Component tokens reference semantic / color-mode tokens, never primitives directly (see [token-naming-conventions](../token-naming-conventions/SKILL.md) for the two chain shapes).
 - Flag inline `style={{ … }}` carrying values that should be tokens; the only exception is values genuinely computed at runtime.
 
 ## How to phrase findings
@@ -98,8 +98,8 @@ Apply each section in order. Stop and flag at the first failure in each section.
 
 ## Cross-references
 
-- **REQUIRED BACKGROUND:** contrast — `apca-contrast`, `wcag-contrast`; typography — `type-scale`, `line-height-grid`; spacing — `spacing-system`, `component-sizing-principles`; tokens — `token-naming-conventions`, `dtcg-format`.
-- **UI-string voice:** `brand-voice-review`.
+- **REQUIRED BACKGROUND:** contrast — [apca-contrast](../apca-contrast/SKILL.md), [wcag-contrast](../wcag-contrast/SKILL.md); typography — [type-scale](../type-scale/SKILL.md), [line-height-grid](../line-height-grid/SKILL.md); spacing — [spacing-system](../spacing-system/SKILL.md), [component-sizing-principles](../component-sizing-principles/SKILL.md); tokens — [token-naming-conventions](../token-naming-conventions/SKILL.md), [dtcg-format](../dtcg-format/SKILL.md).
+- **UI-string voice:** [brand-voice-review](../brand-voice-review/SKILL.md).
 
 ## Verification
 
@@ -109,7 +109,6 @@ After completing a review:
 2. **Every finding has a fix.** Fixless findings get rejected.
 3. **Sections applied in order.** Contrast and a11y come before token discipline; don't lead with cosmetic findings.
 4. **No bundled comments.**
-5. **Skills cross-referenced.** Contrast findings cite `apca-contrast` / `wcag-contrast`; size findings cite `type-scale` / `component-sizing-principles`.
 
 ## Sources
 
@@ -117,4 +116,4 @@ After completing a review:
 - [Material Design 3](https://m3.material.io/) — alternate canon for cross-checks.
 - [Radix UI documentation](https://www.radix-ui.com/primitives) — accessible-component reference.
 - [WCAG 2.2 Recommendation](https://www.w3.org/TR/WCAG22/) — the legal baseline.
-- System-specific review layers (e.g. `udts-review`, incubating) compose on top of this generic lens.
+- System-specific review layers (e.g. [udts-review](../udts-review/SKILL.md), incubating) compose on top of this generic lens.

--- a/tests/test_workflow_triggers.py
+++ b/tests/test_workflow_triggers.py
@@ -1,0 +1,95 @@
+"""The gates must be able to see every input they read.
+
+A `paths:` filter on a gate is a standing hazard here, for two reasons that are
+both matters of record rather than opinion:
+
+1. GitHub treats a filter-skipped check as "expected but never reported". Once a
+   `required_status_checks` rule names that check, a pull request touching none
+   of the filtered paths blocks forever. `check-doc-links.yml:8-12` documents
+   this in this repository, in logmind's own words.
+
+2. A filter has to enumerate every input, and the enumeration rots. The skill
+   validator's filter never listed `skills/skill-size-budget.json`, so for the
+   whole life of the size ratchet a pull request editing only the budget did not
+   run the gate the budget configures. Raising the limit disabled the gate
+   without triggering it.
+
+These tests fail if a filter is reintroduced, so the second instance has to be
+argued for rather than merely typed.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Gates whose result is (or is intended to be) a merge condition. A filter on
+# one of these is the failure described above. Workflows NOT listed here are
+# free to filter — a scheduled refresh or a notifier has no such constraint.
+UNCONDITIONAL_GATES = ["validate-skills.yml", "test.yml"]
+
+
+def _load(name):
+    path = WORKFLOWS / name
+    assert path.exists(), f"{name} is missing from {WORKFLOWS}"
+    # `on:` is the YAML 1.1 boolean True, not the string "on" — PyYAML resolves
+    # it before we see it. Look the key up both ways so this does not silently
+    # pass by finding nothing.
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    triggers = doc.get("on", doc.get(True))
+    assert triggers is not None, f"{name} declares no triggers at all"
+    return doc, triggers
+
+
+@pytest.mark.parametrize("name", UNCONDITIONAL_GATES)
+def test_gate_has_no_paths_filter(name):
+    """A merge gate must run on every pull request, not a guessed subset."""
+    _, triggers = _load(name)
+    assert isinstance(triggers, dict), f"{name}: expected a trigger mapping"
+
+    for event, config in triggers.items():
+        if not isinstance(config, dict):
+            continue  # e.g. `pull_request:` with no body — the shape we want
+        for key in ("paths", "paths-ignore"):
+            assert key not in config, (
+                f"{name} reintroduced a `{key}:` filter on `{event}`. "
+                "A filter-skipped check reports as expected-but-missing and "
+                "blocks the merge once it is required, and the path list rots "
+                "— this repo already shipped a size gate that could not see "
+                "edits to its own budget file. If a filter is genuinely "
+                "needed, delete this assertion in the same commit and say why."
+            )
+
+
+@pytest.mark.parametrize("name", UNCONDITIONAL_GATES)
+def test_gate_runs_on_pull_request(name):
+    """A gate nobody triggers is not a gate."""
+    _, triggers = _load(name)
+    assert "pull_request" in triggers, (
+        f"{name} does not run on `pull_request`, so it cannot gate anything."
+    )
+
+
+def test_validator_inputs_are_reachable():
+    """Every path the validator reads must be reachable by its trigger.
+
+    With no filter this holds by construction. The test states the obligation
+    anyway, so that reintroducing a filter fails here with the reason attached
+    rather than passing quietly and stranding one of these inputs.
+    """
+    _, triggers = _load("validate-skills.yml")
+    reads = [
+        "skills/*/SKILL.md",  # the subject
+        "docs/placement-map.json",  # reconciled 1:1 against skills/
+        ".github/scripts/validate_skills.py",  # the rules themselves
+    ]
+    pr = triggers.get("pull_request")
+    unfiltered = pr is None or (isinstance(pr, dict) and "paths" not in pr)
+    assert unfiltered, (
+        "validate-skills.yml filters `pull_request`, so these inputs are no "
+        f"longer guaranteed reachable: {reads}. Either drop the filter or "
+        "prove every one of them is covered."
+    )


### PR DESCRIPTION
The gate could not see edits to the file that configures it, for its entire life.

## The instance

`validate-skills.yml`s `paths:` filter listed `skills/**/SKILL.md`, `docs/placement-map.json` and the workflow itself. It **never listed `skills/skill-size-budget.json`**.

So for the whole life of the size ratchet, a pull request editing only the budget **did not run the gate that budget configures**. Raising `limitBytes` could disable the ratchet without ever triggering it. #206 has since deleted that file and inlined the constant, which closes this instance — and leaves the class.

## Why deleting beats extending

**The enumeration rots by design.** Fix it by adding one path and you ship the next gap in the same batch: the planned mirror gate reads `.claude/skills/**`, the suite reads `tests/**`. Every future input is a new chance to forget.

**And this repo already wrote down the second reason**, in logmind s own words at `check-doc-links.yml:8-12`:

> Filtered runs interact badly with `required_status_checks` rules: GitHub treats a filter-skipped check as "expected but missing" and blocks the merge forever.

Measured: agent-skills has **zero** `required_status_checks` rules today. That is precisely why this is free to fix now and expensive later — the moment one names `validate skills`, a PR touching none of the filtered paths blocks forever.

**Cost of running unconditionally:** 11-13 seconds over 48 skills, measured from recent runs. Cheaper than being wrong.

## The guard

`tests/test_workflow_triggers.py` fails if `paths:` or `paths-ignore:` is reintroduced on either merge gate, with the reason in the assertion message. So the next filter has to be **argued for rather than merely typed**.

Mutation-tested, not asserted:

```
$ (reintroduce a paths filter)
FAILED test_gate_has_no_paths_filter[validate-skills.yml]
FAILED test_validator_inputs_are_reachable
2 failed, 3 passed

$ (restore)
112 passed
```

**Scoped deliberately.** The test names only *merge gates* — `validate-skills.yml` and `test.yml`. A scheduled refresh or a notifier has no such constraint and may filter freely; that list is explicit in the file.

## One trap worth naming

PyYAML resolves the workflow key `on:` to the **boolean `True`** under YAML 1.1. A naive `doc.get("on")` finds nothing, iterates nothing, and the assertion passes **by vacuity** — a guard that never fires, which is the exact defect class this repo keeps finding. The test looks the key up both ways.

Verified after: `OK: 49 skills validated cleanly`, exit 0.