### PR TITLE
The prose gate never compared added files — a skill could be added and gutted on the same branch, green

### DIFF
--- a/.github/scripts/check_prose_retention.py
+++ b/.github/scripts/check_prose_retention.py
@@ -1403,12 +1403,14 @@ def hatch_state(before: str, after: str, skill: str, net: int) -> str:
 # The one phrase that identifies each failure mode's annotation, owned here so
 # the message and the guidance `main` prints under it cannot drift apart --
 # `run` also annotates the ledger itself and any file it could not scope, and
-# `main` annotates any blob that would not come back. Those are four different
-# findings and they do not share a remedy. LOST_PROSE additionally carries the
-# count of undeclared removals.
+# `main` annotates any blob that would not come back and any added file whose
+# own history could not be walked. Those are five different findings and they
+# do not share a remedy. LOST_PROSE additionally carries the count of
+# undeclared removals.
 LOST_PROSE = "::this SKILL.md lost "
 UNSCOPABLE_FILE = "::this SKILL.md's YAML frontmatter could not be located"
 UNREADABLE_BLOB = "::git lists this file as changed"
+UNWALKABLE_ADDITION = "::this SKILL.md was added within this range, but the commit"
 LEDGER_REWOUND = "::this change takes "
 SLOTS_WITHDRAWN = f"back OUT of {LEDGER}"
 
@@ -1440,13 +1442,19 @@ def run(
 ) -> list[str]:
     """Check every (path -> (before, after)) pair. Returns error annotations.
 
-    `cases` carries every SKILL.md modified between the two revisions, renames
-    included, keyed by its path at head. Whole-file additions and deletions are
-    deliberately out of scope: git renders those as a file appearing or
-    disappearing, which review cannot miss, and `main` says out loud how many
-    it skipped. This gate exists for the removal that hides inside an
-    otherwise-ordinary edit -- which is how all three historical cases got
-    through.
+    `cases` carries every SKILL.md this gate could compare between the two
+    revisions -- modified, renamed, and added-then-changed within the range,
+    keyed by its path at head. A file added and never touched again has
+    nothing in `cases` for it: compared against the commit that introduced
+    it, its own first version, the loss is zero by construction, and that
+    silence is correct rather than a gap this function has.
+
+    Whole-file DELETIONS alone stay deliberately out of scope: a dead file has
+    nothing left to protect, git renders the deletion as a file disappearing,
+    which review cannot miss, and `main` says out loud how many it skipped.
+    This gate exists for the removal that hides inside an otherwise-ordinary
+    edit or an add -- which is how all three historical cases, and the gap
+    that let a whole-file add through undeclared, got through.
     """
     ledger = LedgerDiff(ledger_before, ledger_after)
     errors: list[str] = []
@@ -1596,6 +1604,14 @@ REMEDIES = [
         False,
     ),
     (
+        UNWALKABLE_ADDITION,
+        "Each file named above was listed as added, and the commit that first "
+        "introduced it inside the range could not be found, so it was never "
+        "compared against that first version. Check the checkout step sets "
+        "`fetch-depth: 0`.",
+        False,
+    ),
+    (
         SLOTS_WITHDRAWN,
         f"Put back every line this change took out of {LEDGER}. While anything "
         f"is missing from that file, no row the change adds counts at all.",
@@ -1703,13 +1719,50 @@ def _show(rev: str, path: str) -> str | None:
         raise Undecodable(rev, path) from None
 
 
+def _first_appearance(base: str, head: str, path: str) -> str | None:
+    """The earliest commit in `base..head` that touched `path`.
+
+    Called only for a path git's own diff already calls ADDED between `base`
+    and `head` -- the file does not exist at `base`, so some commit inside the
+    range must have created it, and that commit's own version of the file is
+    what a whole-file add should be compared against instead of `base`, where
+    it is not there to compare against at all. `base` itself was never a
+    candidate: comparing to the version at `base` is exactly what a plain
+    modification does, and this path does not have one.
+
+    None only when the range could not be walked at all -- a clone too
+    shallow to enumerate `base..head` for this path. That is the same
+    shallow-clone failure `main`'s own base-resolution guard already refuses
+    on rather than silently passing over, so a caller gets `None` back rather
+    than an empty result it could mistake for "no commits touched this path",
+    which cannot happen for a path git itself calls added.
+    """
+    got = _git("log", "--reverse", "--format=%H", f"{base}..{head}", "--", path)
+    if got.returncode != 0:
+        return None
+    shas = [ln for ln in got.stdout.splitlines() if ln]
+    return shas[0] if shas else None
+
+
 class Diff:
     """What changed between two revisions, split into what this gate can judge.
 
-    `cases` are the modified and renamed SKILL.md files, keyed by their path at
-    head. `added` and `deleted` are counted but not compared, and `main` says
-    so out loud: a gate that prints OK without mentioning what it left out is
-    reporting success over a comparison it did not make.
+    `cases` are the modified, renamed and added-then-changed SKILL.md files,
+    keyed by their path at head. A file added within the range is compared
+    against the commit that first introduced it, not against `base`, where it
+    does not exist -- so a skill added in one commit and gutted in a later one
+    on the same branch is still caught. A file added and never touched again
+    compares against itself and has nothing in `cases` for it, which is
+    correct: the loss is zero by construction, not a comparison skipped.
+
+    `deleted` is counted but not compared -- a dead file has nothing left to
+    protect. `unresolved_added` is the one whole-file-add case still out of
+    scope on purpose: a path git calls added whose own history inside
+    `base..head` could not be walked, the shallow-clone failure `main`'s own
+    base-resolution guard already refuses on rather than passes over. `main`
+    says so out loud for both `deleted` and `unresolved_added`: a gate that
+    prints OK without mentioning what it left out is reporting success over a
+    comparison it did not make.
     """
 
     def __init__(self) -> None:
@@ -1718,6 +1771,7 @@ class Diff:
         self.deleted: list[str] = []
         self.renamed: list[tuple[str, str]] = []
         self.unreadable: list[tuple[str, str]] = []
+        self.unresolved_added: list[str] = []
 
     def pair(self, base: str, old: str, head: str, new: str) -> None:
         """Record one before/after comparison, whatever the paths were called.
@@ -1778,11 +1832,14 @@ def collect(base: str, head: str) -> Diff:
     large enough cut drops a real rename below the default, turning it back
     into an add plus a delete.
 
-    A cut deep enough to fall below 25% still lands there, and this gate does
-    not compare it -- but `main` prints the count of files added and deleted
-    whole rather than a bare OK, so the run says what it did not look at. At
-    that depth git itself renders the change as a file disappearing, which is
-    the out-of-scope class review cannot miss.
+    A cut deep enough to fall below 25% still lands there as an add plus a
+    delete rather than a rename, and the delete half of that split is not
+    compared -- the file this gate would compare the new path's ADD half
+    against, in turn, is the commit within `base..head` that first introduced
+    it, not `base` itself, where a wholly new path never has a version to
+    diff against. `main` prints the count of files added and deleted whole
+    rather than a bare OK either way, so the run says what it did and did not
+    look at.
     """
     diff = Diff()
     got = _git(
@@ -1803,7 +1860,13 @@ def collect(base: str, head: str) -> Diff:
             diff.renamed.append((old, new))
             diff.pair(base, old, head, new)
         elif status.startswith("A"):
-            diff.added.append(skill_paths[0])
+            path = skill_paths[0]
+            diff.added.append(path)
+            first = _first_appearance(base, head, path)
+            if first is None:
+                diff.unresolved_added.append(path)
+            else:
+                diff.pair(first, path, head, path)
         elif status.startswith("D"):
             diff.deleted.append(skill_paths[0])
         else:  # M, and anything else git reports as a content change
@@ -1889,6 +1952,15 @@ def main(argv: list[str] | None = None) -> int:
         f"compared and no verdict is reported for it."
         for rev, path in diff.unreadable
     ]
+    errors += [
+        f"::error file={path}{UNWALKABLE_ADDITION} that first introduced it "
+        f"could not be found by walking {base}..{args.head}, so it was not "
+        f"compared against its first version and no verdict is reported for "
+        f"it. git lists this path as added, which means some commit inside "
+        f"that range must have created it -- check the checkout step sets "
+        f"`fetch-depth: 0`."
+        for path in diff.unresolved_added
+    ]
     errors += run(diff.cases, ledger_before, ledger_after)
 
     if errors:
@@ -1925,12 +1997,22 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    skipped = ""
-    if diff.added or diff.deleted:
-        skipped = (
-            f", plus {len(diff.added)} added and {len(diff.deleted)} deleted "
-            "whole, which this gate does not compare"
+    # `added` is no longer "which this gate does not compare" -- it is, against
+    # the commit that introduced each one, which is why it gets its own clause
+    # rather than sharing `deleted`'s. Reaching this line at all means
+    # `diff.unresolved_added` was empty, so every added file WAS compared.
+    noted = []
+    if diff.added:
+        noted.append(
+            f"{len(diff.added)} added, each compared against its first "
+            "version within this range"
         )
+    if diff.deleted:
+        noted.append(
+            f"{len(diff.deleted)} deleted whole, which this gate does not "
+            "compare"
+        )
+    skipped = f", plus {'; '.join(noted)}" if noted else ""
     print(
         f"OK: {len(diff.cases)} changed SKILL.md file(s){skipped}. "
         "No undeclared prose removal."

--- a/docs/decisions-branches/fix__prose-gate-added-files.md
+++ b/docs/decisions-branches/fix__prose-gate-added-files.md
@@ -1,0 +1,15 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-18 04:24 - Compare a within-range added SKILL.md against its first-appearance commit, not base, so a same-branch add-then-gut is caught
+
+**Reasoning:** check_prose_retention.py only ever diffed against base, so a file that did not exist at base (git status A) was recorded in diff.added and never compared at all. An author could add a skill in one commit and gut it in the next commit on the same branch and the gate printed OK -- reproduced live: 5 skills added on feat/nominate-thrill-studio-skills (PR #233) get zero content verdict from this gate today. The gate's own OK line was honest about the gap ('which this gate does not compare'), which is what let a reviewer's control catch it before the gate did.
+
+**Alternatives considered:** Diff added files against base with an empty-string 'before' -- rejected: base has no version of the file at all, so every word in a new skill would score as a fabricated loss the moment anyone touched it again, false-firing on ordinary iteration (see test_cli_control_a_skill_added_then_only_grown_stays_quiet)., Compare against the immediately preceding commit on the branch instead of the first appearance -- rejected: a gutting commit followed by an innocuous rewrap-only commit would net to zero against its immediate predecessor while still being a real loss against what the branch actually introduced (see test_cli_compares_an_added_file_against_its_first_appearance_not_its_predecessor, which pins exactly this discriminator)., Silently fall back to 'no verdict' when an added file's within-range history cannot be walked (shallow clone) -- rejected: that is reporting success over a comparison that was never made, the exact failure main()'s own base-resolution guard already refuses on. Hard-errors instead via a new unresolved_added / UNWALKABLE_ADDITION path, mirroring the existing UNREADABLE_BLOB stance.
+
+**Implications:**
+- A file added and never touched again now compares against itself via _first_appearance and finds nothing -- correctly silent, not a second special case.
+- A file added then deleted within the same range never enters git's two-tree diff at all (absent from both base and head), so it stays exactly as invisible to this gate as it is to a human reviewing the PR's Files view -- documented in Diff's docstring and pinned by test_cli_is_silent_on_a_skill_added_then_deleted_within_the_same_branch rather than left implicit.
+- The OK-line summary changed shape: an added file is no longer lumped with deleted files under 'which this gate does not compare' -- it now says 'compared against its first version within this range', so the message stays true of what the gate actually did. tests/test_check_prose_retention.py and tests/test_prose_retention_mutations.py both updated; 3 new mutation entries added for the new guard (added_files_stop_being_compared_to_their_first_appearance, first_appearance_compares_against_the_last_touch_not_the_first, unwalkable_added_history_silently_treated_as_unchanged).
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (24 decisions)
+## 2026-08 (25 decisions)
 
-- **2026-08-18** — Apply the panel's five fixes to PR #238: byte-identity, mirror ordering, exit-code parity, history-order pinning, and the index-absence gate *(feat/per-skill-versioning)* — [decisions-branches/feat__per-skill-versioning.md](decisions-branches/feat__per-skill-versioning.md)
-- *... 22 more decisions ...*
+- **2026-08-18** — Compare a within-range added SKILL.md against its first-appearance commit, not base, so a same-branch add-then-gut is caught *(fix/prose-gate-added-files)* — [decisions-branches/fix__prose-gate-added-files.md](decisions-branches/fix__prose-gate-added-files.md)
+- *... 23 more decisions ...*
 - **2026-08-14** — Gate skill size with a shrink-only ratchet, and deprecate skillforge into the three skills that own its job *(feat/skill-depth-and-interlinking)* — [decisions-branches/feat__skill-depth-and-interlinking.md](decisions-branches/feat__skill-depth-and-interlinking.md)
 
 ## 2026-07 (13 decisions)

--- a/tests/test_check_prose_retention.py
+++ b/tests/test_check_prose_retention.py
@@ -3298,9 +3298,13 @@ def test_cli_a_byte_identical_rename_is_not_counted_as_a_change(repo, capsys):
 
 
 def test_cli_ignores_a_new_skill_and_a_deleted_one(repo, capsys):
-    """Whole-file adds and deletes are out of scope -- git renders them as a
-    file appearing or disappearing, which review cannot miss -- but the gate
-    says how many it skipped rather than printing a bare OK over them.
+    """A whole-file DELETION is still out of scope -- git renders it as a file
+    disappearing, which review cannot miss, and a dead file has nothing left
+    to protect. A whole-file ADD is different: it is now compared against the
+    commit that introduced it, same as any other case -- see the block below.
+    Here gamma is touched by exactly one commit, so that comparison is against
+    itself and finds nothing to declare, correctly. The gate still says what
+    it did with each rather than printing a bare OK over them.
     """
     (repo / "skills" / "alpha" / "SKILL.md").write_text(BODY)
     base = commit(repo, "base")
@@ -3322,7 +3326,221 @@ def test_cli_ignores_a_new_skill_and_a_deleted_one(repo, capsys):
 
     assert cpr.main(["--base", base, "--head", "HEAD"]) == 0
     out = capsys.readouterr().out
-    assert "1 added and 1 deleted whole" in out, out
+    assert "1 added, each compared against its first version within this range" in out, out
+    assert "1 deleted whole, which this gate does not compare" in out, out
+
+
+# --- added files: compared against their first appearance in the range -----
+#
+# The gap this closes: `run()` and `collect()` only ever compared a file to
+# `base`. A skill that does not exist at `base` has nothing there to diff
+# against, so a whole-file add was skipped outright -- and an author could add
+# a skill in one commit and gut it in the very next commit on the same
+# branch, and the gate certified nothing about it. Found live on a real PR
+# that added five skills in one commit each: `OK: 0 changed SKILL.md file(s),
+# plus 5 added ... which this gate does not compare`, exit 0, on a branch
+# whose own history could have gutted any one of them right back.
+
+
+def test_cli_catches_a_skill_added_then_gutted_on_the_same_branch(repo, capsys):
+    """THE GAP ITSELF, reproduced and then closed: gamma does not exist at
+    `base` at all -- there is nothing there to compare it to -- and is added
+    in full by one commit and gutted by the very next commit, both on the
+    same branch. Before this fix this exact history printed "OK: 0 changed
+    SKILL.md file(s), plus 1 added ... which this gate does not compare" and
+    exited 0; the gate has to compare the gutting commit against the commit
+    that introduced the file, not against `base`, where the file is not
+    there to be compared against.
+    """
+    (repo / "skills" / "alpha" / "SKILL.md").write_text(LONG_BODY.format(name="alpha"))
+    base = commit(repo, "base -- gamma does not exist yet")
+
+    (repo / "skills" / "gamma").mkdir()
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(LONG_BODY.format(name="gamma"))
+    commit(repo, "add gamma in full")
+
+    cut = LONG_BODY.format(name="gamma").replace(
+        "The second paragraph gives the worked example and the counter-example.\n\n", ""
+    )
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(cut)
+    commit(repo, "gut gamma on the very next commit, same branch")
+
+    assert cpr.main(["--base", base, "--head", "HEAD"]) == 1
+    out = capsys.readouterr().out
+    assert "::error file=skills/gamma/SKILL.md::" in out, out
+    assert "worked example" in out, "the error should quote what got cut"
+
+
+def test_cli_control_a_skill_added_then_only_grown_stays_quiet(repo, capsys):
+    """The control for the test above: a gate that fires on any later touch to
+    a freshly added file is unusable for a skill built across more than one
+    commit, so pure growth after the add must stay silent.
+    """
+    (repo / "skills" / "alpha" / "SKILL.md").write_text(LONG_BODY.format(name="alpha"))
+    base = commit(repo, "base")
+
+    (repo / "skills" / "gamma").mkdir()
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(LONG_BODY.format(name="gamma"))
+    commit(repo, "add gamma")
+
+    grown = LONG_BODY.format(name="gamma") + (
+        "\nA fourth paragraph, written on the next commit, that only ever adds "
+        "words and takes none away.\n"
+    )
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(grown)
+    commit(repo, "grow gamma on the next commit, same branch")
+
+    assert cpr.main(["--base", base, "--head", "HEAD"]) == 0
+    assert "No undeclared prose removal" in capsys.readouterr().out
+
+
+def test_cli_is_quiet_on_a_skill_added_once_and_never_touched_again(repo, capsys):
+    """A file added and never modified again has nothing to compare -- that is
+    correct and must stay quiet, not become noise. Its only appearance in
+    `base..head` is the commit that added it, so it is compared against
+    itself and the loss is zero by construction.
+    """
+    (repo / "skills" / "alpha" / "SKILL.md").write_text(BODY)
+    base = commit(repo, "base")
+
+    (repo / "skills" / "gamma").mkdir()
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(LONG_BODY.format(name="gamma"))
+    commit(repo, "add gamma, touched exactly once")
+
+    assert cpr.main(["--base", base, "--head", "HEAD"]) == 0
+    out = capsys.readouterr().out
+    assert "No undeclared prose removal" in out, out
+    assert "OK: 0 changed SKILL.md file(s)" in out, out
+    assert "1 added, each compared against its first version within this range" in out, out
+
+
+def test_cli_compares_an_added_file_against_its_first_appearance_not_its_predecessor(
+    repo, capsys
+):
+    """Multiple commits touching the file within the range: compare against
+    the FIRST appearance, not the commit immediately before head. The last
+    commit here only rewraps what survived the cut before it -- against its
+    own immediate predecessor it loses nothing -- so a gate that compared each
+    added file to its most recent prior commit would stay silent. Compared to
+    the commit that actually introduced the file, the cut two commits back is
+    still there to be caught.
+    """
+    (repo / "skills" / "alpha" / "SKILL.md").write_text(LONG_BODY.format(name="alpha"))
+    base = commit(repo, "base")
+
+    full = LONG_BODY.format(name="gamma")
+    (repo / "skills" / "gamma").mkdir()
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(full)
+    commit(repo, "add gamma in full")
+
+    cut = full.replace(
+        "The second paragraph gives the worked example and the counter-example.\n\n", ""
+    )
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(cut)
+    commit(repo, "cut the second paragraph")
+
+    rewrapped = cut.replace(
+        "The third paragraph says what to do when the rule does not apply here.\n",
+        "The third\nparagraph says what to do when the rule does not apply here.\n",
+    )
+    assert collections.Counter(cpr.words(cut)) == collections.Counter(
+        cpr.words(rewrapped)
+    ), "the last commit must be a pure rewrap, or this test proves nothing"
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(rewrapped)
+    commit(repo, "rewrap the remaining paragraph, nothing else, same branch")
+
+    # Pinned rather than a bare non-zero: the excerpt heuristic only quotes a
+    # clean DELETE opcode (see `Loss.excerpt`), and the rewrap sitting right
+    # next to the cut can merge the two into one REPLACE block that names
+    # nothing -- that is a property of the excerpt, not of whether the cut was
+    # caught, so the count is what this test pins.
+    assert cpr.Loss(full, rewrapped).net == 10
+    assert cpr.main(["--base", base, "--head", "HEAD"]) == 1
+    out = capsys.readouterr().out
+    assert "::error file=skills/gamma/SKILL.md::this SKILL.md lost 10 words" in out, out
+
+
+def test_cli_is_silent_on_a_skill_added_then_deleted_within_the_same_branch(repo, capsys):
+    """A file added in the range and then deleted in the range exists at
+    neither `base` nor `head`, so `git diff base head` renders NOTHING for
+    that path -- the same as it would for a human looking at the pull
+    request's own Files view. This gate reads off that same two-tree diff, so
+    the file is as invisible to it as it is to review: not compared, not
+    counted as added, not counted as deleted.
+    """
+    (repo / "skills" / "alpha" / "SKILL.md").write_text(BODY)
+    base = commit(repo, "base")
+
+    (repo / "skills" / "gamma").mkdir()
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(LONG_BODY.format(name="gamma"))
+    commit(repo, "add gamma")
+    (repo / "skills" / "gamma" / "SKILL.md").unlink()
+    (repo / "skills" / "gamma").rmdir()
+    commit(repo, "delete gamma again, same branch")
+
+    assert cpr.main(["--base", base, "--head", "HEAD"]) == 0
+    out = capsys.readouterr().out
+    assert "gamma" not in out, out
+    assert out.strip() == "OK: 0 changed SKILL.md file(s). No undeclared prose removal."
+
+
+def test_cli_refuses_to_pass_when_an_added_files_history_cannot_be_walked(
+    repo, capsys, monkeypatch
+):
+    """Shallow clones / unreachable revisions: the base-resolution guard in
+    `main` already hard-errors on an unresolvable base rather than skipping
+    silently. This is the same stance for a path whose OWN history within
+    `base..head` cannot be walked -- a clone too shallow to enumerate the
+    commits that touched it. Never a silent OK, and never silently treated as
+    brand new (nothing lost) when whether anything was lost could not be
+    determined at all.
+    """
+    (repo / "skills" / "alpha" / "SKILL.md").write_text(BODY)
+    base = commit(repo, "base")
+
+    (repo / "skills" / "gamma").mkdir()
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(LONG_BODY.format(name="gamma"))
+    commit(repo, "add gamma")
+
+    monkeypatch.setattr(cpr, "_first_appearance", lambda base, head, path: None)
+    assert cpr.main(["--base", base, "--head", "HEAD"]) == 1
+    out = capsys.readouterr().out
+    assert "skills/gamma/SKILL.md" in out, out
+    assert "OK:" not in out, out
+    assert "fetch-depth" in out, out
+
+
+def test_first_appearance_finds_the_earliest_commit_touching_the_path(repo):
+    """Unit-level: the helper itself, not through `main`."""
+    (repo / "skills" / "alpha" / "SKILL.md").write_text(BODY)
+    base = commit(repo, "base")
+
+    (repo / "skills" / "gamma").mkdir()
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(LONG_BODY.format(name="gamma"))
+    first = commit(repo, "add gamma")
+
+    (repo / "skills" / "gamma" / "SKILL.md").write_text(
+        LONG_BODY.format(name="gamma") + "\nmore\n"
+    )
+    commit(repo, "touch gamma again")
+
+    assert (
+        cpr._first_appearance(base, "HEAD", "skills/gamma/SKILL.md") == first
+    )
+
+
+def test_first_appearance_returns_none_when_the_range_cannot_be_walked(repo):
+    """The real failure path, not a mock: an unresolvable revision on one end
+    of the range makes `git log` itself fail, and the helper reports that as
+    `None` rather than raising or silently returning an empty result that
+    would read the same as "no commits touched this path".
+    """
+    (repo / "skills" / "alpha" / "SKILL.md").write_text(BODY)
+    commit(repo, "base")
+
+    assert cpr._first_appearance(
+        "nope-not-a-ref", "HEAD", "skills/alpha/SKILL.md"
+    ) is None
 
 
 def test_cli_ignores_a_shrinking_file_that_is_not_a_skill(repo, capsys):

--- a/tests/test_prose_retention_mutations.py
+++ b/tests/test_prose_retention_mutations.py
@@ -484,6 +484,49 @@ MUTATIONS = [
         '    fields = [f if f.isascii() else \'"%s"\' % f for f in out.split("\\0") if f]',
     ),
     (
+        # A file added within the range stops being compared to the commit
+        # that introduced it, restoring the exact gap this module closes: add
+        # a skill in one commit and gut it in the next on the same branch, and
+        # the gate goes back to certifying nothing about it.
+        "added_files_stop_being_compared_to_their_first_appearance",
+        "        elif status.startswith(\"A\"):\n"
+        "            path = skill_paths[0]\n"
+        "            diff.added.append(path)\n"
+        "            first = _first_appearance(base, head, path)\n"
+        "            if first is None:\n"
+        "                diff.unresolved_added.append(path)\n"
+        "            else:\n"
+        "                diff.pair(first, path, head, path)",
+        "        elif status.startswith(\"A\"):\n"
+        "            diff.added.append(skill_paths[0])",
+    ),
+    (
+        # `_first_appearance` compares against the LAST commit in the range
+        # that touched the path instead of the FIRST -- for a file added and
+        # then gutted with nothing after, that last commit is the gutting
+        # commit itself, so the file is compared against its own head version
+        # and the loss is zero by construction every time.
+        "first_appearance_compares_against_the_last_touch_not_the_first",
+        "    shas = [ln for ln in got.stdout.splitlines() if ln]\n"
+        "    return shas[0] if shas else None",
+        "    shas = [ln for ln in got.stdout.splitlines() if ln]\n"
+        "    return shas[-1] if shas else None",
+    ),
+    (
+        # A range this gate cannot walk for an added file -- the shallow-clone
+        # case -- silently falls back to comparing the file to itself instead
+        # of refusing. That is reporting success over a comparison that was
+        # never made, the one thing this gate's own base-resolution guard
+        # already refuses to do.
+        "unwalkable_added_history_silently_treated_as_unchanged",
+        "    got = _git(\"log\", \"--reverse\", \"--format=%H\", f\"{base}..{head}\", \"--\", path)\n"
+        "    if got.returncode != 0:\n"
+        "        return None",
+        "    got = _git(\"log\", \"--reverse\", \"--format=%H\", f\"{base}..{head}\", \"--\", path)\n"
+        "    if got.returncode != 0:\n"
+        "        return head",
+    ),
+    (
         # A blob git named that will not come back is dropped in silence again,
         # so the count in the success line stops meaning what it says.
         "unreadable_blobs_dropped_in_silence",


### PR DESCRIPTION
The prose-retention gate did not compare files **added** within the base..head range. So an author could add a skill in one commit and gut it in the next commit on the same branch, and the gate reported success.

Found by a reviewer's own control while verifying #233 — not by the gate.

## The gap, reproduced both before and after

Exit codes captured into a variable, never read after a pipe:

```
BEFORE   add a skill (50 words), gut it in the next commit   EXIT=0   "…plus 1 added and 0 deleted
                                                                       whole, which this gate does
                                                                       not compare"
AFTER    identical case                                       EXIT=1   "this SKILL.md lost 53 words
                                                                       that nothing in the same part
                                                                       of it replaced"
CONTROL  added once, never touched again                      EXIT=0   silent — no false positive
```

**This was live on #233**, which adds five skills, so the gate certified nothing about their substance.

## The fix

For a path git reports as `A` between base and head, `_first_appearance()` walks `git log --reverse base..head -- path` and returns the earliest commit that touched it; `collect()` compares head against **that** rather than skipping the file. `Diff.pair`'s existing `before != after` guard means a file touched once produces no case — silent and correct, with no special-casing.

Cases pinned by test:

| case | behaviour |
|---|---|
| added, never modified again | silent |
| added, modified several times | compares against the **first** appearance, not the predecessor — the test constructs a case where comparing to the predecessor nets zero (pure rewrap) but the first-appearance comparison still finds a 10-word cut two commits back |
| added then deleted within the range | invisible to `git diff base head` in either tree, so **as invisible to this gate as to a human reading the Files view** — pinned as such rather than claimed OK |
| unwalkable history (shallow clone) | **hard error** `UNWALKABLE_ADDITION`, matching the existing base-resolution stance. Never report success from an absence. |

## Honesty preserved

The gate already *declared* this limitation, which is why it was findable at all. That honesty is kept: the OK line no longer lumps added files into "which this gate does not compare" — it now reads `"N added, each compared against its first version within this range"`, distinct from `"M deleted whole, which this gate does not compare"`. Deleted files remain genuinely out of scope and say so.

## Verification

**Red before green** — 7 tests written first, confirmed failing against unfixed source (`AttributeError: no attribute '_first_appearance'`, wrong exit codes, stale message text), then implemented.

**Three mutations added** to the existing harness, all confirmed red:
- `added_files_stop_being_compared_to_their_first_appearance` — restores the exact original gap
- `first_appearance_compares_against_the_last_touch_not_the_first` — `shas[0]` → `shas[-1]`
- `unwalkable_added_history_silently_treated_as_unchanged` — `return None` → `return head`

Plus a manual mutate/restore on the primary guard with the mutation **grepped in the tree** to confirm it landed before trusting the red.

**Full suite: 581 passed, exit 0** (captured via redirect and explicit `echo $?`).

## Against #233's real branch

```
OK: 6 changed SKILL.md file(s), plus 5 added, each compared against its first version
within this range. No undeclared prose removal.
```

**Not a false positive** — the 6 changed are the pre-existing skills that branch modifies (`git diff --name-status` confirms `M` on each); the 5 added are each a single commit, so comparing against their own first appearance correctly finds nothing, because there is genuinely no gutting commit there.

To prove the fix would actually fire on that branch rather than merely stay quiet, a detached follow-up commit was built with plumbing (`git commit-tree` — no checkout, no ref, nothing touched in any working tree) gutting `## Verification` out of `usability-heuristics`. The gate fired: `exit 1`, naming that file and that section, with no other file flagged.
