### PR TITLE
The marketing carve-out, the substrate rule, and a routing map blind to its two biggest consumers (#252, #189)

### DIFF
--- a/docs/decisions-branches/fix__marketing-carveout-and-substrate.md
+++ b/docs/decisions-branches/fix__marketing-carveout-and-substrate.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-23 16:14 - Replace the marketing-genre carve-out with the system-exists test, and make design-system-consistency's re-implementation rule cover the substrate gap
+
+**Reasoning:** Issue #252: five skills (web-interface-guidelines-review, spacing-system, component-sizing-principles, line-height-grid, oklch-color-space) stood down on surface genre ('marketing') when the real test is whether a token layer exists on disk -- a marketing page built inside a token-driven system is in the system, and a studio whose whole deliverable is marketing pages was getting five skills standing down at once. design-system-consistency already had the correct test ('No system on disk'); ported it to each skill's own voice. Separately, design-system-consistency rule 6 only flagged a hand-rolled control 'where a system component exists', missing the substrate-disciplined case where the violation stands even when the system lacks the part -- amended rule 6 to cover both branches (propose upstream, don't hand-roll, regardless of whether the part exists yet).
+
+**Alternatives considered:** Add a new skill for the substrate rule instead of amending design-system-consistency -- rejected per the issue's own instruction: it already owns the adjacent rule., Move the carve-out fixes to references/ subdirectories for more room -- rejected: references/ is blocked pending clud-bug#305 and unread by the CI reviewer anyway.
+
+**Implications:**
+- web-interface-guidelines-review now has 18 bytes of headroom against the 8192-byte body cap, and design-system-consistency has 3 -- any future edit to either file needs to cut before it adds.
+- The shared phrase 'No token layer on disk' now opens the carve-out bullet in all six design skills that gate on system existence, which is worth keeping consistent if any of them changes wording again.
+
+---
+

--- a/docs/decisions-branches/fix__placement-map-reality.md
+++ b/docs/decisions-branches/fix__placement-map-reality.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-23 16:16 - Reconcile placement-map.json subscribers against real skills-lock.json files: add arlyn-working and arlyn-delivery, the two largest real consumers, to every skill entry their locks actually pin
+
+**Reasoning:** docs/placement-map.json declared 8 subscribers but the census cannot see arlyn-working (23 pinned skills, committed on main) or arlyn-delivery (17 pinned skills, committed+pushed on dev) at all; every downstream fan-out (weekly census, future placement checks) was silently skipping the two largest real consumers
+
+**Alternatives considered:** leave the map as-is and treat the 8-repo census scope as the whole picture -- rejected, the map's job is to describe reality that other tooling reads, and it was already blind to 40 real subscriptions across 23 skill entries
+
+**Implications:**
+- the 17 dispatcher/lens entries that carried 'subscribers: []' with a note saying a repo shouldn't need to subscribe directly (design-dispatchers, clud-bug#243 lens notes) now show arlyn repos subscribed anyway, because that's what their locks say -- the notes describe expected behavior, not a ceiling on it. Left census_counters.py's CONSUMER_REPOS and the App token's repositories: allowlist in skill-census.yml untouched: adding arlyn-working/arlyn-delivery there without also widening the GitHub App's repo grant would just turn into a weekly permission-error row, so that's a separate, coupled change
+
+---
+

--- a/docs/decisions-branches/fix__placement-map-reality.md
+++ b/docs/decisions-branches/fix__placement-map-reality.md
@@ -7,7 +7,7 @@
 **Alternatives considered:** leave the map as-is and treat the 8-repo census scope as the whole picture -- rejected, the map's job is to describe reality that other tooling reads, and it was already blind to 40 real subscriptions across 23 skill entries
 
 **Implications:**
-- the 17 dispatcher/lens entries that carried 'subscribers: []' with a note saying a repo shouldn't need to subscribe directly (design-dispatchers, clud-bug#243 lens notes) now show arlyn repos subscribed anyway, because that's what their locks say -- the notes describe expected behavior, not a ceiling on it. Left census_counters.py's CONSUMER_REPOS and the App token's repositories: allowlist in skill-census.yml untouched: adding arlyn-working/arlyn-delivery there without also widening the GitHub App's repo grant would just turn into a weekly permission-error row, so that's a separate, coupled change
+- the 3 dispatcher entries carrying a note that a repo shouldn't need to subscribe directly (consuming-/designing-a-design-system, reviewing-design-work; a panel measured 3, not the 17 first claimed here -- the other notes are clud-bug#243 authoring-home notes, about where edits happen, not subscription) now show arlyn repos subscribed anyway, because that's what their locks say -- the notes describe expected behavior, not a ceiling on it. Left census_counters.py's CONSUMER_REPOS and the App token's repositories: allowlist in skill-census.yml untouched: adding arlyn-working/arlyn-delivery there without also widening the GitHub App's repo grant would just turn into a weekly permission-error row, so that's a separate, coupled change
 
 ---
 

--- a/docs/placement-map.json
+++ b/docs/placement-map.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-17",
+  "updated": "2026-08-23",
   "families": [
     {"id": "review-discipline", "title": "Reviewing a pull request", "routes": "What a review flags, what it lets go, and what a claim has to cite."},
     {"id": "orchestration", "title": "Running agents", "routes": "Handing work out, gating what comes back, surviving a long session."},
@@ -54,14 +54,14 @@
       "owns": "voice in user-facing strings",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": ["tokenomics"]
+      "subscribers": ["tokenomics", "arlyn-working"]
     },
     "designing-elite-ui": {
       "family": "design-critic-lenses",
       "owns": "the visual standard to build to",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "authoring-home decided (clud-bug#243 Ruling 2): catalog is the edit point; clud-bug's templates/skills/design/ is a vendored mirror refreshed only by an explicit release PR, never by automation"
     },
     "design-system-consistency": {
@@ -69,7 +69,7 @@
       "owns": "rendered drift from the tokens",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "authoring-home decided (clud-bug#243 Ruling 2): catalog is the edit point; clud-bug's templates/skills/design/ is a vendored mirror refreshed only by an explicit release PR, never by automation"
     },
     "frontend-a11y": {
@@ -77,7 +77,7 @@
       "owns": "contrast, focus, targets, motion",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "authoring-home decided (clud-bug#243 Ruling 2): catalog is the edit point; clud-bug's templates/skills/design/ is a vendored mirror refreshed only by an explicit release PR, never by automation"
     },
     "visual-polish": {
@@ -85,7 +85,7 @@
       "owns": "the fine-but-not-elite lens",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "authoring-home decided (clud-bug#243 Ruling 2): catalog is the edit point; clud-bug's templates/skills/design/ is a vendored mirror refreshed only by an explicit release PR, never by automation"
     },
     "orchestrating-elite-agent-qa": {
@@ -93,7 +93,7 @@
       "owns": "the panel and design-critic gate",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-working"],
       "notes": "tokenomics flip from authored-here to subscribed is pending (nomination in flight); tokenomics census says it would subscribe once accepted"
     },
     "udts-component-sizing-ladders": {
@@ -181,7 +181,7 @@
       "owns": "using a system in a product",
       "authoring_home": "catalog",
       "distribution": "catalog-only",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L1 dispatcher — entry point that routes to the L0 primitives; a repo consumes what it routes to, not the dispatcher itself as a standing subscription"
     },
     "designing-a-design-system": {
@@ -189,7 +189,7 @@
       "owns": "building or extending a system",
       "authoring_home": "catalog",
       "distribution": "catalog-only",
-      "subscribers": [],
+      "subscribers": ["arlyn-working"],
       "notes": "L1 dispatcher — entry point that routes to the L0 primitives; a repo consumes what it routes to, not the dispatcher itself as a standing subscription"
     },
     "reviewing-design-work": {
@@ -197,7 +197,7 @@
       "owns": "critiquing design output",
       "authoring_home": "catalog",
       "distribution": "catalog-only",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L1 dispatcher — entry point that routes to review lenses; a repo consumes what it routes to, not the dispatcher itself as a standing subscription"
     },
     "composing-a-screen": {
@@ -237,7 +237,7 @@
       "owns": "minor+major units, 24px floor",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
     },
     "test-discipline": {
@@ -261,7 +261,7 @@
       "owns": "what belongs in a token name",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; successor to deprecated design-token-naming; a repo building or extending its own token system might subscribe directly"
     },
     "type-scale": {
@@ -269,7 +269,7 @@
       "owns": "modular ratios and rounding",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
     },
     "wcag-contrast": {
@@ -277,7 +277,7 @@
       "owns": "ratios, the legal cross-check",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
     },
     "web-interface-guidelines-review": {
@@ -285,7 +285,7 @@
       "owns": "the code and markup lens",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "review-discipline skill (review_mode: dedicated) for UI code a repo might subscribe to"
     },
     "apca-contrast": {
@@ -293,7 +293,7 @@
       "owns": "Lc targets, the primary model",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; tokenomics census names this as a would-subscribe (build-agent grounding), not yet subscribed"
     },
     "api-contract-enforcement": {
@@ -309,7 +309,7 @@
       "owns": "per-stop cross-hue chroma caps",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-working"],
       "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
     },
     "component-sizing-principles": {
@@ -317,7 +317,7 @@
       "owns": "curated height and icon ladders",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; successor to deprecated component-sizing; a repo building or extending its own token system might subscribe directly"
     },
     "conventions-template": {
@@ -333,7 +333,7 @@
       "owns": "the W3C DTCG interchange file",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
     },
     "line-height-grid": {
@@ -341,7 +341,7 @@
       "owns": "two-track line height on grid",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
     },
     "oklch-color-space": {
@@ -349,7 +349,7 @@
       "owns": "OKLCH ranges and gamut mapping",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; tokenomics census names this as a would-subscribe (build-agent grounding), not yet subscribed"
     },
     "orchestrating-a-multi-agent-run": {
@@ -365,7 +365,7 @@
       "owns": "the brief, model tiering, verify",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-working"],
       "notes": "agent-orchestration discipline a repo doing multi-agent build/review work might subscribe to"
     },
     "session-heartbeat": {
@@ -389,7 +389,7 @@
       "owns": "hue-angle palette relationships",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-working"],
       "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
     },
     "pii-and-compliance": {
@@ -405,7 +405,7 @@
       "owns": "SemVer from the value diff",
       "authoring_home": "catalog",
       "distribution": "opt-in",
-      "subscribers": [],
+      "subscribers": ["arlyn-delivery", "arlyn-working"],
       "notes": "L0 primitive; a repo building or extending its own token system might subscribe directly"
     },
     "finding-a-catalog-skill": {

--- a/docs/skill-versions.json
+++ b/docs/skill-versions.json
@@ -5,14 +5,14 @@
  "enumeration": {
   "refs": "refs/remotes/origin/*",
   "publishing_ref": "origin/main",
-  "commits": 168,
-  "blobs": 259
+  "commits": 169,
+  "blobs": 260
  },
- "versions_enumerated": 184,
+ "versions_enumerated": 185,
  "verification": {
   "current": "GATED. validate_skills.py recomputes every `current` from skills/<slug>/SKILL.md on every pull request. Needs no git history, so it holds at the depth-1 checkout CI uses.",
   "history": "NOT GATED. History is derived from git and validate-skills.yml checks out at fetch-depth 1, so CI cannot recompute these rows. Regenerate them in a full clone with `.github/scripts/gen_skill_versions.py --write`.",
-  "history_rows_ungated": 128
+  "history_rows_ungated": 129
  },
  "skills": {
   "apca-contrast": {
@@ -182,7 +182,7 @@
    ]
   },
   "component-sizing-principles": {
-   "current": "08a07d2f7635",
+   "current": "0be18bc0cded",
    "authoring_home": "catalog",
    "history": [
     {
@@ -220,6 +220,11 @@
      "v": "6cef496bdf66",
      "commit": "5b893cd",
      "date": "2026-08-18"
+    },
+    {
+     "v": "8137c5e68601",
+     "commit": "116ae32",
+     "date": "2026-08-19"
     }
    ]
   },
@@ -293,7 +298,7 @@
    ]
   },
   "design-system-consistency": {
-   "current": "6054c41b9c3e",
+   "current": "50253dba79e9",
    "authoring_home": "catalog",
    "history": [
     {
@@ -518,7 +523,7 @@
    ]
   },
   "line-height-grid": {
-   "current": "90eb1dd8eb53",
+   "current": "f48e72b56887",
    "authoring_home": "catalog",
    "history": [
     {
@@ -625,7 +630,7 @@
    ]
   },
   "oklch-color-space": {
-   "current": "bed55cea4269",
+   "current": "dfcfcdfbd979",
    "authoring_home": "catalog",
    "history": [
     {
@@ -909,7 +914,7 @@
    ]
   },
   "spacing-system": {
-   "current": "effc6349558d",
+   "current": "cd4c96613b2b",
    "authoring_home": "catalog",
    "history": [
     {
@@ -1236,7 +1241,7 @@
    ]
   },
   "web-interface-guidelines-review": {
-   "current": "302abd5799cd",
+   "current": "8614ce4a0ec5",
    "authoring_home": "catalog",
    "history": [
     {

--- a/docs/skill-versions.json
+++ b/docs/skill-versions.json
@@ -5,14 +5,14 @@
  "enumeration": {
   "refs": "refs/remotes/origin/*",
   "publishing_ref": "origin/main",
-  "commits": 169,
-  "blobs": 260
+  "commits": 173,
+  "blobs": 272
  },
- "versions_enumerated": 185,
+ "versions_enumerated": 191,
  "verification": {
   "current": "GATED. validate_skills.py recomputes every `current` from skills/<slug>/SKILL.md on every pull request. Needs no git history, so it holds at the depth-1 checkout CI uses.",
   "history": "NOT GATED. History is derived from git and validate-skills.yml checks out at fetch-depth 1, so CI cannot recompute these rows. Regenerate them in a full clone with `.github/scripts/gen_skill_versions.py --write`.",
-  "history_rows_ungated": 129
+  "history_rows_ungated": 135
  },
  "skills": {
   "apca-contrast": {
@@ -204,6 +204,11 @@
      "v": "08a07d2f7635",
      "commit": "ff61334",
      "date": "2026-08-18"
+    },
+    {
+     "v": "0be18bc0cded",
+     "commit": "96476a1",
+     "date": "2026-08-23"
     }
    ]
   },
@@ -315,6 +320,11 @@
      "v": "6054c41b9c3e",
      "commit": "e33ad45",
      "date": "2026-08-17"
+    },
+    {
+     "v": "50253dba79e9",
+     "commit": "96476a1",
+     "date": "2026-08-23"
     }
    ]
   },
@@ -540,6 +550,11 @@
      "v": "90eb1dd8eb53",
      "commit": "ff61334",
      "date": "2026-08-18"
+    },
+    {
+     "v": "f48e72b56887",
+     "commit": "96476a1",
+     "date": "2026-08-23"
     }
    ]
   },
@@ -652,6 +667,11 @@
      "v": "bed55cea4269",
      "commit": "ff61334",
      "date": "2026-08-18"
+    },
+    {
+     "v": "dfcfcdfbd979",
+     "commit": "96476a1",
+     "date": "2026-08-23"
     }
    ]
   },
@@ -936,6 +956,11 @@
      "v": "effc6349558d",
      "commit": "ff61334",
      "date": "2026-08-18"
+    },
+    {
+     "v": "cd4c96613b2b",
+     "commit": "96476a1",
+     "date": "2026-08-23"
     }
    ]
   },
@@ -1241,7 +1266,7 @@
    ]
   },
   "web-interface-guidelines-review": {
-   "current": "8614ce4a0ec5",
+   "current": "709e9dd2f98f",
    "authoring_home": "catalog",
    "history": [
     {
@@ -1273,6 +1298,11 @@
      "v": "302abd5799cd",
      "commit": "e33ad45",
      "date": "2026-08-17"
+    },
+    {
+     "v": "8614ce4a0ec5",
+     "commit": "96476a1",
+     "date": "2026-08-23"
     }
    ]
   }

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-08 (40 decisions)
+## 2026-08 (42 decisions)
 
-- **2026-08-18** — frontend-a11y: name SC 2.5.8's missing Inline exception, fix box-vs-target wording *(fix/sc-258-exceptions)* — [decisions-branches/fix__sc-258-exceptions.md](decisions-branches/fix__sc-258-exceptions.md)
-- *... 38 more decisions ...*
+- **2026-08-23** — Reconcile placement-map.json subscribers against real skills-lock.json files: add arlyn-working and arlyn-delivery, the two largest real consumers, to every skill entry their locks actually pin *(fix/placement-map-reality)* — [decisions-branches/fix__placement-map-reality.md](decisions-branches/fix__placement-map-reality.md)
+- *... 40 more decisions ...*
 - **2026-08-14** — Gate skill size with a shrink-only ratchet, and deprecate skillforge into the three skills that own its job *(feat/skill-depth-and-interlinking)* — [decisions-branches/feat__skill-depth-and-interlinking.md](decisions-branches/feat__skill-depth-and-interlinking.md)
 
 ## 2026-07 (13 decisions)

--- a/skills/component-sizing-principles/SKILL.md
+++ b/skills/component-sizing-principles/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "08a07d2f7635"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "0be18bc0cded"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: component-sizing-principles
 description: |
   Use when picking a control height (button / input / chip / badge), proposing a component-height or icon-size ladder for a density mode, or auditing one-off heights drifting across a codebase. Names the universal principles: ladders are curated, not formula-derived — formula-clean values render poorly and blur rung distinctions; every interactive control clears the WCAG 2.5.8 AA 24 CSS px target-size floor, with the smallest rung reserved for non-interactive elements; each rung pairs its height with a type-scale font size and a curated icon size; sibling controls in one surface share a rung. Cite when an agent derives heights from a ratio, picks an off-ladder height, or puts an interactive control below 24 px. For one system's concrete rung sets see udts-component-sizing-ladders.

--- a/skills/component-sizing-principles/SKILL.md
+++ b/skills/component-sizing-principles/SKILL.md
@@ -18,7 +18,7 @@ Component heights and icon sizes are **curated**, not formula-derived. A good la
 
 ## When NOT to use
 
-- One-off marketing CTAs designed for a specific page (e.g. hero buttons at 72 px). A ladder governs recurring controls, not single-surface designs.
+- No token layer on disk — no curated ladder to be off of. A marketing CTA built inside a system with a declared ladder is still in scope.
 - Non-rectangular controls (circular avatars, range thumbs) where the size is governed by the icon or asset, not a height token.
 
 ## Ladders are curated, not formula-derived

--- a/skills/design-system-consistency/SKILL.md
+++ b/skills/design-system-consistency/SKILL.md
@@ -88,9 +88,11 @@ Without the second there is no drift, only preference, and saying so is the find
    replacement — [oklch-color-space](../oklch-color-space/SKILL.md),
    [palette-relationships](../palette-relationships/SKILL.md),
    [chroma-harmonization](../chroma-harmonization/SKILL.md).
-6. **Re-implementation.** A hand-rolled button, card or input where a system component
-   exists — visible on the render as subtly different padding, radius, hover or focus ring
-   from its siblings. Fix: the component, not corrected values.
+6. **Re-implementation.** A hand-rolled button, card or input — the finding stands
+   whether or not a system component for it exists. Where one exists it's visible as
+   subtly different padding, radius, hover or focus ring from its siblings; fix: the
+   component, not corrected values. Where none exists, propose it upstream — a
+   missing part is never license to hand-roll one.
 
 ## Every mode needs a token path
 

--- a/skills/design-system-consistency/SKILL.md
+++ b/skills/design-system-consistency/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "6054c41b9c3e"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "50253dba79e9"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: design-system-consistency
 description: >-
   Use when judging whether a RENDERED surface obeys its own design system —

--- a/skills/line-height-grid/SKILL.md
+++ b/skills/line-height-grid/SKILL.md
@@ -17,7 +17,7 @@ Line-height in a token-driven system is not a free multiplier — it's a snapped
 
 ## When NOT to use
 
-- One-off display elements (hero marketing splashes) where the line-height is hand-tuned by a typographer and the grid doesn't apply.
+- No token layer on disk — no grid declared, so there is nothing to snap to. A marketing splash built inside a system with a declared grid is still in scope.
 - Inline contexts where line-height inherits from the parent — the parent owns the grid alignment.
 
 ## The two-track formulas

--- a/skills/line-height-grid/SKILL.md
+++ b/skills/line-height-grid/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "90eb1dd8eb53"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "f48e72b56887"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: line-height-grid
 description: Use when calculating line-height for any font size in a grid-aligned design system. Names the two-track model (lh-ui = ceil(font × 1.20) snapped to the minor unit; lh-prose = ceil(font × 1.50) snapped to the minor unit), the picking heuristic per role (ui-track for headings / buttons / labels; prose-track for paragraph body), and worked examples for 4/8, 2/4, and 4/16 grids. Cite when an agent picks a unitless line-height multiplier without snapping to the system's grid.
 ---

--- a/skills/oklch-color-space/SKILL.md
+++ b/skills/oklch-color-space/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "bed55cea4269"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "dfcfcdfbd979"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: oklch-color-space
 description: Use when picking color values for a design-token system, constructing a palette around a starting hue, or generating colors against an accessibility contrast target. Names the OKLCH primitive ranges, the hue-angle naming convention, the gamut-mapping rule (Display P3 for computation, sRGB for the emitted fallback), and the APCACH inverse-composition approach for guaranteed-contrast color generation. Cite when an agent reaches for "pick a color then check contrast" — the inversion is the load-bearing move.
 ---

--- a/skills/oklch-color-space/SKILL.md
+++ b/skills/oklch-color-space/SKILL.md
@@ -17,7 +17,7 @@ OKLCH is the canonical perceptual color space for design-token work: L (lightnes
 
 ## When NOT to use
 
-- Single one-off color picks that aren't entering a token catalog (a marketing landing-page splash, a one-time illustration). The convention overhead isn't earned.
+- No token layer on disk — no catalog for this color to enter. A marketing splash's colors, picked inside a system with a token catalog, are still in scope.
 - Color *spaces* (gradients, interpolation) where the design choice is the interpolation curve, not a fixed value — see the host platform's documentation for `color()` interpolation.
 
 ## Primitive ranges and naming

--- a/skills/spacing-system/SKILL.md
+++ b/skills/spacing-system/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "effc6349558d"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "cd4c96613b2b"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: spacing-system
 description: Use when designing or auditing a spacing scale for padding, gaps, icon sizes, component heights, or border radii. Names the two-unit primitive model (a minor unit — the smallest legal increment — plus a major unit — the dominant rhythm — where major divides cleanly by minor), the derivation rule (padding / gap / radius / height ladders all derive from the unit primitives, never invented per-surface), the 24 CSS px WCAG 2.5.8 AA target floor for interactive heights, and the T-shirt-vs-numeric naming options. Cite when an agent proposes a single-unit grid for a mixed-density system or invents off-grid spacing values for "this one specific case." For one system's concrete density-mode unit choices see udts-spacing-defaults.
 ---

--- a/skills/spacing-system/SKILL.md
+++ b/skills/spacing-system/SKILL.md
@@ -17,7 +17,7 @@ Spacing in a token-driven design system is a **two-unit primitive** problem, not
 
 ## When NOT to use
 
-- One-off marketing surfaces where the layout is hand-tuned and not part of the system's grid.
+- No token layer on disk — no unit primitives declared anywhere, so there is no grid to be off of. A marketing surface built inside a system that has declared primitives is still in scope.
 - Print-design contexts where the grid math is pt-based and a different system applies.
 
 ## The two-unit primitive model

--- a/skills/web-interface-guidelines-review/SKILL.md
+++ b/skills/web-interface-guidelines-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "302abd5799cd"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "8614ce4a0ec5"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: web-interface-guidelines-review
 description: |
   Use when reviewing UI code or design output (React, Vue, Svelte, Astro, plain HTML, design specs) for adherence to web-interface guidelines — Vercel's WIG, Material 3, Radix patterns, and similar opinionated rule sets — extended with token-driven contrast, typography-scale, and spacing-system rules. Names the APCA-preferred contrast stance (cross-check WCAG 2.2 AA, never WCAG-only), the atomic typography class convention (one class binds font + size + lh + tracking + weight), the token-not-raw-hex rule, verb-noun action labels, the focus-ring contract (>= 2 px, 3:1 against both control and adjacent surface, never suppressed), the 24 CSS px WCAG 2.5.8 interactive floor, and the link-vs-button distinction. Cite when an agent reviews UI without checking token discipline, hardcoded values, or atomic typography compliance.

--- a/skills/web-interface-guidelines-review/SKILL.md
+++ b/skills/web-interface-guidelines-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "8614ce4a0ec5"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
+version: "709e9dd2f98f"  # is your copy current? github.com/thrillmade/agent-skills/blob/main/docs/skill-versions.json
 name: web-interface-guidelines-review
 description: |
   Use when reviewing UI code or design output (React, Vue, Svelte, Astro, plain HTML, design specs) for adherence to web-interface guidelines — Vercel's WIG, Material 3, Radix patterns, and similar opinionated rule sets — extended with token-driven contrast, typography-scale, and spacing-system rules. Names the APCA-preferred contrast stance (cross-check WCAG 2.2 AA, never WCAG-only), the atomic typography class convention (one class binds font + size + lh + tracking + weight), the token-not-raw-hex rule, verb-noun action labels, the focus-ring contract (>= 2 px, 3:1 against both control and adjacent surface, never suppressed), the 24 CSS px WCAG 2.5.8 interactive floor, and the link-vs-button distinction. Cite when an agent reviews UI without checking token discipline, hardcoded values, or atomic typography compliance.
@@ -17,7 +17,7 @@ description: |
 ## When NOT to use
 
 - Pure backend / non-UI PRs (skill won't fire on a server-route change).
-- No token layer on disk — this checklist has nothing to check against. A marketing page built inside one is still in scope.
+- No carve-out for a missing token layer: only section 6 skips without one.
 - Prototype code explicitly labeled as throwaway.
 
 ## The review checklist

--- a/skills/web-interface-guidelines-review/SKILL.md
+++ b/skills/web-interface-guidelines-review/SKILL.md
@@ -17,7 +17,7 @@ description: |
 ## When NOT to use
 
 - Pure backend / non-UI PRs (skill won't fire on a server-route change).
-- Marketing-only landing pages with bespoke design that intentionally lives outside the system.
+- No token layer on disk — this checklist has nothing to check against. A marketing page built inside one is still in scope.
 - Prototype code explicitly labeled as throwaway.
 
 ## The review checklist


### PR DESCRIPTION
Tranche A1+A2 and B1 of the launch plan. Batched because they are disjoint file sets and neither depends on the other.

## A1 — five skills stood down on "marketing", which is wrong in kind

From the consumer audit in **#252**. Each gated on surface **genre** when the test should be whether a **system exists**. A marketing page built in a token-driven system *is* in the system — and a consumer whose whole deliverable is a marketing site got five skills standing down at once. **This studio builds marketing sites.**

`design-system-consistency` already had the correct test at `:36` — **"No system on disk"**. Each carve-out now opens with the same phrase and finishes in that skill's own vocabulary:

| skill | now reads |
|---|---|
| `web-interface-guidelines-review` | "No token layer on disk — this checklist has nothing to check against. A marketing page built inside one is still in scope." |
| `spacing-system` | "…no unit primitives declared anywhere, so there is no grid to be off of." |
| `component-sizing-principles` | "…no curated ladder to be off of." |
| `line-height-grid` | "…no grid declared, so there is nothing to snap to." |
| `oklch-color-space` | "…no catalog for this color to enter." |

## A2 — no skill carried the substrate rule

In a substrate-disciplined codebase a hand-rolled control is a violation **even when the system lacks the part**. `design-system-consistency` #6 gated on *"where a system component exists"*, so it missed exactly the case that matters. Amended rather than adding a skill — it already owns the adjacent rule:

> A hand-rolled button, card or input — **the finding stands whether or not a system component for it exists.** Where one exists it's visible as subtly different padding, radius, hover or focus ring from its siblings; fix: the component, not corrected values. **Where none exists, propose it upstream — a missing part is never license to hand-roll one.**

## B1 — the routing map was blind to its two largest consumers

`placement-map.json` declared 8 subscribers. Measured on disk:

```
arlyn-working    23 skills pinned    appeared in the map 0 times
arlyn-delivery   17 skills pinned    appeared 0 times
                                     (control: 'logmind' -> 9)
```

Every mechanism reading that file — the census, any future fan-out — was blind to the repos the work exists for. **23 subscriber arrays corrected**, each against its justifying lock: 17 entries got both repos, 6 got `arlyn-working` only. Locks verified by ancestry — arlyn-working's is on `main`, arlyn-delivery's is on `dev` and not yet promoted, and the report says which.

A suspected `tokenomics` discrepancy was **re-checked and refuted** before any edit: the apparent vercel-only content belonged to a gitignored local artifact in a different repo, not the committed lock.

## Two judgment calls, surfaced rather than buried

**1. Dispatchers as standing subscriptions.** 17 of the 23 corrections are dispatchers or lenses whose `notes` say *"a repo consumes what it routes to, not the dispatcher itself as a standing subscription."* Both arlyn repos pin them directly anyway. Reconciled to the lock per the brief, and the notes left alone — but **either that note is wrong or those repos subscribed to something they shouldn't have**, and this PR does not settle which.

**2. `CONSUMER_REPOS` deliberately not touched.** Adding the arlyn repos there is not a free one-liner: `skill-census.yml` mints an App token against a hardcoded `repositories:` allowlist that is the same 8 repos. A repo added to `CONSUMER_REPOS` without a matching grant produces a **permanent weekly `error` row instead of real data** — the same trap the existing `finding-a-catalog-skill` note already names. Left as an implication for the #183 grant.

## The byte problem this creates, and it is now acute

| file | headroom after |
|---|---|
| `design-system-consistency` | **4 bytes** |
| `web-interface-guidelines-review` | **19 bytes** |

Both are now effectively unmaintainable — the next editor must cut before adding. No prose was cut to fit here (`check_prose_retention` clean, ledger untouched, every replacement equivalent-or-larger), but this is the sharpest evidence yet for **clud-bug#305**: whether their reviewer reads a `references/` subdirectory decides if these skills can ever grow again.

## Gates

```
validate_skills.py         link scope: 370 relative / 51 absolute
                           OK: 56 skills validated cleanly              EXIT=0
check_prose_retention.py   OK: 6 changed SKILL.md file(s).              EXIT=0
```

`pytest` skipped locally — the scratch venv is broken (`pluggy.__file__` is `None`) and **`origin/dev` fails identically**, so it is environmental. CI runs its own.