### PR TITLE
composing-a-screen: the prescriptive design spine the catalog never had

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 # python
 __pycache__/
 *.pyc
+
+# Playwright MCP session debris (console logs, page snapshots) — never repo content
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The design catalog is organized in three layers (locked by the CDO; executed in 
 | [`designing-a-design-system`](skills/designing-a-design-system/SKILL.md) | Dispatcher for **building or extending** a design system — routes through naming → color → non-color families → format/versioning → the elite bar → testing, in build order. |
 | [`reviewing-design-work`](skills/reviewing-design-work/SKILL.md) | Dispatcher for **reviewing or critiquing** design output — ordered lenses (code rules → rendered-surface lenses → the opinion bar) with routing rules for when the browser-driven design-critic pass fires. |
 | [`consuming-a-design-system`](skills/consuming-a-design-system/SKILL.md) | Dispatcher for **using** a design system in a product — token discipline, composition rules, DTCG install patterns, SemVer-aware upgrades, extend-vs-fork. |
+| [`composing-a-screen`](skills/composing-a-screen/SKILL.md) | Entry point for **making** a screen — the composition sequence in dependency order (rank → group → encode → space → lay out → conventionalise → target → clear the floors → defer). Carries the principles nothing else owns: hierarchy, proximity as a between-to-within ratio, measure and column count, alignment axes, progressive disclosure, Jakob's and Fitts's. |
 
 ### L0 — universal primitives
 

--- a/docs/decisions-branches/feat__composing-a-screen.md
+++ b/docs/decisions-branches/feat__composing-a-screen.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-18 02:04 - Add composing-a-screen: the prescriptive spine the design catalog never had
+
+**Reasoning:** Measured coverage against the seven basics a free Figma resource page covers: contrast 12 skills, accessibility 12, consistency 3, hierarchy 1, alignment 1, proximity 0, progressive disclosure 0 (control: zorkmid 0, design 24). The catalog grew out of design-critic needing citable lenses, so depth accumulated exactly where a finding can be argued numerically and nowhere near where design judgement lives. Every design skill was review-framed; nothing told an agent how to compose a screen. The CEO's test was that a ten-second Google search covered our four zeros.
+
+**Alternatives considered:** Extend designing-elite-ui, or grow empirical-design-principles into the spine. Rejected: the first is the visual bar and this is structure, and the second explicitly scopes itself to falsifiable prediction and disclaims usability heuristics including progressive disclosure. A third option, doing nothing on the grounds that the depth already exists, fails because depth an agent cannot route to is not coverage.
+
+**Implications:**
+- L1 and opt-in, diverging from the other three dispatchers' catalog-only: catalog-only makes a subscribing repo raise a placement verdict, which would make this skill un-installable by the repos it is written for. Deliberately absent from census_counters STRUCTURAL_L0, so zero subscriptions reads as a real gap rather than by-design. A refute-first panel caught three defects that would have shipped guidance making screens worse: Fitts stated backwards, a hierarchy rule forbidding redundant coding, and a proximity metric that scored an inverted layout as ideal. The skill's own severability grep then caught that the body contained zero instances of 'progressive disclosure' — it would have scored 0 on the very census query that established the gap, the same defect PR #233 has. Body 8097 bytes, 95 headroom. Whether an agent actually designs better with it is untested and stated as a hypothesis, not a result; the behavioural diff has not been run.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -7,8 +7,6 @@ agent-skills
 ├── .claude
 │   ├── commands
 │   ├── skills
-│   ├── worktrees
-│   ├── scheduled_tasks.lock
 │   └── settings.json
 ├── .github
 │   ├── ISSUE_TEMPLATE

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -92,9 +92,6 @@ agent-skills
 ├── .cursorrules
 ├── .gitattributes
 ├── .gitignore
-├── .merge_file_Ggwrba
-├── .merge_file_OVMET7
-├── .merge_file_QRUAns
 ├── AGENTS.md
 ├── CLAUDE.md
 ├── LICENSE

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -7,6 +7,8 @@ agent-skills
 ├── .claude
 │   ├── commands
 │   ├── skills
+│   ├── worktrees
+│   ├── scheduled_tasks.lock
 │   └── settings.json
 ├── .github
 │   ├── ISSUE_TEMPLATE
@@ -33,6 +35,7 @@ agent-skills
 │   ├── clud-bug-collaboration
 │   ├── component-sizing
 │   ├── component-sizing-principles
+│   ├── composing-a-screen
 │   ├── consuming-a-design-system
 │   ├── conventions-template
 │   ├── critical-issues-only
@@ -89,6 +92,9 @@ agent-skills
 ├── .cursorrules
 ├── .gitattributes
 ├── .gitignore
+├── .merge_file_Ggwrba
+├── .merge_file_OVMET7
+├── .merge_file_QRUAns
 ├── AGENTS.md
 ├── CLAUDE.md
 ├── LICENSE

--- a/docs/placement-map.json
+++ b/docs/placement-map.json
@@ -201,6 +201,8 @@
       "notes": "L1 dispatcher — entry point that routes to review lenses; a repo consumes what it routes to, not the dispatcher itself as a standing subscription"
     },
     "composing-a-screen": {
+      "family": "design-dispatchers",
+      "owns": "laying out a screen",
       "authoring_home": "catalog",
       "distribution": "opt-in",
       "subscribers": [],

--- a/docs/placement-map.json
+++ b/docs/placement-map.json
@@ -200,6 +200,12 @@
       "subscribers": [],
       "notes": "L1 dispatcher — entry point that routes to review lenses; a repo consumes what it routes to, not the dispatcher itself as a standing subscription"
     },
+    "composing-a-screen": {
+      "authoring_home": "catalog",
+      "distribution": "opt-in",
+      "subscribers": [],
+      "notes": "L1 entry point for MAKING a screen. Deliberately opt-in rather than the other L1 dispatchers' catalog-only, and that is a reasoned divergence rather than an oversight: those route to lenses a repo consumes directly, so the dispatcher itself need not travel. This one also CARRIES the principles nothing else in the catalog owns — hierarchy, proximity as a between-to-within ratio, measure, alignment axes, progressive disclosure, Jakob's and Fitts's — so catalog-only would make a subscribing repo raise a placement verdict for installing the only copy of that content. Not added to census_counters STRUCTURAL_L0: it is L1, so zero direct subscriptions is a real gap, not by design."
+    },
     "curating-a-skill-catalog": {
       "family": "catalog-and-tooling",
       "owns": "the census rubric and verdicts",

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (21 decisions)
+## 2026-08 (22 decisions)
 
 - **2026-08-18** — Close the review's four real holes in the catalog directory: a retired skill filed as live, a probe scan that reddened foreign PRs, growth numbers with no owner, and a README nothing reconciled *(feat/catalog-directory)* — [decisions-branches/feat__catalog-directory.md](decisions-branches/feat__catalog-directory.md)
-- *... 19 more decisions ...*
+- *... 20 more decisions ...*
 - **2026-08-14** — Gate skill size with a shrink-only ratchet, and deprecate skillforge into the three skills that own its job *(feat/skill-depth-and-interlinking)* — [decisions-branches/feat__skill-depth-and-interlinking.md](decisions-branches/feat__skill-depth-and-interlinking.md)
 
 ## 2026-07 (13 decisions)

--- a/skills/composing-a-screen/SKILL.md
+++ b/skills/composing-a-screen/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: composing-a-screen
+description: |
+  Entry point for MAKING a screen — deciding what is primary, what groups with what, what shares an edge, and what waits behind a click, before any pixel, token, or component is picked. Names the composition sequence (rank → group → encode → space → lay out → conventionalise → target → clear the floors → defer) and carries the principles nothing else in this catalog owns: visual hierarchy and the attribute that must separate each level on its own, proximity as a between-to-within gap ratio rather than a pixel count, column count and measure, alignment as an axis count, and progressive disclosure with the three tests anything hidden must pass — plus Jakob's Law (standard / convention / confusion) and Fitts's Law (cut the distance before you grow the target). Use when asked which design principles apply to a screen, when a layout has to be composed from scratch, when ranking actions before picking button variants, or when an interface shows more at once than the task needs. Not the visual bar (designing-elite-ui), not judging work that already exists (reviewing-design-work), not the scales themselves (spacing-system, type-scale, component-sizing-principles), and not contrast or accessibility thresholds (apca-contrast, wcag-contrast, frontend-a11y). Cite when every element on a screen carries equal weight, when every gap is the same step, when a group's inner and outer spacing match, when a paragraph runs the full width of the viewport, or when every option is visible at once.
+---
+
+# Composing a screen
+
+Composition has a dependency order — you cannot encode a hierarchy you have not ranked, or space a group you have not drawn. Run the nine steps before writing markup and **write each step's answer down**; that list, not the markup, is this skill's output. Each step gives a default and what changes it, and where the answer is judgement it says so rather than fake a number.
+
+## When NOT to use
+
+- **Not this skill:** judging existing work → [reviewing-design-work](../reviewing-design-work/SKILL.md) · contrast and accessibility thresholds → [frontend-a11y](../frontend-a11y/SKILL.md), `apca-contrast`, `wcag-contrast` · empty, loading and error states, and whether the chosen steps read → [visual-polish](../visual-polish/SKILL.md).
+- **Pick values from, never invent:** [spacing-system](../spacing-system/SKILL.md), `type-scale`, `component-sizing-principles`, `line-height-grid`, `oklch-color-space`.
+- **REQUIRED BACKGROUND:** [designing-elite-ui](../designing-elite-ui/SKILL.md), the bar this must survive.
+
+## The sequence
+
+**1. Rank before you place.** *(Judgement, no threshold.)* What one task is this screen for; what must be read to *decide* to do it; what to *do* it; what only a minority asks for. **Rank 1 is one thing and one primary action.** Rank 4 and below is a disclosure *candidate* — collect them; step 9 adjudicates each. A list that won't write means too much content: cut, don't add a level.
+
+**2. Group before you space.** Draw the boundaries as *sets*, in prose. **Name each group in three words or fewer; a group you cannot name is not a group.** Separate with space alone, escalating only on a condition: a background shift when step 4's 2× won't fit the container, a shadow only for a floating plane, a border only when two adjacent groups need one.
+
+**3. Encode the hierarchy.** Give every level **one attribute that separates it on its own** — size, weight, colour, position, enclosure, whitespace. A second is free and helps; the failure is a level findable only by *intersecting* two that neighbouring levels each own — a conjunction, and conjunction search is far slower (~60 vs ~3 ms/item). **Default: three levels — size, then weight, then colour**; for a fourth spend position, enclosure or whitespace before you spend a conjunction. **De-emphasise before you emphasise:** if rank 1 doesn't stand out, lower 2 and 3.
+
+**4. Space by ratio, not by pixel — proximity is relative.** Per group compute **`between ÷ within`**. **Default ≥ 2** — two distinct steps off the ladder, never one step twice. **Below 1 the grouping is inverted**: items read with the wrong neighbours. Anchor the absolutes too — 16 within / 32–48 between for content, 8 / 16–24 for dense data. Across breakpoints **multiply the ramp, never add to it**: `+8px on desktop` drags every ratio toward 1.
+
+**5. Set the columns, then collapse the axes.** **Default: one column, body text 45–75 characters per line** — a full-viewport paragraph is the commonest agent layout defect and passes every other rule here. Then count the distinct start edges and baselines per group and drive it down. *(Judgement — no evidence backs a count.)* **Default: one axis per group**; an axis holding one element is a defect. Align to the **start**, never a hard-coded `left`, so RTL survives. Never justify body copy — a house rule, not a floor: SC 1.4.8 is **AAA** and asks only for an unjustify *mechanism* (F88). Centre nothing meant to be read. Right-align numerals **in a column**, never alone in a form.
+
+**6. Take the conventional form — Jakob's Law.** *"Users prefer your site to work the same way as all the other sites they already know"* (Nielsen 2000). Classify each control from memory: **standard** — you cannot name three products that differ (comply; deviating is a defect); **convention** — you can name three each way (comply unless you write the reason); **confusion** — no nameable pattern (choose freely). Defaults worth taking: logo upper-left linking home; nav top or left; account far right; breadcrumbs above the H1; submit ending its form, bottom-right of its group, cancel to its left and never primary; `×` top-right. Nielsen 2004 measured search *placement* as confusion, not standard — **the class you assume is the class you get wrong**. It governs placement and behaviour, **not** typeface, palette, motion, or voice.
+
+**7. Cut distance, then grow the target — Fitts's Law.** Movement time **rises** with the log of distance ÷ target size, and halving the distance buys about what doubling the target buys — so **cut distance first, which is free; raise size second, which costs layout**. Put the next action beside what was just touched, and **make the whole row or card the target, not the 16 px icon inside it**. **Name the input device first:** pointer → a 24 px floor, screen edges and corners effectively infinite; touch → 44 px comfortable, edges worth nothing.
+
+**8. Clear the floors, then stop.** Computed, not judged — and *layout* decisions, so settle them now rather than retrofitting: contrast (a pass is not legibility, and colour is never the only difference between two states), 24×24 CSS px targets, reflow at 320 CSS px with no two-dimensional scroll, containers that survive text-spacing overrides, repeated nav that keeps its relative order. Every SC number and conformance level is `frontend-a11y`'s; consistency past nav order is `design-system-consistency`'s.
+
+**9. Defer the rest — progressive disclosure.** **Default to visible** — hiding is a cost paid for a named reason. Every rank-4 candidate passes **all three** or stays on the screen:
+
+1. **Sufficiency** — the primary task completes, correctly, without opening it.
+2. **Decision-completeness** — the user can decide *whether* to do it without opening it. A hidden price or constraint fails here even when the task completes.
+3. **Predictability** — the trigger names its contents: "More options" fails, "Shipping options" passes. Better, derive it from what was just selected.
+
+Fail one and it does not get hidden. **Two levels maximum** — anything reachable only through another disclosure comes back out. **Never hide the whole navigation:** fully hidden cost ≥39% desktop task time, while a *combo* — top destinations visible, the rest behind a control — measured like fully visible, and is the mobile answer where the hamburger is standard. A wizard is *staged*, not progressive: everyone walks every stage.
+
+## Worked example — an invoice page
+
+Rank: 1 amount due + Pay; 2 due date and sender; 3 line items; 4 payment history → step 9. Groups: {amount, due date}, {from, to}, {line items}, {total}. Encoding: amount two size steps up and bolder (redundant, free), labels one weight down, nothing else coloured. Gaps: 8 within, 24 between → 3.0. Layout: one column at 60ch, one start axis, totals right-aligned. Deferred: "Payment history (3)" — passes all three.
+
+## Verification
+
+1. **Blur test.** Blur ~8 px and read the rank order off it. Ambiguous, or not step 1's order, means hierarchy failed.
+2. **Gap ratios.** Per group print `between ÷ within`: below 1 inverted, 1–1.5 a defect, 1.5–2 a warning.
+3. **Axis count.** Cluster elements by the edge their computed `text-align` uses, within 1 px, skipping centred text; a cluster of one is a stray axis.
+4. **Disclosure.** Depth ≤ 2; no trigger matching `More|Advanced|Options|Details` without a noun; primary task completed without opening anything hidden.
+5. **Deviations.** Every non-standard control from step 6 carries its written reason.
+
+## Sources
+
+Treisman & Gelade 1980 (the ms/item split; a continuum since Wolfe 2021) · Kubovy via Wagemans 2012 p. 1184 · Fitts 1954 · Nielsen 2000, 2004, 2006 · NN/g 2016, n=179. Scope: the grouping ratio is dot lattices transferred to UI, not measured on it — which is why 2 is a default, not a discovery.
+
+**Do not repeat:** modular type-scale ratios (1.25, 1.618) have no empirical validation, and "80% of customers lost" for Jakob's Law is uncited by Nielsen.

--- a/skills/finding-a-catalog-skill/SKILL.md
+++ b/skills/finding-a-catalog-skill/SKILL.md
@@ -73,6 +73,7 @@ Finding, censusing and authoring skills; decision logging; CLI conventions.
 ## Design: start here (L1)
 Three entry points. Each routes to the primitives below in work order.
 
+- `composing-a-screen` — laying out a screen
 - `consuming-a-design-system` — using a system in a product
 - `designing-a-design-system` — building or extending a system
 - `reviewing-design-work` — critiquing design output
@@ -139,7 +140,7 @@ go on advertising itself:
 - **The same discipline under its other name** -- `test-driven` matches **0** skills.
 - **Norman's design primitives** -- forcing functions, mapping, the two gulfs -- `forcing function` matches **0** skills.
 
-(Control: `APCA` matches 7, so the probe finds what is there.)
+(Control: `APCA` matches 8, so the probe finds what is there.)
 
 Not being named above is not evidence of absence either. Search `skills/`
 before concluding a second time -- and control the search against a term you


### PR DESCRIPTION
The catalog had no skill that tells an agent how to **make** a screen. This adds one.

## The gap, measured

Against the seven basics a free [Figma resource page](https://www.figma.com/resource-library/ui-design-principles/) covers, this 49-skill design-heavy catalog scored:

| principle | skills covering it |
|---|---|
| contrast | **12** |
| accessibility | **12** |
| consistency | 3 |
| hierarchy | 1 |
| alignment | 1 |
| **proximity** | **0** |
| **progressive disclosure** | **0** |

Controls: `zorkmid` → 0, `design` → 24, so the zeros discriminate.

Twelve skills deep on contrast, nothing on four of the seven. The catalog grew out of `design-critic` needing *citable* lenses, so depth accumulated exactly where a finding can be argued numerically and nowhere near where design judgement lives. Every design skill is review-framed. A ten-second Google search covered our four zeros.

## What this is

`composing-a-screen` — nine steps in dependency order, each handing back a default or a forbidden move rather than a description. Rank → group → encode → space → lay out → conventionalise → target → clear the floors → defer.

It **routes down** rather than restating: values come from `spacing-system`, `type-scale`, `component-sizing-principles`; thresholds from `frontend-a11y`, `apca-contrast`, `wcag-contrast`; the visual bar from `designing-elite-ui`, which it names as REQUIRED BACKGROUND.

Where the honest answer is judgement it says so — steps 1 and 5 are explicitly marked *(Judgement, no threshold.)* rather than inventing precision. The Sources block carries its own scope condition:

> the grouping ratio is dot lattices transferred to UI, not measured on it — which is why 2 is a default, not a discovery

and closes with a **Do not repeat** naming two things it refuses to assert (modular type-scale ratios; the uncited "80% of customers lost" for Jakob's Law).

## The panel caught three defects that would have made screens worse

Not stylistic — wrong in the direction that damages output:

1. **Fitts's Law stated backwards** — movement time "falls" with distance ÷ size.
2. **The hierarchy rule forbade redundant coding**, which is *faster*, not slower.
3. **The proximity metric was `longer ÷ shorter`**, which scores an inverted layout as ideal.

Then its own severability grep caught a fourth: the body contained **zero** instances of the exact phrase "progressive disclosure" (the step was titled *"Decide what waits behind a click"*), so the skill would have scored 0 on the very census query that established the gap — **the same defect the panel confirmed in PR #233**. Retitled; same for "accessibility", which had been compressed to "a11y".

## Verification

Four control probes, each seen to fail and recover:

| probe | injected | result |
|---|---|---|
| size gate | +143 B | `over the 8192-byte limit by 72` exit 1 → restore → `OK: 50` exit 0 |
| placement map | entry deleted | `missing an entry for: composing-a-screen` exit 1 → restore → exit 0 |
| link checker | `../visual-polish-NOPE/SKILL.md` | `BROKEN: 1` exit 1 → restore → `BROKEN: 0` exit 0 |
| slug checker | `` `zorkmid-scale` `` | `NOT-A-SKILL zorkmid-scale` exit 1 → restore → exit 0 |

Boundary-tested against the validator's own arithmetic: +95 B → `body is 8193 bytes, over ... by 1`. So **8,097 bytes, 95 headroom** is the gate's number, not mine.

Links verified by hand — 5 relative, all resolve; 8 backticked slugs, all real directories — because `check-links` does not read skill bodies (#234).

**`pytest` was unavailable in the build sandbox and is reported as unrun, not as passing.** CI runs it here.

## Placement

`opt-in`, diverging from the other three L1 dispatchers' `catalog-only`. Their note explains their choice — *"a repo consumes what it routes to, not the dispatcher itself"* — and that reasoning does not transfer: this one also **carries** the principles nothing else owns, so `catalog-only` would make a subscribing repo raise a placement verdict for installing the only copy of that content. Deliberately absent from `census_counters`' `STRUCTURAL_L0` frozenset, so zero subscriptions reads as a real gap rather than by-design.

## What it does not claim

It produces a correctly **organised** screen, not a beautiful one. It says nothing about colour, type personality, motion, or restraint, and cannot inside 8,192 bytes — that is `designing-elite-ui`'s job, which is why the REQUIRED BACKGROUND link is load-bearing rather than decorative.

**Whether an agent actually designs better with it is untested.** The behavioural diff — run an agent through a screen with and without this file — has not been done. Treat "it helps an agent design well" as a hypothesis this file makes testable, not a result.

## Reviewer notes

- `.gitignore` gains `.playwright-mcp/` — browser-automation debris found untracked in the tree; it should never be committable by anyone.
- My first draft of the `placement-map.json` edit reserialised and alphabetised the whole file (322-line diff for one entry, destroying a curated family grouping). Caught in self-review and redone as a 6-line textual insertion; the original 49 entries' order is preserved, verified programmatically.
- `docs/file-structure.md` is **deliberately not updated** — regenerating it adds `.claude/worktrees` and `scheduled_tasks.lock`, both `tracked-files=0, ignored=YES`. That is #221, and I am not committing gitignored paths into a tracked doc.
