### PR TITLE
Three design lenses to house standard — and a WCAG level that was wrong in shipped guidance

### DIFF
--- a/docs/decisions-branches/feat__three-design-lenses-to-house-standard.md
+++ b/docs/decisions-branches/feat__three-design-lenses-to-house-standard.md
@@ -13,3 +13,16 @@
 
 ---
 
+## 2026-08-15 10:24 - Correct the 2.5.8 spacing exception — the paraphrase was more lenient than the spec
+
+**Reasoning:** The panel found frontend-a11y's rendering of the SC 2.5.8 spacing exception wrong in a way that certifies real failures as passes. It said undersized targets pass when a 24px circle centred on each bounding box does not intersect another target's circle. Verified verbatim against the W3C Understanding document: undersized targets are positioned so that if a 24 CSS pixel diameter circle is centered on the bounding box of each, the circles do not intersect another target or the circle for another undersized target. Two differences, both lenient. Circles are drawn only for undersized targets, not for each target. And against an adequately sized neighbour the test is that neighbour's bounding box, not a circle — a 24px circle centred on a box of 24px or more sits strictly inside it, so comparing circle to circle can never fail there. Concretely a 20 by 20 button one pixel from a 40 by 40 button fails the criterion and passed the skill's rule. That is the dense icon toolbar case the same paragraph tells a reviewer to look at, and it ships to a client who then freezes it.
+
+**Alternatives considered:** Leave the paraphrase and add a caveat, which keeps a rule that reports a real AA failure as a pass
+
+**Implications:**
+- Also tightened 2.4.11 from covering to hiding entirely, since the criterion requires the component not be entirely hidden and partial occlusion is 2.4.12 at AAA. Same error shape as the 2.4.13 level: an AAA obligation reported as an AA failure
+- The correction pushed the body 45 bytes over the ceiling and the gate caught it — a live instance of #213, resolved the way the CEO ruled. I rewrote my own two additions tighter rather than cutting a rule elsewhere; 8,237 down to 8,128, headroom 64
+- This is the second WCAG level error found in this PR's own subject matter, and both were found by an independent panel rather than by the author. The first was 2.4.13 stated as AA in two skills. Guidance that asserts conformance levels needs the primary source read at review time, not recalled
+
+---
+

--- a/docs/decisions-branches/feat__three-design-lenses-to-house-standard.md
+++ b/docs/decisions-branches/feat__three-design-lenses-to-house-standard.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-15 09:08 - Bring the three design lenses to house standard, and correct a WCAG level that ships to a client
+
+**Reasoning:** frontend-a11y, visual-polish and design-system-consistency sat at 1,665 to 1,821 body bytes against a 46-skill mean of 4,950, with none of the five required sections and an in-degree of 1. They ship to a client repository on 20 August that then leaves the org and freezes permanently, so for that consumer a thin skill is not temporary. They are now 7,998 to 8,046 bytes, carry the full house frame, and route rather than restate — which is issue #200's actual complaint. frontend-a11y previously asserted WCAG AA 4.5:1 as the contrast model while never naming apca-contrast or wcag-contrast, the two skills that own those thresholds; it now declares both REQUIRED BACKGROUND with stated reasons and defers to the system's declared primary. Written dispatched rather than standalone: reviewing-design-work routes above them and orchestrating-a-multi-agent-run carries the family axioms, so none of the three re-establishes framing something above it already supplies.
+
+**Alternatives considered:** Drop the three from the client handoff to meet the date, which ships a design-critic that cannot cite half its territory; hand them to the consuming lane to fill, which makes another team pay for a gap in my repo under my deadline
+
+**Implications:**
+- Corrected a factual error in shipped accessibility guidance. wcag-contrast stated SC 2.4.13 Focus Appearance as Level AA in three places and web-interface-guidelines-review in one. It is Level AAA — verified against the published WCAG 2.2 Recommendation at w3.org, not against a secondary source. The AA hooks are 1.4.11 for the ring's contrast and 2.4.11 for the ring being obscured, and neither skill named 2.4.11 at all. An agent following the old text would report a AAA enhancement as an AA compliance failure, which in an accessibility audit is a claim about legal baseline
+- The WCAG fix consumed 43 of web-interface-guidelines-review's 46 bytes of headroom, leaving 3. A file at 3 bytes forces the next editor to delete something, which is exactly the #213 failure. Rather than cut a rule elsewhere I rewrote my own sentence tighter, per the CEO's ruling that a file at the ceiling gets rewritten rather than trimmed. Headroom is back to 49
+- All three land at 146 to 194 bytes of headroom and should be treated as at-ceiling: any future addition must displace something. 303 relative skill links across the catalog, zero broken; 112 tests pass; validator clean at 49 skills
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (10 decisions)
+## 2026-08 (11 decisions)
 
-- **2026-08-15** — Delete the skill gate's paths filter rather than extending it, and assert it stays gone *(fix/unfilter-the-skill-gate)* — [decisions-branches/fix__unfilter-the-skill-gate.md](decisions-branches/fix__unfilter-the-skill-gate.md)
-- *... 8 more decisions ...*
+- **2026-08-15** — Bring the three design lenses to house standard, and correct a WCAG level that ships to a client *(feat/three-design-lenses-to-house-standard)* — [decisions-branches/feat__three-design-lenses-to-house-standard.md](decisions-branches/feat__three-design-lenses-to-house-standard.md)
+- *... 9 more decisions ...*
 - **2026-08-14** — Gate skill size with a shrink-only ratchet, and deprecate skillforge into the three skills that own its job *(feat/skill-depth-and-interlinking)* — [decisions-branches/feat__skill-depth-and-interlinking.md](decisions-branches/feat__skill-depth-and-interlinking.md)
 
 ## 2026-07 (13 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (11 decisions)
+## 2026-08 (12 decisions)
 
-- **2026-08-15** — Bring the three design lenses to house standard, and correct a WCAG level that ships to a client *(feat/three-design-lenses-to-house-standard)* — [decisions-branches/feat__three-design-lenses-to-house-standard.md](decisions-branches/feat__three-design-lenses-to-house-standard.md)
-- *... 9 more decisions ...*
+- **2026-08-15** — Correct the 2.5.8 spacing exception — the paraphrase was more lenient than the spec *(feat/three-design-lenses-to-house-standard)* — [decisions-branches/feat__three-design-lenses-to-house-standard.md](decisions-branches/feat__three-design-lenses-to-house-standard.md)
+- *... 10 more decisions ...*
 - **2026-08-14** — Gate skill size with a shrink-only ratchet, and deprecate skillforge into the three skills that own its job *(feat/skill-depth-and-interlinking)* — [decisions-branches/feat__skill-depth-and-interlinking.md](decisions-branches/feat__skill-depth-and-interlinking.md)
 
 ## 2026-07 (13 decisions)

--- a/skills/design-system-consistency/SKILL.md
+++ b/skills/design-system-consistency/SKILL.md
@@ -1,40 +1,152 @@
 ---
 name: design-system-consistency
-description: Visual review — flag rendered UI that drifts from the design system's tokens, scale, and color discipline. Judges the screenshot, not just the code.
+description: >-
+  Use when judging whether a RENDERED surface obeys its own design system —
+  screenshots or a live page plus the computed styles behind them — as the drift
+  lens of a design review. Owns: establishing what the system actually declares
+  before judging anything, off-token and right-value-wrong-role values, off-scale
+  spacing and type, hand-rolled re-implementations of system components, and
+  whether a mode (dark, forced-colors, density, a second brand) has a token path
+  at all. Judges drift, not correctness of the scales themselves — those live in
+  spacing-system, type-scale, line-height-grid, token-naming-conventions,
+  component-sizing-principles. Cite when a review calls a value wrong with no
+  system on disk to be wrong against, or passes a hardcoded value because it
+  happens to equal the token.
 kind: design
 applies_to:
-  paths: ["site/**", "app/**", "**/components/**", "**/ui/**"]
-  extensions: [".tsx", ".jsx", ".css", ".scss", ".vue", ".svelte"]
+  paths: ["site/**", "app/**", "**/site/**", "**/app/**", "**/components/**", "**/ui/**", "**/styles/**"]
+  extensions: [".tsx", ".jsx", ".vue", ".svelte", ".astro", ".html", ".css", ".scss"]
 ---
 
 # Design-system consistency
 
-You are reviewing the **rendered** change (screenshots, light and dark) against the
-project's design system. Cite the specific element you see in the screenshot — name it
-and where it is — not just the source line.
+The drift lens on the **rendered** surface: does what shipped obey *this* system. Drift is
+a relation, so it needs both things on disk — the render, and the system it should match.
+Without the second there is no drift, only preference, and saying so is the finding.
 
-## Flag
+## When to use
 
-1. **Off-token values.** A hardcoded color, spacing, radius, shadow, or font-size where a
-   design token / CSS variable already exists for that role. Quote the value and name the
-   token it should use.
-2. **Color discipline.** Fills should be cool/neutral; strokes and text are the warm/ink
-   layer; a saturated red (or the system's "danger" hue) is reserved for destructive or
-   critical states. Flag a red used for a non-critical accent, or a one-off accent hue that
-   isn't in the palette. Prefer perceptually-uniform color (OKLCH/LCH) over ad-hoc hex when
-   the system uses it.
-3. **Off-scale spacing.** Margins/padding/gaps that don't land on the spacing scale (e.g. a
-   `13px` gap in a 4-/8-pt system). Rhythm should be consistent between sibling elements.
-4. **Type ramp drift.** A font-size/weight/line-height combination outside the defined type
-   scale, or the same semantic level rendered at two different sizes across the view.
-5. **Re-implementation.** A button/card/input hand-rolled inline when a system component
-   exists — visible as subtly different padding, radius, or hover from its siblings.
+- Judging a rendered surface against the project's tokens, scales and declared stance.
+- A PR adds or restyles UI in a codebase that already has a token layer.
+- Auditing a surface that "looks right" for values that bypass the system.
 
-## How to judge
+## When NOT to use
 
-- Compare the new surface against an existing, known-good surface in the same product.
-- "It renders" is not the bar — **token-correct** is the bar. Flag a value that looks fine
-  but bypasses the system; say which token restores consistency.
-- One concrete drift per finding, with the rendered element quoted and the fix named.
+- **No system on disk.** File one finding — the system is undeclared — and stop. Per-value
+  opinions against nothing are taste wearing a uniform.
+- **Designing the scale rather than judging against it** —
+  [spacing-system](../spacing-system/SKILL.md), [type-scale](../type-scale/SKILL.md) and
+  [token-naming-conventions](../token-naming-conventions/SKILL.md) own what a well-formed
+  scale *is*.
+- **On-system but badly executed** — [visual-polish](../visual-polish/SKILL.md). Two legal
+  steps that read identically are a craft finding, not drift.
+- **The pairing fails a contrast or target threshold** —
+  [frontend-a11y](../frontend-a11y/SKILL.md). Token-correct and inaccessible is a real
+  state, and theirs.
 
-If the rendered change is token-clean and on-scale in both themes, say so in one line.
+## Establish the reference before judging
+
+1. **Find the token source and name it in the review** — DTCG JSON
+   ([dtcg-format](../dtcg-format/SKILL.md)), custom properties on `:root` and the theme
+   selectors, a Tailwind theme, a `theme.ts`. Read the computed style on the rendered
+   node, not only the diff: that is where an inherited or overridden value shows.
+2. **Find the declared stance** — which hue is reserved for destructive or critical, which
+   dimension varies within a role, which density mode is in force.
+   [designing-elite-ui](../designing-elite-ui/SKILL.md) describes a well-formed stance:
+   one role, one meaning, one variation axis. **Read the stance; do not supply one.** Where
+   a system never wrote one down, that is the finding, filed once — not one finding per hue
+   you would have picked differently.
+3. **Find a known-good sibling surface** and compare against it. A Figma frame is a
+   proposal; the tokens on disk are the system, and where the two disagree that is itself
+   the finding.
+
+## What drift looks like on a render
+
+1. **Off-token value.** A literal colour, spacing, radius, shadow or font-size where a
+   role token exists. Recognise it in the computed style (a hex or px with no custom
+   property behind it), in arbitrary utilities (`bg-[#f5f5f5]`, `p-[13px]`), and in inline
+   `style`. The render is identical today and diverges at the first theme, density or
+   brand change. Fix: name the token whose **role** matches, not the one whose value does.
+2. **Right value, wrong role.** A border token used for text, a surface token on a fill
+   that must invert. It looks correct until a mode flips and one element moves the wrong
+   way. [token-naming-conventions](../token-naming-conventions/SKILL.md) owns the role
+   families and the chain shapes a component token may take.
+3. **Off-scale spacing and sizing.** A gap or height that is not a step — recognisable as
+   sibling controls sitting a hair apart, or a value that is *nearly* a step.
+   [spacing-system](../spacing-system/SKILL.md) owns the steps;
+   [component-sizing-principles](../component-sizing-principles/SKILL.md) owns the rungs
+   and the rule that siblings share one. Fix: the nearest legal step, named.
+4. **Type ramp drift.** A size, weight or line-height off the ramp, or one semantic level
+   rendered at two sizes in a single view — measure two same-level headings in the capture.
+   [type-scale](../type-scale/SKILL.md) owns the ratio and rounding;
+   [line-height-grid](../line-height-grid/SKILL.md) owns the UI-versus-prose tracks.
+5. **Colour discipline — observe, then judge.** Hold the surface to the system's stance,
+   not yours. Three things are universal: one role does not carry two meanings; a hue
+   reserved for destructive or critical is not spent on decoration; an accent in no palette
+   is drift even when it is pretty. Cite the construction skills when proposing a
+   replacement — [oklch-color-space](../oklch-color-space/SKILL.md),
+   [palette-relationships](../palette-relationships/SKILL.md),
+   [chroma-harmonization](../chroma-harmonization/SKILL.md).
+6. **Re-implementation.** A hand-rolled button, card or input where a system component
+   exists — visible on the render as subtly different padding, radius, hover or focus ring
+   from its siblings. Fix: the component, not corrected values.
+
+## Every mode needs a token path
+
+Light and dark are both primary and not the whole axis: forced-colors, an
+increased-contrast preference, each density mode and any second brand are modes too. The
+test is not "does dark look right" but **is there a path** — a mode-aware token every
+surface resolves through. A theme written as a `.dark` block of literal values renders
+correctly in two modes and has nowhere to put the third.
+
+## Silent failures
+
+- **A hardcoded value that equals its token.** Pixel-identical render, every check green,
+  and it stops tracking the token at the next release. The screenshot never shows this;
+  the computed style does.
+- **A component token pointing straight at a primitive.** Skips the semantic layer,
+  renders correctly, cannot be re-themed —
+  [token-naming-conventions](../token-naming-conventions/SKILL.md).
+- **A new token invented for a one-off.** On-system by construction, so nothing flags it,
+  and the catalog grows a synonym for a role it had. Check for an existing role first;
+  [semver-design-tokens](../semver-design-tokens/SKILL.md) owns what adding one costs.
+
+## Verification
+
+1. The review names the token source it judged against and quotes a computed value, not
+   only a screenshot impression; every drift finding names the token that restores it,
+   chosen by role rather than by matching value.
+2. Colour findings quote the declared stance or state that none is declared. No finding
+   prescribes a hue this lens preferred.
+3. Findings belonging to the scale-owning skills, to
+   [visual-polish](../visual-polish/SKILL.md) or to
+   [frontend-a11y](../frontend-a11y/SKILL.md) were routed, not re-argued here.
+4. Each mode the system claims to support was checked for a token *path*, not just for
+   looking right in the two captured themes.
+5. A token-clean surface gets one line saying so, naming what it was checked against.
+
+## Sources
+
+- [W3C Design Tokens Format Module](https://tr.designtokens.org/format/) — what a token
+  file declares and what an alias is; the catalog's reading is
+  [dtcg-format](../dtcg-format/SKILL.md).
+- **House convention, not a standard:** establish the reference before judging; "no
+  declared stance" is one finding, not many; a mode needs a path, not a screenshot.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** [token-naming-conventions](../token-naming-conventions/SKILL.md)
+  — role families and chain shapes, without which "wrong role" cannot be argued; and
+  [spacing-system](../spacing-system/SKILL.md) with
+  [type-scale](../type-scale/SKILL.md) — the two scales most drift lands on.
+- **Also cited when proposing a fix:** [oklch-color-space](../oklch-color-space/SKILL.md) ·
+  [palette-relationships](../palette-relationships/SKILL.md) ·
+  [chroma-harmonization](../chroma-harmonization/SKILL.md).
+- **Siblings:** [visual-polish](../visual-polish/SKILL.md) (on-system, badly executed) ·
+  [frontend-a11y](../frontend-a11y/SKILL.md) (token-correct, illegible) ·
+  [designing-elite-ui](../designing-elite-ui/SKILL.md) (a well-formed stance) ·
+  [web-interface-guidelines-review](../web-interface-guidelines-review/SKILL.md) (the same
+  discipline from the diff). **Above:**
+  [reviewing-design-work](../reviewing-design-work/SKILL.md) orders the lenses;
+  [consuming-a-design-system](../consuming-a-design-system/SKILL.md) is where a repo with
+  no token path goes.

--- a/skills/frontend-a11y/SKILL.md
+++ b/skills/frontend-a11y/SKILL.md
@@ -56,15 +56,17 @@ commonest false pass here.
 2. **Focus rings, in place.** Source shows a ring exists; only the render shows it
    survives — clipped by an ancestor `overflow: hidden`, drowned against the *actual*
    adjacent surface, or gone in forced-colors. **SC 2.4.11 Focus Not Obscured (Minimum),
-   AA in 2.2** is separate: sticky chrome covering the focused control fails even with a
-   perfect ring, so capture the row scrolling under it. Ring contrast is SC 1.4.11;
+   AA in 2.2** is separate: sticky chrome hiding the focused control *entirely* fails even
+   with a perfect ring, so capture the row scrolling under it. Partial occlusion is 2.4.12,
+   AAA. Ring contrast is SC 1.4.11;
    **SC 2.4.13 Focus Appearance is AAA** — an enhancement, never an AA failure. Tooltips
    and hover cards have their own rule: hoverable, dismissible without moving the pointer,
    persistent (**SC 1.4.13, AA**).
 3. **Hit area, as laid out.** **SC 2.5.8, AA — 24 by 24 CSS px**, then the spacing
-   exception: undersized targets pass when a 24 px-diameter circle centred on each
-   bounding box does not intersect another target's circle. Dense icon toolbars fail on
-   spacing more often than on size, so measure the gap too. Touch surfaces have a higher
+   exception: a 24 px circle on each **undersized** target must miss **another target's
+   box** — not its circle — or another undersized target's circle. So a 20 px button 1 px
+   from a 40 px one fails. Dense icon toolbars fail on spacing more than size; measure the
+   gap. Touch surfaces have a higher
    platform floor; read that platform's HIG. The ladder behind the height is
    [component-sizing-principles](../component-sizing-principles/SKILL.md).
 4. **Meaning that can vanish.** **SC 1.4.1 Use of Color, A** — status as red/green with

--- a/skills/frontend-a11y/SKILL.md
+++ b/skills/frontend-a11y/SKILL.md
@@ -1,43 +1,148 @@
 ---
 name: frontend-a11y
 description: >-
-  Visual review — accessibility on the rendered surface: contrast, focus
-  visibility, tap targets, semantics, motion. Cite the element and the
-  failing ratio or state.
+  Use when judging accessibility on a RENDERED surface — screenshots or a live
+  page, in light, dark, forced-colors and reduced-motion, at real zoom — as the
+  a11y lens of a design review. Owns what only the render shows: contrast
+  measured on the composited pixel rather than the token, focus rings that
+  survive forced-colors and are not covered by sticky chrome (SC 2.4.11), hit
+  areas measured as laid out including the 2.5.8 spacing exception, meaning
+  carried by colour / gradient / shadow, and motion that actually plays.
+  Thresholds are NOT restated here — contrast belongs to apca-contrast and
+  wcag-contrast, target size to component-sizing-principles. Cite when a review
+  calls contrast "low" with no measured pair, checks light mode only, reports an
+  AAA criterion as an AA failure, or infers accessibility from source alone.
 kind: design
 applies_to:
-  paths: ["site/**", "app/**", "**/components/**", "**/ui/**"]
-  extensions: [".tsx", ".jsx", ".css", ".scss", ".vue", ".svelte"]
+  paths: ["site/**", "app/**", "**/site/**", "**/app/**", "**/components/**", "**/ui/**", "**/styles/**"]
+  extensions: [".tsx", ".jsx", ".vue", ".svelte", ".astro", ".html", ".css", ".scss"]
 ---
 
 # Frontend accessibility
 
-You are reviewing the **rendered** change (screenshots, light and dark) plus the markup for
-accessibility. Cite the element and the concrete failure (the measured ratio, the missing
-state, the tag).
+The a11y lens on the **rendered** surface. The code lens already read the source, so a
+finding here should be one a source read could not produce — naming the element, the
+mode, the measured value, the fix.
 
-## Flag
+**Measure the composited pixel, not the token.** Opacity, overlays, `backdrop-filter`, a
+photo behind text and antialiasing on thin weights all change the pair the eye receives,
+so a token that passes in the palette can fail where it landed. House convention, and the
+commonest false pass here.
 
-1. **Contrast.** Body text below WCAG AA 4.5:1, or large text / UI borders below 3:1 — in
-   **either** theme (check both screenshots; dark mode is where contrast quietly fails).
-   Name the foreground/background and the approximate ratio.
-2. **Focus visibility.** Any interactive element with no visible focus indicator, or a focus
-   ring removed (`outline: none`) without a replacement. Keyboard users must see focus.
-3. **Tap / click targets.** Controls smaller than ~24x24 CSS px (44px on touch surfaces),
-   or targets packed too tightly to hit reliably.
-4. **Semantics.** Icon-only buttons without an accessible name (`aria-label`/visually-hidden
-   text); headings that skip levels; a `<div>` with a click handler where a `<button>`/`<a>`
-   belongs; images conveying meaning without alt text.
-5. **Color-only signaling.** State or meaning carried by color alone (e.g. red/green status
-   with no icon or label).
-6. **Motion.** Auto-playing or large motion that doesn't honor `prefers-reduced-motion`.
+## When to use
 
-## How to judge
+- Judging a screenshot set or live page for accessibility inside a design review.
+- A visual surface changed and renders exist in more than one mode.
+- Auditing a shipped surface for failures that appear only once composited.
 
-- Prefer findings you can see or measure in the screenshot/markup; estimate the contrast
-  ratio rather than hand-waving "low contrast."
-- A genuine WCAG-AA failure on interactive/text content is high severity; a borderline ratio
-  or a nice-to-have is medium/low.
-- One issue per finding: element, the failure, the fix.
+## When NOT to use
 
-If the surface is clean on these checks in both themes, say so in one line.
+- **No render.** Labels, input types, tab order and `aria-*` read off the diff belong to
+  [web-interface-guidelines-review](../web-interface-guidelines-review/SKILL.md).
+- **Setting a threshold.** [apca-contrast](../apca-contrast/SKILL.md) and
+  [wcag-contrast](../wcag-contrast/SKILL.md) own contrast;
+  [component-sizing-principles](../component-sizing-principles/SKILL.md) owns the height
+  ladder. Cite them, never re-derive them — this lens measures what the render gives the
+  pointer, not what the ladder should have been.
+- Non-visual diffs — routing, state wiring, backend. Nothing renders; stay silent.
+
+## What only the render shows
+
+1. **Composited contrast.** Report the sampled pair and value, then cite the owner:
+   [apca-contrast](../apca-contrast/SKILL.md) for Lc targets and the primary-model policy,
+   [wcag-contrast](../wcag-contrast/SKILL.md) for the 2.2 thresholds and the
+   points-not-pixels rule. Obey the system's declared primary model and name it; absent
+   one, the pairing fails if either model fails.
+2. **Focus rings, in place.** Source shows a ring exists; only the render shows it
+   survives — clipped by an ancestor `overflow: hidden`, drowned against the *actual*
+   adjacent surface, or gone in forced-colors. **SC 2.4.11 Focus Not Obscured (Minimum),
+   AA in 2.2** is separate: sticky chrome covering the focused control fails even with a
+   perfect ring, so capture the row scrolling under it. Ring contrast is SC 1.4.11;
+   **SC 2.4.13 Focus Appearance is AAA** — an enhancement, never an AA failure. Tooltips
+   and hover cards have their own rule: hoverable, dismissible without moving the pointer,
+   persistent (**SC 1.4.13, AA**).
+3. **Hit area, as laid out.** **SC 2.5.8, AA — 24 by 24 CSS px**, then the spacing
+   exception: undersized targets pass when a 24 px-diameter circle centred on each
+   bounding box does not intersect another target's circle. Dense icon toolbars fail on
+   spacing more often than on size, so measure the gap too. Touch surfaces have a higher
+   platform floor; read that platform's HIG. The ladder behind the height is
+   [component-sizing-principles](../component-sizing-principles/SKILL.md).
+4. **Meaning that can vanish.** **SC 1.4.1 Use of Color, A** — status as red/green with
+   no icon, text or shape; and on a render, meaning carried by a gradient or a shadow,
+   which forced-colors removes outright.
+5. **Names, as exposed.** A control that renders as a bare glyph must still expose a
+   name, so read the accessibility tree rather than `aria-*` in the source — `aria-label`
+   on a role-less element is never exposed (**SC 4.1.2, A**), and visual structure the
+   markup does not carry is **SC 1.3.1, A**.
+
+## The modes you must actually look at
+
+A mode not captured is not checked — name the ones you saw.
+
+| Mode | What fails first |
+|---|---|
+| **Light and dark**, both primary | Borders, disabled text, shadow-drawn separators |
+| **`forced-colors: active`** | `box-shadow` and `text-shadow` compute to `none`, `background-image` to `none` without a `url()` — anything drawn as a shadow or gradient is gone. System colours come from **native semantics, not ARIA roles** |
+| **`prefers-contrast: more`** | Deliberately subtle borders; placeholder text already near the floor |
+| **`prefers-reduced-motion`** | CSS transitions usually honour it; JS/WAAPI animation, autoplaying video and carousels usually do not |
+| **Reflow — SC 1.4.10, AA** | 320 CSS px wide (≈ 400% zoom at 1280), no two-dimensional scrolling; 256 CSS px tall when scrolling horizontally |
+| **Text spacing — SC 1.4.12, AA** | No loss of content at line-height 1.5×, paragraph 2×, letter-spacing 0.12em, word-spacing 0.16em: fixed-height buttons, single-line chips |
+
+Motion has two obligations: auto-starting motion over five seconds must be pausable
+(**SC 2.2.2, A**); disabling interaction-triggered motion is **SC 2.3.3, AAA**.
+`prefers-reduced-motion` is the mechanism, not the criterion.
+
+## Silent failures
+
+- **A `box-shadow` focus ring.** Passes source review and both theme screenshots, gone in
+  forced-colors. Fix: `outline` + `outline-offset` (only its colour is forced), or a
+  `@media (forced-colors: active)` rule.
+- **Reduced motion honoured in CSS only.** The `@media` block exists, the JS animation
+  ignores it, and screenshots are static so this lens never sees it. Check the JS/WAAPI
+  path, `<video autoplay>`, library defaults.
+- **A clean automated run read as a pass.** A checker reports what it can compute — not a
+  ring lost under sticky chrome, meaning in a gradient, or text over a photo.
+
+## Verification
+
+1. Every finding names element + mode + measured value + the SC with its level, or the
+   skill owning it. No bare "low contrast".
+2. Contrast findings cite [apca-contrast](../apca-contrast/SKILL.md) /
+   [wcag-contrast](../wcag-contrast/SKILL.md), name the system's primary model, and quote
+   a value sampled from the composited render rather than read off a token.
+3. No AAA criterion (2.4.13, 2.3.3) is reported as an AA failure, and focus was exercised
+   by tabbing rather than inferred from a `:focus-visible` rule.
+4. Every mode in the table is reported as checked or as not captured — including on a
+   clean surface, whose one-line pass **names the modes checked**. A clean report not
+   naming its modes is not evidence.
+
+## Sources
+
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/) — every SC above carries its published level
+  ([2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum),
+  [2.4.11](https://www.w3.org/TR/WCAG22/#focus-not-obscured-minimum)). 2.4.13 and 2.4.12
+  are **AAA** there, not AA.
+- [CSS Color Adjust 1](https://www.w3.org/TR/css-color-adjust-1/#forced) is normative for
+  the forced-colors `box-shadow` / `text-shadow` / `background-image` behaviour;
+  [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors) adds that
+  system colours come from native semantics, not ARIA roles.
+  [Media Queries 5](https://www.w3.org/TR/mediaqueries-5/#prefers-reduced-motion) defines
+  the preference queries.
+- **House convention, not a standard:** sampling the composited pixel; "a mode not
+  captured is not checked".
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** [apca-contrast](../apca-contrast/SKILL.md) — Lc targets and
+  which model is primary; [wcag-contrast](../wcag-contrast/SKILL.md) — the 2.2 thresholds
+  and the points-not-pixels rule. This lens measures; they own the numbers.
+- **Target size:** [component-sizing-principles](../component-sizing-principles/SKILL.md)
+  and [spacing-system](../spacing-system/SKILL.md). **Code side:**
+  [web-interface-guidelines-review](../web-interface-guidelines-review/SKILL.md) — a
+  finding makeable from the diff alone is theirs.
+- **Siblings:** [design-system-consistency](../design-system-consistency/SKILL.md)
+  (off-system, not inaccessible) · [visual-polish](../visual-polish/SKILL.md) (passes but
+  reads dull) · [designing-elite-ui](../designing-elite-ui/SKILL.md) (the bar).
+  [reviewing-design-work](../reviewing-design-work/SKILL.md) orders all four, and
+  [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md) drives the
+  browser pass producing these renders.

--- a/skills/visual-polish/SKILL.md
+++ b/skills/visual-polish/SKILL.md
@@ -1,43 +1,144 @@
 ---
 name: visual-polish
 description: >-
-  Visual review — hold the rendered UI to an elite bar: alignment, optical
-  centering, spacing rhythm, glyph/pattern quality, state coverage, theme
-  parity. Flag "fine but not elite," not only broken.
+  Use when judging execution craft on a RENDERED surface — screenshots or a live
+  page — as the polish lens of a design review: optical versus metric alignment,
+  hairlines and half-pixel blur, whether spacing reads as grouping, the full
+  state and content matrix, theme parity beyond colour, RTL and long-locale
+  mirroring, clutter. Flags "fine but not elite", not only broken. Judges craft,
+  not values — whether a chosen step is on the system's scale belongs to
+  design-system-consistency, whether a pairing is legible to frontend-a11y, and
+  what the bar is to designing-elite-ui. Cite when a review passes a surface off
+  one light-mode screenshot at seed content, when a nit arrives without the
+  concrete upgrade, or when a polish fix is proposed as a magic pixel value.
 kind: design
 applies_to:
-  paths: ["site/**", "app/**", "**/components/**", "**/ui/**"]
-  extensions: [".tsx", ".jsx", ".css", ".scss", ".vue", ".svelte"]
+  paths: ["site/**", "app/**", "**/site/**", "**/app/**", "**/components/**", "**/ui/**", "**/styles/**"]
+  extensions: [".tsx", ".jsx", ".vue", ".svelte", ".astro", ".html", ".css", ".scss"]
 ---
 
 # Visual polish
 
-You are judging the **rendered** change (screenshots, light and dark) against a
-Figma-grade bar. Most of what you flag will be "acceptable but not elite" — that is the
-point. Cite the element and where it sits in the screenshot.
+The craft lens on the **rendered** surface: whether what shipped is *executed* well, not
+whether its values are on-system or its pairings legible. Most of what you flag will be
+"acceptable but not elite" — that is the job, and every finding carries the concrete
+upgrade (the trim, the token, the missing cell), never just the verdict.
 
-## Flag
+## When to use
 
-1. **Alignment & optical centering.** Elements off a shared grid/baseline; an icon
-   geometrically centered in a button but optically off (glyphs with side-bearing need a
-   nudge); label and control not on the same baseline; ragged edges between siblings.
-2. **Spacing rhythm.** Inconsistent gaps in a list/stack; cramped or floaty padding; a
-   section that breaks the vertical rhythm the rest of the page establishes.
-3. **Glyph & pattern quality.** Blurry/missized icons, mismatched stroke widths, a pattern
-   or texture that tiles visibly or clips, emoji where a real glyph is warranted.
-4. **State coverage.** Interactive elements missing a distinct hover / focus-visible /
-   active / disabled state, or states that are present but indistinguishable.
-5. **Theme parity.** Compare the light and dark screenshots: a color that loses contrast,
-   a shadow that vanishes, a border that disappears, or an asset baked for one theme only.
-6. **Clutter & duplication.** Redundant chrome, two affordances doing the same job,
-   competing focal points, or content that overflows / truncates awkwardly at the captured
-   viewport.
+- Judging a rendered surface against a Figma-grade bar inside a design review.
+- A component or layout changed and renders exist across themes and states.
+- Comparing a build against the design file — what differs is usually craft, not intent.
 
-## How to judge
+## When NOT to use
 
-- Ask "would this ship in a top-tier product?" If it's *fine but not elite*, flag it with
-  the concrete upgrade (the nudge, the token, the missing state).
-- Severity: layout breakage or an unreadable state is high; polish gaps are medium/low.
-- One issue per finding; name the element, say what's off, say the fix.
+- **No render.** This lens has nothing to read.
+- **The value is off-system** — [design-system-consistency](../design-system-consistency/SKILL.md).
+  "That gap is 13 px in a 4/8 system" is drift; "those two gaps read identical and should
+  not" is polish.
+- **The pairing is illegible, or the target too small** —
+  [frontend-a11y](../frontend-a11y/SKILL.md). A polish nit never outranks a measured
+  success-criterion failure, and never gets filed as one.
+- **Deciding what the bar *is*** — [designing-elite-ui](../designing-elite-ui/SKILL.md).
+  This lens applies a bar; it does not set one.
 
-If the surface is genuinely polished in both themes, say so — don't manufacture nits.
+## What to look at
+
+1. **Optical vs metric alignment.** Glyphs carry side bearings and asymmetric mass, so a
+   box-centred element is not eye-centred: a play triangle in a round button reads
+   left-heavy, and a cap-height label metric-centred in a pill sits low because the empty
+   descender space counts. Fix by trimming the text box (`text-box-trim` / `text-box`,
+   where supported) rather than hand-tuning `line-height`, and nudge a glyph *toward its
+   optical centroid* — give the direction and the reason, not a magic pixel count.
+2. **Hairlines and half-pixel blur.** A border landing on a fractional device pixel
+   renders grey and soft. Usual causes: an odd container height with a centred child,
+   `translate(-50%)` on an odd width, a fractional `scale` on an ancestor, a 1 px rule
+   inside a transformed parent. Recognise it as a divider crisp on one side and mushy on
+   the other, or one that vanishes at a particular zoom. Fix the geometry — even
+   dimensions, integer offsets — not the colour.
+3. **Rhythm has to read as grouping.** Grouping is perceived from *relative* distance, so
+   the gap inside a group must be visibly smaller than the gap between groups. When both
+   land on the *same* legal step, every value passes and the hierarchy is gone — a form
+   where each label looks equidistant from its own field and the next one. Fix: two
+   distinct steps. [spacing-system](../spacing-system/SKILL.md) owns the scale; this lens
+   owns whether the chosen steps read.
+4. **The state and content matrix.** Two axes, both usually under-covered. States: rest,
+   hover, focus-visible, active, disabled, loading, error. Content: empty, one item, long
+   string, overflow, slow network. Flag cells that are *missing* and cells that are
+   *present but indistinguishable* — hover and active rendering identically is the same
+   defect as no hover at all. A disabled state built from opacity alone often drops its
+   label under the contrast floor; that half is [frontend-a11y](../frontend-a11y/SKILL.md)'s.
+5. **Theme parity beyond colour.** Dark is not light inverted. A drop shadow is a
+   light-surface device — over near-black there is little left to darken, so elevation has
+   to come from surface lightness, which is why Material's dark guidance makes higher
+   surfaces *lighter* rather than shadowing them harder. Low-alpha borders that read on
+   white disappear on near-black, and assets bake the assumption in: a raster logo with a
+   white matte, an SVG with a hardcoded fill where `currentColor` belongs.
+6. **Direction and locale.** In RTL the layout mirrors, and so do direction-encoding
+   icons (back, next, indentation); icons depicting real objects — a clock, a printer — do
+   not, and a blanket `scaleX(-1)` over the icon set is the usual bug. Long-locale strings
+   are the honest test of a fixed-width label.
+7. **Clutter and duplication.** Two affordances doing one job, competing focal points,
+   chrome restating what the content already says, decoration carrying no meaning.
+
+## Silent failures
+
+- **Captured at one DPR.** Hairline blur and antialiasing differences only show at 1×;
+  a 2× capture flatters the surface. Say which DPR the evidence came from.
+- **Captured at seed content.** "Jane Doe" and three rows hide every truncation and every
+  empty state. Re-capture with real strings, one item, and none.
+- **The fix landed as a magic number.** A 2 px optical nudge hardcoded is drift the moment
+  density or type changes — it is a finding for
+  [design-system-consistency](../design-system-consistency/SKILL.md) on the next pass. The
+  fix is a trim, a token, or a geometry change.
+- **Motion judged from stills.** A transition that jumps, a hover that shifts layout, an
+  entrance animation replaying on every re-render: none of it is in a screenshot.
+- **Nits manufactured to look thorough.** A polished surface reported as polished is a
+  valid output; padding the list costs the reviewer's credibility on the findings that
+  matter.
+
+## Verification
+
+1. Every finding names the element, where it sits in the capture, what is off, and the
+   concrete upgrade. A verdict without an upgrade is not a finding.
+2. No finding proposes a raw value as the fix where a token, a trim or a geometry change
+   is available.
+3. Both themes were compared, and the DPR and content state of the evidence are stated.
+4. Findings that are really drift or really a11y were routed, not re-filed here — severity
+   never ranks a polish nit above a measured failure.
+5. A genuinely polished surface gets one line saying so, naming what was exercised.
+
+## Sources
+
+- [CSS Inline Layout 3 — `text-box-trim`](https://drafts.csswg.org/css-inline-3/#text-box-trim)
+  and [MDN `text-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-box) — the
+  standards-track replacement for hand-tuned `line-height` centring, plus its support.
+- [MDN `devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)
+  — why a 1 px rule is not one device pixel.
+- [Material 3 — elevation](https://m3.material.io/styles/elevation/overview): higher
+  surfaces are expressed lighter, which is why shadow-only elevation fails on dark.
+- [Apple HIG — right to left](https://developer.apple.com/design/human-interface-guidelines/right-to-left)
+  for which glyphs mirror.
+- **Design principle, not a spec:** grouping read from relative distance (Gestalt
+  proximity). **House convention:** "fine but not elite" is a legitimate finding, and so
+  is a clean verdict.
+
+## Cross-references
+
+- **REQUIRED BACKGROUND:** [designing-elite-ui](../designing-elite-ui/SKILL.md) — the bar
+  this lens applies, including the one-role-one-axis rule behind clutter findings. A critic
+  with no encoded bar finds nothing.
+- **Siblings, and the boundary with each:**
+  [design-system-consistency](../design-system-consistency/SKILL.md) — off-system values ·
+  [frontend-a11y](../frontend-a11y/SKILL.md) — measured contrast, focus, target failures.
+- **Scales these judgements sit on:** [spacing-system](../spacing-system/SKILL.md) (rhythm
+  steps) · [type-scale](../type-scale/SKILL.md) and
+  [line-height-grid](../line-height-grid/SKILL.md) (why a label sits low in its box) ·
+  [component-sizing-principles](../component-sizing-principles/SKILL.md) (siblings sharing
+  a rung).
+- **Code side:**
+  [web-interface-guidelines-review](../web-interface-guidelines-review/SKILL.md) — state
+  and transition rules readable from the diff. **Above:**
+  [reviewing-design-work](../reviewing-design-work/SKILL.md) orders the lenses and
+  [orchestrating-elite-agent-qa](../orchestrating-elite-agent-qa/SKILL.md) drives the
+  browser pass producing the states and themes this lens needs.

--- a/skills/wcag-contrast/SKILL.md
+++ b/skills/wcag-contrast/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wcag-contrast
-description: Use when verifying a color pair meets WCAG 2.2 AA contrast requirements as a cross-check on APCA-driven generation, or when auditing a token catalog or design for legal-baseline accessibility compliance. Names the 4.5:1 normal-text rule, the 3:1 large-text rule, the size threshold for "large" stated in points (≥ 18 pt regular ≈ 24 CSS px, OR ≥ 14 pt bold ≈ 18.67 CSS px — not pixels), the SC 1.4.11 non-text rule, SC 2.4.13 focus appearance (AA in 2.2), and the role this check plays alongside APCA. Cite when an agent treats WCAG as the *primary* contrast model, or writes the large-text threshold as "14 px bold / 18 px regular" — UDTS uses WCAG as a cross-check with APCA as primary, and WCAG sizes are in points.
+description: Use when verifying a color pair meets WCAG 2.2 AA contrast requirements as a cross-check on APCA-driven generation, or when auditing a token catalog or design for legal-baseline accessibility compliance. Names the 4.5:1 normal-text rule, the 3:1 large-text rule, the size threshold for "large" stated in points (≥ 18 pt regular ≈ 24 CSS px, OR ≥ 14 pt bold ≈ 18.67 CSS px — not pixels), the SC 1.4.11 non-text rule, SC 2.4.13 focus appearance (AAA — the AA hooks are 1.4.11 and 2.4.11), and the role this check plays alongside APCA. Cite when an agent treats WCAG as the *primary* contrast model, or writes the large-text threshold as "14 px bold / 18 px regular" — UDTS uses WCAG as a cross-check with APCA as primary, and WCAG sizes are in points.
 ---
 
 # WCAG 2.2 AA contrast
@@ -25,8 +25,9 @@ WCAG 2.2 Level AA is the **legal-baseline** contrast standard for most jurisdict
 | 1.4.3 | AA | Normal text | **4.5:1** | Text < 18 pt (24 CSS px) regular OR < 14 pt (~18.67 CSS px) bold |
 | 1.4.3 | AA | Large text | **3:1** | Text ≥ 18 pt (24 CSS px) regular OR ≥ 14 pt (~18.67 CSS px) bold |
 | 1.4.11 | AA | Non-text contrast | **3:1** | UI components, focus indicators, graphical objects |
-| 2.4.13 | **AA** (added in 2.2) | Focus appearance | Specific minimums | Verify the focus indicator is ≥ 2 px and meets 3:1 contrast against the focused control and adjacent background |
-| 2.4.12 | AAA (added in 2.2) | Focus not obscured (enhanced) | n/a | Focus indicator must not be obscured by author content |
+| 2.4.11 | **AA** (added in 2.2) | Focus not obscured (minimum) | n/a | The focused control must not be **entirely** hidden by author content — sticky headers, cookie bars, drawers |
+| 2.4.13 | **AAA** (added in 2.2) | Focus appearance | Specific minimums | Indicator ≥ 2 px perimeter and 3:1 against unfocused. **AAA — cite as an enhancement, never as an AA failure** |
+| 2.4.12 | AAA (added in 2.2) | Focus not obscured (enhanced) | n/a | Focus indicator must not be obscured **at all** by author content |
 
 **WCAG sizes are in points, not pixels** — a frequent miss. 1 pt = 1.333 CSS px, so:
 
@@ -75,6 +76,7 @@ For each contrast-bound pairing:
 
 - [WCAG 2.2 Recommendation — SC 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum) — text contrast.
 - [SC 1.4.11 — non-text contrast](https://www.w3.org/TR/WCAG22/#non-text-contrast).
-- [SC 2.4.13 — focus appearance (AA, added in 2.2)](https://www.w3.org/TR/WCAG22/#focus-appearance).
+- [SC 2.4.11 — focus not obscured, minimum (AA, added in 2.2)](https://www.w3.org/TR/WCAG22/#focus-not-obscured-minimum) — the AA hook for a focus ring being covered.
+- [SC 2.4.13 — focus appearance (**AAA**, added in 2.2)](https://www.w3.org/TR/WCAG22/#focus-appearance). Verified against the published Recommendation 2026-08-15; this skill previously said AA.
 - [SC 2.4.12 — focus not obscured, enhanced (AAA, added in 2.2)](https://www.w3.org/TR/WCAG22/#focus-not-obscured-enhanced).
 - [Contrast Checker, WebAIM](https://webaim.org/resources/contrastchecker/) — sanity-check tool that matches the spec.

--- a/skills/web-interface-guidelines-review/SKILL.md
+++ b/skills/web-interface-guidelines-review/SKILL.md
@@ -60,7 +60,7 @@ Apply each section in order. Stop and flag at the first failure in each section.
 ### 6. Focus + keyboard
 
 - **Focus-visible always.** Every interactive element has a visible focus ring on `:focus-visible`. The default Tailwind reset suppresses outlines; the system must re-add them.
-- **Focus ring contract:** ≥ 2 px thickness; 3:1 contrast against both the focused control's background AND the adjacent surface (WCAG 2.4.13, AA in WCAG 2.2). A well-formed system generates its focus token to satisfy this contract.
+- **Focus ring contract:** 3:1 against both the control and the adjacent surface — **1.4.11, AA**. The ≥ 2 px perimeter is **2.4.13, AAA**: an enhancement, never an AA failure. A well-formed system's focus token satisfies both.
 - **Keyboard reachability:** every interactive control is tabbable; tab order matches visual order.
 - **Escape closes overlays:** dialogs, popovers, dropdowns close on Escape.
 


### PR DESCRIPTION
Closes the delivery blocker on `arlyn-delivery` PR #1 (see #215 q4). These three ship to a client on **20 Aug** and then freeze permanently — that repo leaves the org, so for it a thin skill is not temporary.

## Before / after

| skill | before | after | headroom |
|---|---|---|---|
| `frontend-a11y` | 1,665 | **8,032** | 160 |
| `visual-polish` | 1,812 | **7,998** | 194 |
| `design-system-consistency` | 1,821 | **8,046** | 146 |

Catalog mean is 4,950 across 49. All three carry the full house frame; **in-degree 1 → 3** each.

**Treat these as at-ceiling.** Each hit 9–12 KB on first draft and was cut three times; any future addition must displace something.

## What #200 actually complained about, fixed

`frontend-a11y` asserted "WCAG AA 4.5:1" as the contrast model while **never naming** [apca-contrast] or [wcag-contrast] — the two skills that own those thresholds. It now declares both REQUIRED BACKGROUND with stated reasons and defers to the system s declared primary.

All three are written **dispatched, not standalone**: `reviewing-design-work` routes above them and `orchestrating-a-multi-agent-run` carries the family axioms, so none re-establishes framing something above it already supplies. That is the #205 discipline applied at write time rather than retrofitted.

## The correction that matters more than the stubs

**`wcag-contrast` stated SC 2.4.13 Focus Appearance as Level AA in three places; `web-interface-guidelines-review` in one. It is Level AAA.**

Verified against the published Recommendation at `w3.org/TR/WCAG22`, not a secondary source:

```
2.4.13 Focus Appearance              → (Level AAA)
2.4.11 Focus Not Obscured (Minimum)  → (Level AA)
1.4.11 Non-text Contrast             → (Level AA)
```

An agent following the old text would report a **AAA enhancement as an AA compliance failure** — in an accessibility audit that is a claim about legal baseline, made to a client. And **neither skill named 2.4.11 at all**, which is the actual AA hook for a focus ring being covered by sticky chrome. It is now in the table.

This was found by the agent writing `frontend-a11y`, because the new file had to declare `wcag-contrast` REQUIRED BACKGROUND and the two then contradicted each other. **The interlinking work surfaced the defect** — which is the argument for #200 in one example.

## A live instance of #213, handled per the ruling

The WCAG fix consumed **43 of `web-interface-guidelines-review`s 46 bytes** of headroom, leaving **3**. A file at 3 bytes forces the next editor to delete something — exactly #213.

Per the CEO s ruling — *rewrite the section rather than delete it* — I tightened **my own sentence**, the one that consumed the room, rather than cutting a rule elsewhere. Headroom back to **49**.

## Verified

- `python3 .github/scripts/validate_skills.py` → `OK: 49 skills validated cleanly`, exit 0
- `pytest tests/ -q` → **112 passed**
- **303 relative skill links catalog-wide, 0 broken**; all 12 external URLs return 200
- Five required sections byte-identical in all three; **zero backticked skill slugs** remain in them

## Flagged, deliberately not done here

- **`designing-elite-ui` is the fourth `kind: design` lens and is in the state these three were in** — no required sections, one backticked slug reference, 5,325 bytes. It ships to the same client and is REQUIRED BACKGROUND for `reviewing-design-work` and now `visual-polish`. **Recommend it joins this lane before the 20 Aug freeze.**
- **The five required sections are house convention, unenforced by CI** — the validator checks frontmatter, an H1, size and the placement map. Nothing catches a regression here. That is #202.
- **Section ordering is split 9/9** across the catalog (`Verification` before vs after `Cross-references`). I followed the brief; the catalog needs an owner s ruling, not a third variant.
- **The 24 px floor is stated as a height rule** in `spacing-system:99` and `component-sizing-principles:47`. SC 2.5.8 is 24 **by** 24 CSS px — a 120×20 button and a 20×40 button both fail.
- **`applies_to` widened** in all three (additive only) to catch monorepo layouts. `designing-elite-ui` still carries the narrow globs, so **the design family disagrees with itself until that is fixed** — revert mine or fix all four, but do not leave it split.