### PR TITLE
frontend-a11y: one word — the 2.5.8 disjunction read as either-suffices

### DIFF
--- a/skills/frontend-a11y/SKILL.md
+++ b/skills/frontend-a11y/SKILL.md
@@ -64,7 +64,7 @@ commonest false pass here.
    persistent (**SC 1.4.13, AA**).
 3. **Hit area, as laid out.** **SC 2.5.8, AA — 24 by 24 CSS px**, then the spacing
    exception: a 24 px circle on each **undersized** target must miss **another target's
-   box** — not its circle — or another undersized target's circle. So a 20 px button 1 px
+   box** — not its circle — and another undersized target's circle. So a 20 px button 1 px
    from a 40 px one fails. Dense icon toolbars fail on spacing more than size; measure the
    gap. Touch surfaces have a higher
    platform floor; read that platform's HIG. The ladder behind the height is


### PR DESCRIPTION
Closes #220.

`SKILL.md` stated the SC 2.5.8 spacing exception as **"must miss another target's box — not its circle — *or* another undersized target's circle."**

The spec states it in the indicative: *"the circles do **not** intersect another target **or** the circle for another undersized target"* — where the negation distributes and both conditions bind (`¬(A ∨ B) ≡ ¬A ∧ ¬B`).

Converting that to a **deontic** "must miss A or B" admits the either-suffices reading ("you must eat an apple or a pear"). Under that misreading, the exact case the sentence was written to catch passes again.

**Why it is minor, not critical:** the worked example immediately after — *"a 20 px button 1 px from a 40 px one fails"* — fails under the strict reading and passes under the lenient one, so a mis-parsing reader hits a contradiction and re-reads. That inoculates it in practice.

**Why fix it anyway:** this ships to a client as accessibility guidance, and it is one word.

Verified: `validate skills` clean, body 8128/8192, and the new `check prose retention` gate returns `OK: 1 changed SKILL.md file(s). No undeclared prose removal.`
