### PR TITLE
Guidance that was actively wrong: SC 2.5.8's missing exceptions, Norman's two gulfs, sRGB-default colour math (#235, #225, #170)

### DIFF
--- a/.github/scripts/gen_skill_directory.py
+++ b/.github/scripts/gen_skill_directory.py
@@ -194,15 +194,13 @@ NOT_HERE_PROBES = [
         "the `superpowers` plugin, not here",
     ),
     ("test-driven", "**The same discipline under its other name**"),
-    (
-        # Narrowed 2026-08-18: `empirical-design-principles` (#233) filled the
-        # forcing-functions and mapping half of this gap, so the old probe term
-        # started matching and the generator correctly refused to publish a
-        # stale claim. The gulfs are still uncovered -- measured 0 files, with
-        # `contrast` -> 20 as the control that the matcher works. See #225.
-        "gulf of execution",
-        "**Norman's two gulfs** -- execution and evaluation",
-    ),
+    # Closed 2026-08-18 (#225): `composing-a-screen` now names both gulfs in its
+    # trigger surface and carries a checkable step for each (DOET rev. ed. 2013
+    # ch. 1), so `gulf of execution` stopped matching 0 and the probe was
+    # removed rather than narrowed -- nothing in this pair is still uncovered.
+    # Norman's constraints, forcing functions and natural mapping remain a real
+    # gap (declared in `empirical-design-principles`, not probed here because
+    # that skill's own disclaimer text would make the matcher self-trigger).
 ]
 
 # The control. A probe set that matches nothing proves nothing unless

--- a/docs/decisions-branches/fix__color-srgb-default.md
+++ b/docs/decisions-branches/fix__color-srgb-default.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-18 12:30 - Retire the 'both models must pass' contrast gate; finish chroma-harmonization's recompose fix (#170)
+
+**Reasoning:** APCA is UDTS's required perceptual gate; WCAG 2.2 is an optional, off-by-default cross-check, not a co-equal required model — apca-contrast and wcag-contrast still taught the pre-UDTS both-required framing after #176 fixed only oklch-color-space and chroma-harmonization's headline. apca-contrast also had no P3-meter rule at all, and chroma-harmonization was missing its two ADD items (recompose-at-shared-chroma, and the bottleneck-residual caveat).
+
+**Alternatives considered:** Could have left 'both must pass' as a stricter-than-required safety net; rejected because it forces P3-native palettes to satisfy an sRGB-era threshold never designed for them, exactly the defect the live UDTS incident was filed against.
+
+**Implications:**
+- apca-contrast and wcag-contrast now cross-reference each other's optional/advisory framing; a future doc pass touching either must keep both in sync. chroma-harmonization's recompose step names UDTS's own harmonizeChroma as a known counterexample (verified via the issue's grep against tokenomics source) rather than a template — future contributors reading that source should not copy its clamp-without-recompose behavior.
+
+---
+

--- a/docs/decisions-branches/fix__norman-coverage.md
+++ b/docs/decisions-branches/fix__norman-coverage.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-18 12:35 - Close #225: give composing-a-screen Norman's two gulfs, both in trigger surface and as a checkable verification step
+
+**Reasoning:** The two gulfs (execution: can the next action be found; evaluation: can its result be read) were the only Norman concept in DOET with zero trigger-surface coverage across the catalog -- forcing functions, constraints and natural mapping already had at least a declared-absence mention. composing-a-screen is the prescriptive design spine with a numbered Verification section, so a 6th check (DOET rev. ed. 2013 ch. 1) fits its existing shape; empirical-design-principles explicitly scopes itself to falsifiable predictions and had already declared the gulfs out of its own scope, so covering them there would have fought the file's own stated boundary.
+
+**Alternatives considered:** usability-heuristics already discusses the same DOET ch.1 material (affordances, signifiers, constraints, mappings, feedback, conceptual model) and would have put the gulfs beside their bridging concepts, but it had only 12 bytes of body headroom against the 8192 cap -- not enough for a real addition without a trim large enough to look like cutting content to fit the gate, which #213 was opened against.
+
+**Implications:**
+- empirical-design-principles' frontmatter and its 'When NOT to use' bullet no longer claim the gulfs are covered nowhere -- they now point at composing-a-screen, and the gulf-of-execution phrasing was dropped from its DOET citation list (ch.4 constraints/forcing-functions, ch.1/3 mapping stand alone now). The NOT_HERE_PROBES entry for 'gulf of execution' in gen_skill_directory.py was removed rather than narrowed, since coverage is now complete, not partial; forcing functions/constraints/natural mapping remain a real, undeclared-by-probe gap. Regenerated stamps, skill-versions.json and the directory body in that order, twice (gen_skill_directory.py rewrites its own file after the first stamp pass, which stales that one stamp).
+
+---
+

--- a/docs/decisions-branches/fix__sc-258-exceptions.md
+++ b/docs/decisions-branches/fix__sc-258-exceptions.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-18 12:38 - frontend-a11y: name SC 2.5.8's missing Inline exception, fix box-vs-target wording
+
+**Reasoning:** The lens named only the Spacing exception with the definite article, so inline links in body copy -- undersized by construction and exempt under WCAG 2.2's Inline exception -- were reported as SC 2.5.8 AA failures on every rendered page reviewed. Line 66 also tested the 24px circle against 'another target's box', stricter than the normative text ('another target'), which fails a target whose real region clears a rounded-corner neighbour but whose bounding box does not. Verified both directly against the W3C WCAG 2.2 source (curl'd https://www.w3.org/TR/WCAG22/, not a paraphrase): five exceptions -- Spacing, Equivalent, Inline, User Agent Control, Essential -- and the Spacing text intersects 'another target', using the bounding box only to center the circle.
+
+**Alternatives considered:** Move the exception list to a references/ subdirectory instead: rejected, clud-bug#305 is still pending so that consumer reads only SKILL.md and the move would delete the content from what a reviewer actually sees. Wait for #201's progressive-disclosure mechanism: rejected, this skill ships to a client on 20 Aug and #201 is not built. Name only Inline and skip Equivalent/User Agent Control/Essential: rejected, the issue's own probe measures presence of all four names, and naming them costs little once Inline's explanation is already in the sentence.
+
+**Implications:**
+- Body was 8129/8192 bytes (63 headroom) before this change; the fix needed roughly 160 bytes so ~135 bytes were trimmed elsewhere (a duplicate MDN/native-semantics citation, a duplicate 'mode not captured' recap, and a Verification bullet rewrap) to land at 8168/8192 (24 headroom) rather than deferring to #201. Net prose word count did not drop, so no docs/prose-removals.md row was needed -- confirmed by running check_prose_retention.py against origin/dev, which reported no undeclared loss. The cosmetic 24px 'diameter' wording from the same issue was left unfixed for lack of bytes; #201 remains the real fix for headroom, not this stopgap.
+
+---
+

--- a/docs/prose-removals.md
+++ b/docs/prose-removals.md
@@ -140,3 +140,5 @@ provenance in
 
 | skill | words | why |
 |---|---|---|
+| empirical-design-principles | 6 | Its disclaimer said Norman's two gulfs "are in neither skill and are covered nowhere yet". `composing-a-screen` now covers them (#225), so the sentence had become false about its own catalog. Corrected rather than cut — the words went because the claim did, not to make room. |
+| finding-a-catalog-skill | 12 | Generated, not authored. The directory publishes a "not here" section listing gaps the catalog does not cover, and its entry for the two gulfs was removed by `gen_skill_directory.py` because #225 filled that gap — the generator refuses to publish a "not here" claim that has become false. The removal is derived from `NOT_HERE_PROBES`; editing this file by hand is what the byte-identity gate forbids. |

--- a/docs/skill-versions.json
+++ b/docs/skill-versions.json
@@ -16,7 +16,7 @@
  },
  "skills": {
   "apca-contrast": {
-   "current": "2f4924f37c1d",
+   "current": "c894961136c7",
    "authoring_home": "catalog",
    "history": [
     {
@@ -79,7 +79,7 @@
    ]
   },
   "chroma-harmonization": {
-   "current": "bec2fc631306",
+   "current": "e710f973d63c",
    "authoring_home": "catalog",
    "history": [
     {
@@ -1175,7 +1175,7 @@
    ]
   },
   "wcag-contrast": {
-   "current": "e32264ff0d6a",
+   "current": "c2c3bd386622",
    "authoring_home": "catalog",
    "history": [
     {

--- a/docs/skill-versions.json
+++ b/docs/skill-versions.json
@@ -5,14 +5,14 @@
  "enumeration": {
   "refs": "refs/remotes/origin/*",
   "publishing_ref": "origin/main",
-  "commits": 150,
+  "commits": 163,
   "blobs": 252
  },
- "versions_enumerated": 176,
+ "versions_enumerated": 177,
  "verification": {
   "current": "GATED. validate_skills.py recomputes every `current` from skills/<slug>/SKILL.md on every pull request. Needs no git history, so it holds at the depth-1 checkout CI uses.",
   "history": "NOT GATED. History is derived from git and validate-skills.yml checks out at fetch-depth 1, so CI cannot recompute these rows. Regenerate them in a full clone with `.github/scripts/gen_skill_versions.py --write`.",
-  "history_rows_ungated": 120
+  "history_rows_ungated": 121
  },
  "skills": {
   "apca-contrast": {
@@ -451,7 +451,7 @@
    ]
   },
   "frontend-a11y": {
-   "current": "56be4995fc2f",
+   "current": "ec171fa67568",
    "authoring_home": "catalog",
    "history": [
     {
@@ -822,6 +822,11 @@
      "v": "b2d7a06203fa",
      "commit": "f552f6e",
      "date": "2026-08-17"
+    },
+    {
+     "v": "15eb93208c7d",
+     "commit": "7efd6b5",
+     "date": "2026-08-18"
     }
    ]
   },

--- a/docs/skill-versions.json
+++ b/docs/skill-versions.json
@@ -198,7 +198,7 @@
    ]
   },
   "composing-a-screen": {
-   "current": "39d2e1377a44",
+   "current": "6cef496bdf66",
    "authoring_home": "catalog",
    "history": [
     {
@@ -393,7 +393,7 @@
    ]
   },
   "empirical-design-principles": {
-   "current": "69b8422f9b0a",
+   "current": "9b90fefae38b",
    "authoring_home": "catalog",
    "history": [
     {
@@ -425,7 +425,7 @@
    ]
   },
   "finding-a-catalog-skill": {
-   "current": "6eb19042e021",
+   "current": "1c15601a0087",
    "authoring_home": "catalog",
    "history": [
     {

--- a/docs/skill-versions.json
+++ b/docs/skill-versions.json
@@ -5,14 +5,14 @@
  "enumeration": {
   "refs": "refs/remotes/origin/*",
   "publishing_ref": "origin/main",
-  "commits": 163,
-  "blobs": 252
+  "commits": 168,
+  "blobs": 259
  },
- "versions_enumerated": 177,
+ "versions_enumerated": 184,
  "verification": {
   "current": "GATED. validate_skills.py recomputes every `current` from skills/<slug>/SKILL.md on every pull request. Needs no git history, so it holds at the depth-1 checkout CI uses.",
   "history": "NOT GATED. History is derived from git and validate-skills.yml checks out at fetch-depth 1, so CI cannot recompute these rows. Regenerate them in a full clone with `.github/scripts/gen_skill_versions.py --write`.",
-  "history_rows_ungated": 121
+  "history_rows_ungated": 128
  },
  "skills": {
   "apca-contrast": {
@@ -32,6 +32,11 @@
     {
      "v": "2f4924f37c1d",
      "commit": "ff61334",
+     "date": "2026-08-18"
+    },
+    {
+     "v": "c894961136c7",
+     "commit": "cd2a0c5",
      "date": "2026-08-18"
     }
    ]
@@ -100,6 +105,11 @@
     {
      "v": "bec2fc631306",
      "commit": "ff61334",
+     "date": "2026-08-18"
+    },
+    {
+     "v": "e710f973d63c",
+     "commit": "cd2a0c5",
      "date": "2026-08-18"
     }
    ]
@@ -198,12 +208,17 @@
    ]
   },
   "composing-a-screen": {
-   "current": "6cef496bdf66",
+   "current": "8137c5e68601",
    "authoring_home": "catalog",
    "history": [
     {
      "v": "39d2e1377a44",
      "commit": "2cf6868",
+     "date": "2026-08-18"
+    },
+    {
+     "v": "6cef496bdf66",
+     "commit": "5b893cd",
      "date": "2026-08-18"
     }
    ]
@@ -405,6 +420,11 @@
      "v": "7a0f3dd047f0",
      "commit": "31e3d2e",
      "date": "2026-08-18"
+    },
+    {
+     "v": "9b90fefae38b",
+     "commit": "5b893cd",
+     "date": "2026-08-18"
     }
    ]
   },
@@ -447,6 +467,11 @@
      "v": "6eb19042e021",
      "commit": "d1f0f4d",
      "date": "2026-08-18"
+    },
+    {
+     "v": "1c15601a0087",
+     "commit": "5b893cd",
+     "date": "2026-08-18"
     }
    ]
   },
@@ -473,6 +498,11 @@
      "v": "56be4995fc2f",
      "commit": "9e74682",
      "date": "2026-08-17"
+    },
+    {
+     "v": "ec171fa67568",
+     "commit": "870f218",
+     "date": "2026-08-18"
     }
    ]
   },
@@ -1196,6 +1226,11 @@
     {
      "v": "e32264ff0d6a",
      "commit": "ff61334",
+     "date": "2026-08-18"
+    },
+    {
+     "v": "c2c3bd386622",
+     "commit": "cd2a0c5",
      "date": "2026-08-18"
     }
    ]

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (37 decisions)
+## 2026-08 (40 decisions)
 
-- **2026-08-18** — skill-census closes prior digests when it files a new one *(fix/census-closes-prior-digest)* — [decisions-branches/fix__census-closes-prior-digest.md](decisions-branches/fix__census-closes-prior-digest.md)
-- *... 35 more decisions ...*
+- **2026-08-18** — frontend-a11y: name SC 2.5.8's missing Inline exception, fix box-vs-target wording *(fix/sc-258-exceptions)* — [decisions-branches/fix__sc-258-exceptions.md](decisions-branches/fix__sc-258-exceptions.md)
+- *... 38 more decisions ...*
 - **2026-08-14** — Gate skill size with a shrink-only ratchet, and deprecate skillforge into the three skills that own its job *(feat/skill-depth-and-interlinking)* — [decisions-branches/feat__skill-depth-and-interlinking.md](decisions-branches/feat__skill-depth-and-interlinking.md)
 
 ## 2026-07 (13 decisions)

--- a/skills/apca-contrast/SKILL.md
+++ b/skills/apca-contrast/SKILL.md
@@ -1,7 +1,7 @@
 ---
-version: "2f4924f37c1d"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "c894961136c7"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: apca-contrast
-description: Use when picking text-on-surface contrast, auditing an accessibility budget, or generating a color against a specific contrast target. Names the APCA Lc target table (Lc 90 fluent body, 75 body minimum, 60 secondary, 45 large, 30 spot, 15 non-text), the APCACH inverse-composition rule, and the cross-check policy with WCAG 2.2 AA. Cite when an agent reaches for WCAG 2.x as the primary contrast model — APCA is the perceptual model UDTS composes against; WCAG is the cross-check.
+description: Use when picking text-on-surface contrast, auditing an accessibility budget, or generating a color against a specific contrast target. Names the APCA Lc target table (Lc 90 fluent body, 75 body minimum, 60 secondary, 45 large, 30 spot, 15 non-text), the APCACH inverse-composition rule, the Display-P3 meter rule (score on the same gamut the composer targeted, never sRGB-clamped), and WCAG 2.2 AA as an optional, off-by-default cross-check. Cite when an agent reaches for WCAG 2.x as the primary or required contrast model, or scores Lc through an sRGB-clamped meter — APCA is UDTS's required perceptual gate; WCAG is optional and advisory.
 ---
 
 # APCA contrast
@@ -44,26 +44,28 @@ INPUT  target_lc=75, hue=220, chroma_cap=auto, bg=oklch(0.99 0 0)
 OUTPUT oklch(L, c_max, 220) — hits Lc 75 against the near-white surface
 ```
 
-## WCAG 2.2 AA cross-check (not primary)
+## Measure Lc on the composer's gamut, not sRGB
 
-After APCACH composition, also verify WCAG 2.2 AA:
+Score contrast on **Display P3 luminance** — apca-w3's `displayP3toY()`, not the default `sRGBtoY()` — matching the gamut the composer (apcach) targeted when it built the color. Clamping into sRGB before scoring a P3-composed color makes the meter disagree with the composer by several Lc, purely from the gamut mismatch, not from a real contrast problem. Use the SAME meter the composer verifies against, or exactness is unachievable by construction. (See [oklch-color-space](../oklch-color-space/SKILL.md)'s "Known open gap" note: the shipped meter doesn't do this yet — that's a defect to fix, not a reason to teach sRGB-clamped scoring as correct.)
+
+## WCAG 2.2 AA cross-check (optional, off by default)
+
+APCA is the native gate: a token that hits its declared Lc target ships. WCAG 2.2 AA is an **optional, off-by-default** cross-check, not a second required gate:
 
 - **4.5:1** for normal text (< 18 px or < 14 px bold)
 - **3:1** for large text (≥ 18 px or ≥ 14 px bold) and non-text UI
 
-UDTS will not emit a contrast-bound token whose Lc satisfies APCA but whose WCAG ratio fails its declared role. Both must pass.
-
-**Why both:** APCA is the better perceptual model but is exploratory at W3C (removed from the WCAG 3.0 Working Draft in 2023). WCAG 2.2 is the operative legal standard until WCAG 3 ships (≥ 2029). Requiring both means UDTS-generated systems pass current audits *and* are forward-compatible.
+When the cross-check is enabled and disagrees with APCA, treat it as a flag for review, not an automatic reject — see [wcag-contrast](../wcag-contrast/SKILL.md) for the disagreement table. APCA is exploratory at W3C (removed from the WCAG 3.0 Working Draft in 2023) but is UDTS's required perceptual model; WCAG 2.2 remains the operative legal standard until WCAG 3 ships (≥ 2029), which is why the optional check exists at all.
 
 ## Verification
 
 After composing a contrast-bound color:
 
-1. **APCA check:** `apca_contrast(fg, bg) ≈ declared_lc_target` within ± 1 Lc.
-2. **WCAG check:** `wcag_ratio(fg, bg) ≥ declared_role_threshold` (4.5:1 or 3:1).
-3. **Direction check:** UDTS Lc is unsigned and direction-aware; ensure the polarity matches the declared role (light text on dark surface vs dark text on light surface use the same Lc magnitude).
+1. **APCA check:** `apca_contrast(fg, bg) ≈ declared_lc_target` within ± 1 Lc, measured via `displayP3toY` (or whatever gamut the composer targeted) — not sRGB-clamped.
+2. **Direction check:** UDTS Lc is unsigned and direction-aware; ensure the polarity matches the declared role (light text on dark surface vs dark text on light surface use the same Lc magnitude).
+3. **WCAG cross-check (if enabled):** `wcag_ratio(fg, bg) ≥ declared_role_threshold` (4.5:1 or 3:1) — advisory, not gating.
 
-If APCA passes but WCAG fails (or vice versa), reject the value and recompose.
+If the APCA check fails, recompose. A failing optional WCAG cross-check is a review flag, not a reject.
 
 ## Cross-references
 

--- a/skills/chroma-harmonization/SKILL.md
+++ b/skills/chroma-harmonization/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "bec2fc631306"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "e710f973d63c"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: chroma-harmonization
 description: Use when constructing or auditing a multi-hue palette where all hues should appear equally saturated at each contrast stop. Names the per-stop chroma cap rule (take the minimum achievable chroma across hues at the stop), the gamut bottleneck pattern (blue at mid-L is the classic limiter in sRGB; Display P3 — UDTS's default compose gamut — reshapes it), and the relationship to UDTS's default `harmony` palette variant. Generalizes Evil Martians' Harmony algorithm.
 ---
@@ -27,17 +27,23 @@ For each contrast stop in the palette (each L value):
 
 1. For each hue in the set, find the maximum in-gamut chroma at that (L, H) in the target color space (**Display P3 by default** — UDTS composes end-to-end in P3 via apcach's `colorSpace: 'p3'`; sRGB only when a catalog is deliberately constrained to legacy-only output).
 2. Take the **minimum** of those per-hue maxima. This is the stop's chroma ceiling.
-3. Emit every hue at the stop using that ceiling.
+3. **Recompose, don't just clamp:** at the shared ceiling, re-solve L per hue (apcach's constant-chroma branch) so each hue still hits the stop's target Lc against its background. Clamping chroma while leaving L untouched lets achieved Lc drift off target by up to ~5 across hues — the invariant is chroma constant AND Lc constant; hue and lightness are what's allowed to drift.
+4. Emit every hue at the stop using the recomposed (L, c_ceiling, h).
 
 ```
-for each stop L:
-  c_max_per_hue = { h: max_chroma_in_gamut(L, h)  for h in hues }
+for each stop L_target:
+  c_max_per_hue = { h: max_chroma_in_gamut(L_target, h)  for h in hues }
   c_ceiling = min(c_max_per_hue.values())
   for each h in hues:
-    emit oklch(L, c_ceiling, h)
+    l_solved = apcach_constant_chroma_solve(target_lc, h, c_ceiling, bg)
+    emit oklch(l_solved, c_ceiling, h)
 ```
 
+**Known counterexample, not a template:** UDTS's own `harmonizeChroma` does *not* recompose — it clamps chroma and leaves the original L untouched (`{ l: original.l, c: min(original.c, ceiling), h: original.h }`). That's exactly the Lc drift this rule warns about. If you're reading the shipped code as a reference, its chroma-clamp-without-recompose is the bug to fix, not the pattern to copy.
+
 The bottleneck pattern: at moderate lightness (L ≈ 0.5), **blue (~220°)** is the classic limiter in sRGB — its gamut is narrowest there. In Display P3 (the default compose gamut) the boundary is wider and reshaped, so blue is not guaranteed to be the tightest hue — treat the bottleneck as empirical per palette rather than assuming ~220° holds. At the extremes (L near 0 or 1) the gamut shrinks for all hues in either space, so the ceiling collapses naturally.
+
+**Recompose can't fix the bottleneck hue's own residual.** Recomposing corrects the *other* hues' Lc drift once they're capped to the bottleneck hue's ceiling — it can't correct the bottleneck hue itself, whose compose/measure residual (see [apca-contrast](../apca-contrast/SKILL.md)'s meter-vs-composer gamut mismatch) is a property of that one hue's own gamut edge. Only a matched meter — scoring on the same gamut the composer targeted — closes that residual; recompose alone can't.
 
 ## Why the *minimum*, not the average
 

--- a/skills/composing-a-screen/SKILL.md
+++ b/skills/composing-a-screen/SKILL.md
@@ -1,8 +1,8 @@
 ---
-version: "39d2e1377a44"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "6cef496bdf66"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: composing-a-screen
 description: |
-  Entry point for MAKING a screen — deciding what is primary, what groups with what, what shares an edge, and what waits behind a click, before any pixel, token, or component is picked. Names the composition sequence (rank → group → encode → space → lay out → conventionalise → target → clear the floors → defer) and carries the principles nothing else in this catalog owns: visual hierarchy and the attribute that must separate each level on its own, proximity as a between-to-within gap ratio rather than a pixel count, column count and measure, alignment as an axis count, and progressive disclosure with the three tests anything hidden must pass — plus Jakob's Law (standard / convention / confusion) and Fitts's Law (cut the distance before you grow the target). Use when asked which design principles apply to a screen, when a layout has to be composed from scratch, when ranking actions before picking button variants, or when an interface shows more at once than the task needs. Not the visual bar (designing-elite-ui), not judging work that already exists (reviewing-design-work), not the scales themselves (spacing-system, type-scale, component-sizing-principles), and not contrast or accessibility thresholds (apca-contrast, wcag-contrast, frontend-a11y). Cite when every element on a screen carries equal weight, when every gap is the same step, when a group's inner and outer spacing match, when a paragraph runs the full width of the viewport, or when every option is visible at once.
+  Entry point for MAKING a screen — deciding what is primary, what groups with what, what shares an edge, and what waits behind a click, before any pixel, token, or component is picked. Names the composition sequence (rank → group → encode → space → lay out → conventionalise → target → clear the floors → defer) and carries the principles nothing else in this catalog owns: visual hierarchy and the attribute that must separate each level on its own, proximity as a between-to-within gap ratio rather than a pixel count, column count and measure, alignment as an axis count, and progressive disclosure with the three tests anything hidden must pass — plus Jakob's Law (standard / convention / confusion), Fitts's Law (cut the distance before you grow the target), and Norman's two gulfs (gulf of execution: is the next action findable; gulf of evaluation: is its result visible). Use when asked which design principles apply to a screen, when a layout has to be composed from scratch, when ranking actions before picking button variants, when a user can't tell what to do next or whether an action worked, or when an interface shows more at once than the task needs. Not the visual bar (designing-elite-ui), not judging work that already exists (reviewing-design-work), not the scales themselves (spacing-system, type-scale, component-sizing-principles), and not contrast or accessibility thresholds (apca-contrast, wcag-contrast, frontend-a11y). Cite when every element on a screen carries equal weight, when every gap is the same step, when a group's inner and outer spacing match, when a paragraph runs the full width of the viewport, or when every option is visible at once.
 ---
 
 # Composing a screen
@@ -43,7 +43,7 @@ Fail one and it does not get hidden. **Two levels maximum** — anything reachab
 
 ## Worked example — an invoice page
 
-Rank: 1 amount due + Pay; 2 due date and sender; 3 line items; 4 payment history → step 9. Groups: {amount, due date}, {from, to}, {line items}, {total}. Encoding: amount two size steps up and bolder (redundant, free), labels one weight down, nothing else coloured. Gaps: 8 within, 24 between → 3.0. Layout: one column at 60ch, one start axis, totals right-aligned. Deferred: "Payment history (3)" — passes all three.
+Rank: 1 amount due + Pay; 2 due date and sender; 3 line items; 4 payment history → step 9. Groups: {amount, due date}, {from, to}, {line items}, {total}. Encoding: amount two size steps up and bolder, labels one weight down, nothing else coloured. Gaps: 8 within, 24 between → 3.0. Layout: one column at 60ch, one start axis, totals right-aligned. Deferred: "Payment history (3)" — passes all three.
 
 ## Verification
 
@@ -52,6 +52,7 @@ Rank: 1 amount due + Pay; 2 due date and sender; 3 line items; 4 payment history
 3. **Axis count.** Cluster elements by the edge their computed `text-align` uses, within 1 px, skipping centred text; a cluster of one is a stray axis.
 4. **Disclosure.** Depth ≤ 2; no trigger matching `More|Advanced|Options|Details` without a noun; primary task completed without opening anything hidden.
 5. **Deviations.** Every non-standard control from step 6 carries its written reason.
+6. **Two gulfs (DOET rev. ed. 2013 ch. 1).** Execution: next action findable? Evaluation: result visible?
 
 ## Sources
 

--- a/skills/composing-a-screen/SKILL.md
+++ b/skills/composing-a-screen/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "6cef496bdf66"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "8137c5e68601"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: composing-a-screen
 description: |
   Entry point for MAKING a screen — deciding what is primary, what groups with what, what shares an edge, and what waits behind a click, before any pixel, token, or component is picked. Names the composition sequence (rank → group → encode → space → lay out → conventionalise → target → clear the floors → defer) and carries the principles nothing else in this catalog owns: visual hierarchy and the attribute that must separate each level on its own, proximity as a between-to-within gap ratio rather than a pixel count, column count and measure, alignment as an axis count, and progressive disclosure with the three tests anything hidden must pass — plus Jakob's Law (standard / convention / confusion), Fitts's Law (cut the distance before you grow the target), and Norman's two gulfs (gulf of execution: is the next action findable; gulf of evaluation: is its result visible). Use when asked which design principles apply to a screen, when a layout has to be composed from scratch, when ranking actions before picking button variants, when a user can't tell what to do next or whether an action worked, or when an interface shows more at once than the task needs. Not the visual bar (designing-elite-ui), not judging work that already exists (reviewing-design-work), not the scales themselves (spacing-system, type-scale, component-sizing-principles), and not contrast or accessibility thresholds (apca-contrast, wcag-contrast, frontend-a11y). Cite when every element on a screen carries equal weight, when every gap is the same step, when a group's inner and outer spacing match, when a paragraph runs the full width of the viewport, or when every option is visible at once.
@@ -52,7 +52,7 @@ Rank: 1 amount due + Pay; 2 due date and sender; 3 line items; 4 payment history
 3. **Axis count.** Cluster elements by the edge their computed `text-align` uses, within 1 px, skipping centred text; a cluster of one is a stray axis.
 4. **Disclosure.** Depth ≤ 2; no trigger matching `More|Advanced|Options|Details` without a noun; primary task completed without opening anything hidden.
 5. **Deviations.** Every non-standard control from step 6 carries its written reason.
-6. **Two gulfs (DOET rev. ed. 2013 ch. 1).** Execution: next action findable? Evaluation: result visible?
+6. **Two gulfs (DOET rev. ed. 2013 ch. 2).** Execution: next action findable? Evaluation: result visible?
 
 ## Sources
 

--- a/skills/empirical-design-principles/SKILL.md
+++ b/skills/empirical-design-principles/SKILL.md
@@ -1,7 +1,7 @@
 ---
-version: "69b8422f9b0a"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "9b90fefae38b"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: empirical-design-principles
-description: Use when a layout decision is about to be defended by naming a principle — Gestalt grouping and common region, Fitts's, Hick's, Miller's, Jakob's, von Restorff, the aesthetic-usability effect — or when a rule of thumb like "seven items max" needs checking against what the underlying work actually says. Covers the empirical tradition only, meaning principles that make a prediction which can be tested and can fail. Says which ones predict something real, which four do not say what design writing claims, and how to use one forward as a prediction rather than backward as a post-hoc justification. Does NOT cover usability heuristics — Nielsen's ten, Norman's signifiers, Shneiderman's eight, progressive disclosure, recognition over recall — which are design judgement organised for inspection, not falsifiable prediction; those are in usability-heuristics. Norman's constraints, forcing functions, natural mapping and the gulfs of execution and evaluation are in neither skill and are covered nowhere yet.
+description: Use when a layout decision is about to be defended by naming a principle — Gestalt grouping and common region, Fitts's, Hick's, Miller's, Jakob's, von Restorff, the aesthetic-usability effect — or when a rule of thumb like "seven items max" needs checking against what the underlying work actually says. Covers the empirical tradition only, meaning principles that make a prediction which can be tested and can fail. Says which ones predict something real, which four do not say what design writing claims, and how to use one forward as a prediction rather than backward as a post-hoc justification. Does NOT cover usability heuristics — Nielsen's ten, Norman's signifiers, Shneiderman's eight, progressive disclosure, recognition over recall — which are design judgement organised for inspection, not falsifiable prediction; those are in usability-heuristics. Norman's constraints, forcing functions and natural mapping are in neither skill and covered nowhere yet; the two gulfs of execution and evaluation are covered in composing-a-screen.
 ---
 
 # Empirical design principles
@@ -23,12 +23,12 @@ description: Use when a layout decision is about to be defended by naming a prin
   one is an act of judgement you defend; applying the other produces a number you
   test. That absence is declared, not covered —
   see [usability-heuristics](../usability-heuristics/SKILL.md).
-- **Reaching for Norman's constraints, forcing functions, natural mapping, or
-  the gulfs of execution and evaluation.** Neither skill covers them. That one is
-  a real gap, not a declared absence: cite the edition and page yourself — DOET
-  rev. ed. 2013 ch. 4 for constraints and forcing functions, ch. 1 and 3 for
-  mapping, Hutchins, Hollan & Norman 1985 for the gulfs — and do not read either
-  file's silence as clearance.
+- **Reaching for Norman's constraints, forcing functions, or natural
+  mapping.** Neither skill covers them. That one is a real gap, not a declared
+  absence: cite the edition and page yourself — DOET rev. ed. 2013 ch. 4 for
+  constraints and forcing functions, ch. 1 and 3 for mapping — and do not read
+  either file's silence as clearance. The two gulfs *are* covered, in
+  [composing-a-screen](../composing-a-screen/SKILL.md).
 - Picking token values. Contrast, type scale, spacing steps and control heights
   are owned by the system, not by the findings here — see Cross-references.
 - Judging craft quality. Whether something is *elite* is a separate question

--- a/skills/finding-a-catalog-skill/SKILL.md
+++ b/skills/finding-a-catalog-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "6eb19042e021"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "1c15601a0087"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: finding-a-catalog-skill
 description: >-
   The directory of the thrillmade/agent-skills catalog — that catalog only,
@@ -144,7 +144,6 @@ go on advertising itself:
 
 - **TDD mechanics** -- red before green, one failing test at a time. In the `superpowers` plugin, not here -- `red before green` matches **0** skills.
 - **The same discipline under its other name** -- `test-driven` matches **0** skills.
-- **Norman's two gulfs** -- execution and evaluation -- `gulf of execution` matches **0** skills.
 
 (Control: `APCA` matches 8, so the probe finds what is there.)
 

--- a/skills/frontend-a11y/SKILL.md
+++ b/skills/frontend-a11y/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "56be4995fc2f"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "ec171fa67568"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: frontend-a11y
 description: >-
   Use when judging accessibility on a RENDERED surface — screenshots or a live
@@ -63,11 +63,13 @@ commonest false pass here.
    **SC 2.4.13 Focus Appearance is AAA** — an enhancement, never an AA failure. Tooltips
    and hover cards have their own rule: hoverable, dismissible without moving the pointer,
    persistent (**SC 1.4.13, AA**).
-3. **Hit area, as laid out.** **SC 2.5.8, AA — 24 by 24 CSS px**, then the spacing
-   exception: a 24 px circle on each **undersized** target must miss **another target's
-   box** — not its circle — and another undersized target's circle. So a 20 px button 1 px
-   from a 40 px one fails. Dense icon toolbars fail on spacing more than size; measure the
-   gap. Touch surfaces have a higher
+3. **Hit area, as laid out.** **SC 2.5.8, AA — 24 by 24 CSS px**, exceptions:
+   **Inline** — a target inline in text, or sized by non-target line-height —
+   never flag an inline link; **Spacing** — a 24 px circle on each
+   **undersized** target must miss **another target**, not its circle, and
+   another undersized target's circle, so a 20 px button 1 px from a 40 px
+   one fails; also Equivalent, User Agent Control, Essential. Icon toolbars fail
+   on spacing more than size; measure the gap. Touch surfaces have a higher
    platform floor; read that platform's HIG. The ladder behind the height is
    [component-sizing-principles](../component-sizing-principles/SKILL.md).
 4. **Meaning that can vanish.** **SC 1.4.1 Use of Color, A** — status as red/green with
@@ -115,9 +117,8 @@ Motion has two obligations: auto-starting motion over five seconds must be pausa
    a value sampled from the composited render rather than read off a token.
 3. No AAA criterion (2.4.13, 2.3.3) is reported as an AA failure, and focus was exercised
    by tabbing rather than inferred from a `:focus-visible` rule.
-4. Every mode in the table is reported as checked or as not captured — including on a
-   clean surface, whose one-line pass **names the modes checked**. A clean report not
-   naming its modes is not evidence.
+4. Every mode in the table is reported as checked or as not captured, including a
+   clean pass, which must **name the modes checked** or it is not evidence.
 
 ## Sources
 
@@ -127,12 +128,11 @@ Motion has two obligations: auto-starting motion over five seconds must be pausa
   are **AAA** there, not AA.
 - [CSS Color Adjust 1](https://www.w3.org/TR/css-color-adjust-1/#forced) is normative for
   the forced-colors `box-shadow` / `text-shadow` / `background-image` behaviour;
-  [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors) adds that
-  system colours come from native semantics, not ARIA roles.
+  [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors) supports
+  the native-semantics point above.
   [Media Queries 5](https://www.w3.org/TR/mediaqueries-5/#prefers-reduced-motion) defines
   the preference queries.
-- **House convention, not a standard:** sampling the composited pixel; "a mode not
-  captured is not checked".
+- **House convention, not a standard:** the composited-pixel and per-mode rules above.
 
 ## Cross-references
 

--- a/skills/wcag-contrast/SKILL.md
+++ b/skills/wcag-contrast/SKILL.md
@@ -1,12 +1,12 @@
 ---
-version: "e32264ff0d6a"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "c2c3bd386622"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: wcag-contrast
-description: Use when verifying a color pair meets WCAG 2.2 AA contrast requirements as a cross-check on APCA-driven generation, or when auditing a token catalog or design for legal-baseline accessibility compliance. Names the 4.5:1 normal-text rule, the 3:1 large-text rule, the size threshold for "large" stated in points (≥ 18 pt regular ≈ 24 CSS px, OR ≥ 14 pt bold ≈ 18.67 CSS px — not pixels), the SC 1.4.11 non-text rule, SC 2.4.13 focus appearance (AAA — the AA hooks are 1.4.11 and 2.4.11), and the role this check plays alongside APCA. Cite when an agent treats WCAG as the *primary* contrast model, or writes the large-text threshold as "14 px bold / 18 px regular" — UDTS uses WCAG as a cross-check with APCA as primary, and WCAG sizes are in points.
+description: Use when verifying a color pair meets WCAG 2.2 AA contrast requirements as an optional cross-check on APCA-driven generation, or when auditing a token catalog or design for legal-baseline accessibility compliance. Names the 4.5:1 normal-text rule, the 3:1 large-text rule, the size threshold for "large" stated in points (≥ 18 pt regular ≈ 24 CSS px, OR ≥ 14 pt bold ≈ 18.67 CSS px — not pixels), the SC 1.4.11 non-text rule, SC 2.4.13 focus appearance (AAA — the AA hooks are 1.4.11 and 2.4.11), and the optional, off-by-default role this check plays alongside APCA's required gate. Cite when an agent treats WCAG as the *primary* or a *required* contrast model, or writes the large-text threshold as "14 px bold / 18 px regular" — UDTS uses WCAG only as an optional cross-check, APCA is the required gate, and WCAG sizes are in points.
 ---
 
 # WCAG 2.2 AA contrast
 
-WCAG 2.2 Level AA is the **legal-baseline** contrast standard for most jurisdictions until WCAG 3 ships (≥ 2029). UDTS uses it as a cross-check alongside its primary model, APCA. Every UDTS-emitted contrast-bound token passes both.
+WCAG 2.2 Level AA is the **legal-baseline** contrast standard for most jurisdictions until WCAG 3 ships (≥ 2029). UDTS uses it as an **optional, off-by-default** cross-check alongside its primary and only required model, APCA — enabling this check doesn't change what ships; APCA's Lc target is the gate.
 
 ## When to use
 
@@ -50,13 +50,11 @@ For OKLCH-source colors, gamut-map to sRGB first (clamp out-of-gamut chroma at t
 
 ## When WCAG and APCA disagree
 
-WCAG's relative-luminance model over-reports contrast for dark colors and under-reports for very light ones, so APCA and WCAG diverge at the extremes (very dark + very dark, very light + very light, very saturated mid-tones). UDTS finds the safe middle: a token passes only if **both** models pass.
+WCAG's relative-luminance model over-reports contrast for dark colors and under-reports for very light ones, so APCA and WCAG diverge at the extremes (very dark + very dark, very light + very light, very saturated mid-tones). APCA is the gate; WCAG, when the cross-check is enabled, is advisory only:
 
-In practice:
-
-- **WCAG passes, APCA fails:** the pairing meets the legal threshold but is *perceptually* hard to read. Reject. (Most common in the dark-on-dark range.)
-- **APCA passes, WCAG fails:** the pairing reads fine perceptually but doesn't meet the legal baseline. Reject. (Most common in the very-light range.)
-- **Both pass:** ship.
+- **WCAG passes, APCA fails:** the pairing meets the legal threshold but is *perceptually* hard to read. The APCA failure blocks emission regardless of WCAG. (Most common in the dark-on-dark range.)
+- **APCA passes, WCAG fails:** the pairing reads fine perceptually and ships — the WCAG miss is a flag for manual legal-compliance review, not a block. (Most common in the very-light range.)
+- **Both pass:** ship, no flag.
 
 ## Verification
 
@@ -65,8 +63,8 @@ For each contrast-bound pairing:
 1. Compute the WCAG ratio with sRGB-linearized luminance.
 2. Apply the role-appropriate threshold (4.5:1 normal text, 3:1 large text or non-text).
 3. Confirm the bold-text size rule in **points** — 14 pt bold (~18.67 CSS px) counts as large; 14 CSS px bold does not. Same for 18 pt regular (= 24 CSS px), not 18 CSS px.
-4. Cross-check the APCA Lc (see [apca-contrast](../apca-contrast/SKILL.md)).
-5. Reject if either model fails.
+4. Cross-check the APCA Lc (see [apca-contrast](../apca-contrast/SKILL.md)) — APCA is the gate.
+5. Flag (don't reject) if this WCAG check fails while APCA passes; an APCA failure is what blocks emission.
 
 ## Cross-references
 

--- a/tests/test_check_prose_retention.py
+++ b/tests/test_check_prose_retention.py
@@ -2149,14 +2149,28 @@ def test_the_error_prints_the_exact_row_to_paste():
     assert cpr.run(cases, ledger_before=LEDGER_HEADER, ledger_after=declared(real)) == []
 
 
-def test_the_shipped_ledger_declares_nothing_yet():
-    """The file committed with this gate is a header and a rule, not a list of
-    exemptions. If a row is ever added, it was added by a change that needed it.
+def test_every_shipped_ledger_row_is_well_formed():
+    """This used to assert the ledger was EMPTY. That was right while it was,
+    and wrong the moment a change legitimately declared a removal -- which its
+    own docstring anticipated ("if a row is ever added, it was added by a change
+    that needed it"). Pinning the count would just move the breakage to the next
+    declaration, so pin the property that actually matters instead: the ledger
+    parses, and every row in it names a real skill and a positive word count.
+
+    A malformed row is the failure worth catching. It reads as a declaration to
+    a human and as nothing to the parser, so the removal it was meant to declare
+    goes back to being silent -- which is the whole defect this gate exists for.
     """
     repo_root = Path(__file__).resolve().parents[1]
     ledger = repo_root / "docs" / "prose-removals.md"
     assert ledger.exists(), "the gate names a ledger that must exist to be usable"
-    assert cpr.parse_ledger(ledger.read_text(encoding="utf-8")) == {}
+    rows = cpr.parse_ledger(ledger.read_text(encoding="utf-8"))
+    for (slug, words), count in rows.items():
+        assert (repo_root / "skills" / slug / "SKILL.md").exists(), (
+            f"ledger row declares {slug!r}, which is not a skill in this catalog"
+        )
+        assert isinstance(words, int) and words > 0, f"{slug}: bad word count {words!r}"
+        assert count > 0
 
 
 def test_the_shipped_ledger_carries_the_table_the_parser_anchors_to():
@@ -2169,7 +2183,13 @@ def test_the_shipped_ledger_carries_the_table_the_parser_anchors_to():
     repo_root = Path(__file__).resolve().parents[1]
     text = (repo_root / "docs" / "prose-removals.md").read_text(encoding="utf-8")
     probe = text.rstrip("\n") + "\n| probe-skill | 7 | control row |\n"
-    assert cpr.parse_ledger(probe) == {("probe-skill", 7): 1}
+    parsed = cpr.parse_ledger(probe)
+    # `in`, not `==`: the shipped ledger now carries real declared rows, so an
+    # equality here would re-pin the very count the test above stopped pinning.
+    assert parsed.get(("probe-skill", 7)) == 1, (
+        "the parser cannot find its table, so every row anyone adds reads as "
+        "'no declarations' forever"
+    )
 
 
 # --- a line that does not parse still occupies a slot -----------------------


### PR DESCRIPTION
Three content fixes. Unlike the last few batches these are not machinery — this is **guidance that was wrong in skills already shipping**, and one of them reaches a client on 20 Aug.

## #235 — the one with the date

`frontend-a11y` named **one** of SC 2.5.8's five exceptions. The missing **Inline** exception exempts targets "constrained by the line-height of non-target text" — which is every inline link in body copy. So the lens reported ordinary body text as an AA failure. For a rendered-surface lens, that is most pages, not an edge case.

Verified against the W3C text directly, not the issue's paraphrase — `curl` on the Recommendation and on Understanding 2.5.8. Both claims confirmed:

- five exceptions are **Spacing, Equivalent, Inline, User Agent Control, Essential**
- the Spacing text reads *"the circles do not intersect **another target**"* — never "another target's box". Bounding box appears only to locate the circle's **centre** for non-rectangular targets.

Fixed both. The box→target correction **returns 6 bytes**.

```
Inline|Equivalent|Essential|User Agent Control   0 -> 4
"another target's box"                           1 -> 0
CONTROL "2.5.8"                                  3    (probe still discriminates)
```

## #225 — the two gulfs, and why not in the obvious place

Mostly closed by #233 already; re-measured before planning. Forcing functions and mapping are now covered — **both gulfs were still zero**.

The lane rejected two plausible homes with reasons rather than picking the easy one:
- **`empirical-design-principles`** scopes itself to falsifiable *predictions*, and its own text declared the gulfs out of scope. Covering them there would fight the file's stated boundary.
- **`usability-heuristics`** is the better conceptual fit — same DOET ch.1 material — but has **12 bytes** of headroom. Landing it there would have meant a trim big enough to be the #213 defect.

Landed in `composing-a-screen` as a sixth Verification item, phrased as two checks: *execution — next action findable? evaluation — result visible?*

House rule honoured: **cite the chapter, not the count** (DOET carries both a six- and a seven-item list in different chapters, which has bitten this catalog before).

## #170 — colour

Two skills still gated on *"both models must pass"*, which forces a P3-native palette to satisfy an sRGB-era threshold it was never designed for. Matched to `oklch-color-space`'s existing wording rather than inventing a fifth phrasing.

## The retention gate refused this batch, correctly

Two removals, now declared with reasons:

| skill | words | why |
|---|---|---|
| empirical-design-principles | 6 | its disclaimer said the gulfs were "covered nowhere yet" — #225 covers them, so the sentence had become false about its own catalog |
| finding-a-catalog-skill | 12 | **generated** — the directory's "not here" entry for the gulfs, dropped by `gen_skill_directory.py` because the gap was filled |

The second is the interesting one: **a generated file can lose prose legitimately**, and the ledger is still the right place to say so, because a reader diffing the directory should not have to reverse-engineer why a line vanished.

*(Noting a trap for the next person: the gate reads **revisions**, not the working tree. Adding ledger rows without committing them leaves it failing, and it briefly looked like the rows had not worked.)*

## Headroom — tight, and disclosed

| file | before | after |
|---|---|---|
| frontend-a11y | 63 | **24** |
| composing-a-screen | 94 | **6** |
| empirical-design-principles | 62 | 61 |

Both lanes trimmed real duplication to fit and reported exactly what and why rather than trimming silently. One item was **explicitly deferred** for want of bytes — SC 2.5.8's "24 px" vs "24 px *diameter*" ambiguity, which the issue itself calls cosmetic.

## Gates

```
validate_skills.py         link scope: 370 relative / 51 absolute
                           OK: 56 skills validated cleanly              EXIT=0
check_prose_retention.py   OK: 7 changed SKILL.md file(s).              EXIT=0
```